### PR TITLE
Modulo Distribution

### DIFF
--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -27,6 +27,7 @@ clustering-related helpers.
 
 import subprocess
 import os
+import time
 
 from socket import gethostname as get_unit_hostname
 
@@ -44,6 +45,9 @@ from charmhelpers.core.hookenv import (
     unit_get,
     is_leader as juju_is_leader,
     status_set,
+)
+from charmhelpers.core.host import (
+    modulo_distribution,
 )
 from charmhelpers.core.decorators import (
     retry_on_exception,
@@ -361,3 +365,24 @@ def canonical_url(configs, vip_setting='vip'):
     else:
         addr = unit_get('private-address')
     return '%s://%s' % (scheme, addr)
+
+
+def distributed_wait(modulo=None, wait=None):
+    ''' Distribute operations by waiting based on modulo_distribution
+
+    If modulo and or wait are not set, check config_get for those values.
+
+    :side effect: Calls config_get()
+    :side effect: Calls log()
+    :side effect: Calls status_set()
+    :side effect: Calls time.sleep()
+    '''
+    if modulo is None:
+        modulo = config_get('modulo-nodes')
+    if wait is None:
+        wait = config_get('known-wait')
+    calculated_wait = modulo_distribution(modulo=modulo, wait=wait)
+    msg = "Waiting {} seconds for operation ...".format(calculated_wait)
+    log(msg, DEBUG)
+    status_set('maintenance', msg)
+    time.sleep(calculated_wait)

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -367,11 +367,15 @@ def canonical_url(configs, vip_setting='vip'):
     return '%s://%s' % (scheme, addr)
 
 
-def distributed_wait(modulo=None, wait=None):
+def distributed_wait(modulo=None, wait=None, operation_name='operation'):
     ''' Distribute operations by waiting based on modulo_distribution
 
     If modulo and or wait are not set, check config_get for those values.
 
+    :param modulo: int The modulo number creates the group distribution
+    :param wait: int The constant time wait value
+    :param operation_name: string Operation name for status message
+                           i.e.  'restart'
     :side effect: Calls config_get()
     :side effect: Calls log()
     :side effect: Calls status_set()
@@ -382,7 +386,8 @@ def distributed_wait(modulo=None, wait=None):
     if wait is None:
         wait = config_get('known-wait')
     calculated_wait = modulo_distribution(modulo=modulo, wait=wait)
-    msg = "Waiting {} seconds for operation ...".format(calculated_wait)
+    msg = "Waiting {} seconds for {} ...".format(calculated_wait,
+                                                 operation_name)
     log(msg, DEBUG)
     status_set('maintenance', msg)
     time.sleep(calculated_wait)

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -952,9 +952,9 @@ def modulo_distribution(modulo=3, wait=30):
     """ Modulo distribution
 
     This helper uses the unit number, a modulo value and a constant wait time
-    to produce a calculated wait time distribution.
-    This is useful in large scale deployments to distribute load during an
-    expensive operation such as service restarts.
+    to produce a calculated wait time distribution. This is useful in large
+    scale deployments to distribute load during an expensive operation such as
+    service restarts.
 
     If you have 1000 nodes that need to restart 100 at a time 1 minute at a
     time:

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -34,7 +34,7 @@ import six
 
 from contextlib import contextmanager
 from collections import OrderedDict
-from .hookenv import log, DEBUG
+from .hookenv import log, DEBUG, local_unit
 from .fstab import Fstab
 from charmhelpers.osplatform import get_platform
 
@@ -946,3 +946,31 @@ def updatedb(updatedb_text, new_path):
                 lines[i] = 'PRUNEPATHS="{}"'.format(' '.join(paths))
     output = "\n".join(lines)
     return output
+
+
+def modulo_distribution(modulo=3, wait=30):
+    """ Modulo distribution
+
+    This helper uses the unit number, a modulo value and a constant wait time
+    to produce a calculated wait time distribution.
+    This is useful in large scale deployments to distribute load during an
+    expensive operation such as service restarts.
+
+    If you have 1000 nodes that need to restart 100 at a time 1 minute at a
+    time:
+
+      time.wait(modulo_distribution(modulo=100, wait=60))
+      restart()
+
+    If you need restarts to happen serially set modulo to the exact number of
+    nodes and set a high constant wait time:
+
+      time.wait(modulo_distribution(modulo=10, wait=120))
+      restart()
+
+    @param modulo: int The modulo number creates the group distribution
+    @param wait: int The constant time wait value
+    @return: int Calculated time to wait for unit operation
+    """
+    unit_number = int(local_unit().split('/')[1])
+    return (unit_number % modulo) * wait

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -518,3 +518,27 @@ class ClusterUtilsTests(TestCase):
         self.config_get.side_effect = _fake_config_get
         self.assertTrue(cluster_utils.valid_hacluster_config())
         self.assertFalse(status_set.called)
+
+    @patch.object(cluster_utils, 'status_set')
+    @patch.object(cluster_utils.time, 'sleep')
+    @patch.object(cluster_utils, 'modulo_distribution')
+    @patch.object(cluster_utils, 'log')
+    def test_distributed_wait(self, log, modulo_distribution, sleep,
+                              status_set):
+        conf = {
+            'modulo-nodes': 7,
+            'known-wait': 10,
+        }
+
+        def _fake_config_get(setting):
+            return conf[setting]
+
+        self.config_get.side_effect = _fake_config_get
+
+        # Uses config values
+        cluster_utils.distributed_wait()
+        modulo_distribution.assert_called_with(modulo=7, wait=10)
+
+        # Uses passed values
+        cluster_utils.distributed_wait(modulo=3, wait=45)
+        modulo_distribution.assert_called_with(modulo=3, wait=45)

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1821,6 +1821,11 @@ class HelpersTest(TestCase):
         handle.write.assert_called_once_with(
             'PRUNEPATHS="/tmp /srv/node /tmp/test"')
 
+    @patch.object(host, 'local_unit')
+    def test_modulo_distribution(self, local_unit):
+        local_unit.return_value = 'test/7'
+        self.assertEqual(host.modulo_distribution(modulo=6, wait=10), 10)
+
 
 class TestHostCompator(TestCase):
 


### PR DESCRIPTION
Charms have needed a way to distribute load during expensive operations
in large scale deployments. This change adds two helpers to mitigate
load.

modulo_distribution uses unit number, a modulo value and a constant wait time
to produce a calculated wait time distribution.

If you have 1000 nodes that need to restart 100 at a time 1 minute at a time:

      time.wait(modulo_distribution(modulo=100, wait=60))
      restart()

If you need restarts to happen serially set modulo to the exact number of
nodes and set a high constant wait time:

      time.wait(modulo_distribution(modulo=10, wait=120))
      restart()

distributed_wait is a helper for OpenStack charms to use which checks
for config values to pass to modulo_distribution and uses the returned
value to use with time.wait().