### PR TITLE
Fix ssl certs for os-*-hostname override.

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -802,8 +802,9 @@ class ApacheSSLContext(OSContextGenerator):
         else:
             # Expect cert/key provided in config (currently assumed that ca
             # uses ip for cn)
-            cn = resolve_address(endpoint_type=INTERNAL)
-            self.configure_cert(cn)
+            for endpoint_type in (INTERNAL, ADMIN, PUBLIC):
+                cn = resolve_address(endpoint_type=endpoint_type)
+                self.configure_cert(cn)
 
         addresses = self.get_network_addresses()
         for address, endpoint in addresses:

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -802,8 +802,8 @@ class ApacheSSLContext(OSContextGenerator):
         else:
             # Expect cert/key provided in config (currently assumed that ca
             # uses ip for cn)
-            for endpoint_type in (INTERNAL, ADMIN, PUBLIC):
-                cn = resolve_address(endpoint_type=endpoint_type)
+            for net_type in (INTERNAL, ADMIN, PUBLIC):
+                cn = resolve_address(endpoint_type=net_type, override=False)
                 self.configure_cert(cn)
 
         addresses = self.get_network_addresses()

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2012,6 +2012,12 @@ class ContextTests(unittest.TestCase):
             call('10.5.3.6')
         ])
 
+        self.resolve_address.assert_has_calls([
+            call(endpoint_type=context.INTERNAL, override=False),
+            call(endpoint_type=context.ADMIN, override=False),
+            call(endpoint_type=context.PUBLIC, override=False),
+        ])
+
         self.assertTrue(apache.configure_ca.called)
         self.assertTrue(apache.enable_modules.called)
         self.assertTrue(apache.configure_cert.called)

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1944,7 +1944,11 @@ class ContextTests(unittest.TestCase):
         self.https.return_value = False
         self.assertEquals({}, apache())
 
-    def test_https_context(self):
+    def _https_context_setup(self):
+        '''
+        Helper for test_https_context* tests.
+
+        '''
         self.https.return_value = True
         self.determine_api_port.return_value = 8756
         self.determine_apache_port.return_value = 8766
@@ -1976,12 +1980,36 @@ class ContextTests(unittest.TestCase):
             'ext_ports': [8766]
         }
 
+        return apache, ex
+
+    def test_https_context(self):
+        apache, ex = self._https_context_setup()
+
         self.assertEquals(ex, apache())
 
         apache.configure_cert.assert_has_calls([
             call('10.5.1.1'),
             call('10.5.2.1'),
             call('10.5.3.1')
+        ])
+
+        self.assertTrue(apache.configure_ca.called)
+        self.assertTrue(apache.enable_modules.called)
+        self.assertTrue(apache.configure_cert.called)
+
+    def test_https_context_no_canonical_names(self):
+        apache, ex = self._https_context_setup()
+        apache.canonical_names.return_value = []
+
+        self.resolve_address.side_effect = (
+            '10.5.1.4', '10.5.2.5', '10.5.3.6')
+
+        self.assertEquals(ex, apache())
+
+        apache.configure_cert.assert_has_calls([
+            call('10.5.1.4'),
+            call('10.5.2.5'),
+            call('10.5.3.6')
         ])
 
         self.assertTrue(apache.configure_ca.called)


### PR DESCRIPTION
This is intended to address
https://bugs.launchpad.net/charm-glance/+bug/1711360

In the case where an operator has set os-*-hostname overrides, we now
loop through PRIVATE, ADMIN and PUBLIC endpoint types, and write out
an ssl cert for each type. Previously, we would only write out an ssl
cert for the private address.

@thedac @ryan-beisner 