### PR TITLE
Refactor charm-helpers-sync for git usage

### DIFF
--- a/tests/tools/test_charm_helper_sync.py
+++ b/tests/tools/test_charm_helper_sync.py
@@ -28,10 +28,10 @@ class HelperSyncTests(unittest.TestCase):
     def test_clone_helpers(self):
         '''It properly branches the correct helpers branch'''
         with patch('subprocess.check_call') as check_call:
-            sync.clone_helpers(work_dir='/tmp/foo', branch='lp:charm-helpers')
-            check_call.assert_called_with(['bzr',
-                                           'checkout', '--lightweight',
-                                           'lp:charm-helpers',
+            sync.clone_helpers(work_dir='/tmp/foo', repo='git:charm-helpers')
+            check_call.assert_called_with(['git',
+                                           'clone', '--depth=1',
+                                           'git:charm-helpers',
                                            '/tmp/foo/charm-helpers'])
 
     def test_module_path(self):

--- a/tools/charm_helpers_sync/charm_helpers_sync.py
+++ b/tools/charm_helpers_sync/charm_helpers_sync.py
@@ -29,7 +29,7 @@ from fnmatch import fnmatch
 
 import six
 
-CHARM_HELPERS_BRANCH = 'lp:charm-helpers'
+CHARM_HELPERS_REPO = 'https://github.com/juju/charm-helpers'
 
 
 def parse_config(conf_file):
@@ -39,10 +39,10 @@ def parse_config(conf_file):
     return yaml.load(open(conf_file).read())
 
 
-def clone_helpers(work_dir, branch):
+def clone_helpers(work_dir, repo):
     dest = os.path.join(work_dir, 'charm-helpers')
-    logging.info('Checking out %s to %s.' % (branch, dest))
-    cmd = ['bzr', 'checkout', '--lightweight', branch, dest]
+    logging.info('Cloning out %s to %s.' % (repo, dest))
+    cmd = ['git', 'clone', '--depth=1', repo, dest]
     subprocess.check_call(cmd)
     return dest
 
@@ -198,8 +198,8 @@ if __name__ == '__main__':
                       default=None, help='helper config file')
     parser.add_option('-D', '--debug', action='store_true', dest='debug',
                       default=False, help='debug')
-    parser.add_option('-b', '--branch', action='store', dest='branch',
-                      help='charm-helpers bzr branch (overrides config)')
+    parser.add_option('-r', '--repository', action='store', dest='repo',
+                      help='charm-helpers git repository (overrides config)')
     parser.add_option('-d', '--destination', action='store', dest='dest_dir',
                       help='sync destination dir (overrides config)')
     (opts, args) = parser.parse_args()
@@ -218,10 +218,10 @@ if __name__ == '__main__':
     else:
         config = {}
 
-    if 'branch' not in config:
-        config['branch'] = CHARM_HELPERS_BRANCH
-    if opts.branch:
-        config['branch'] = opts.branch
+    if 'repo' not in config:
+        config['repo'] = CHARM_HELPERS_REPO
+    if opts.repo:
+        config['repo'] = opts.repo
     if opts.dest_dir:
         config['destination'] = opts.dest_dir
 
@@ -241,7 +241,7 @@ if __name__ == '__main__':
         sync_options = config['options']
     tmpd = tempfile.mkdtemp()
     try:
-        checkout = clone_helpers(tmpd, config['branch'])
+        checkout = clone_helpers(tmpd, config['repo'])
         sync_helpers(config['include'], checkout, config['destination'],
                      options=sync_options)
     except Exception as e:

--- a/tools/charm_helpers_sync/example-config.yaml
+++ b/tools/charm_helpers_sync/example-config.yaml
@@ -1,5 +1,5 @@
-# Import from remote bzr branch.
-branch: lp:charm-helpers
+# Import from remote git repository.
+repo: https://github.com/juju/charm-helpers
 # install helpers to ./hooks/charmhelpers
 destination: hooks/charmhelpers
 include:


### PR DESCRIPTION
Update sync tool to work from git repositories rather than
bzr branches, inline with move to github.com for development.