### PR TITLE
Remove override=False in ApacheSSLContext.call

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -803,7 +803,7 @@ class ApacheSSLContext(OSContextGenerator):
             # Expect cert/key provided in config (currently assumed that ca
             # uses ip for cn)
             for net_type in (INTERNAL, ADMIN, PUBLIC):
-                cn = resolve_address(endpoint_type=net_type, override=False)
+                cn = resolve_address(endpoint_type=net_type)
                 self.configure_cert(cn)
 
         addresses = self.get_network_addresses()

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2013,9 +2013,9 @@ class ContextTests(unittest.TestCase):
         ])
 
         self.resolve_address.assert_has_calls([
-            call(endpoint_type=context.INTERNAL, override=False),
-            call(endpoint_type=context.ADMIN, override=False),
-            call(endpoint_type=context.PUBLIC, override=False),
+            call(endpoint_type=context.INTERNAL),
+            call(endpoint_type=context.ADMIN),
+            call(endpoint_type=context.PUBLIC),
         ])
 
         self.assertTrue(apache.configure_ca.called)


### PR DESCRIPTION
This was intended to address
https://bugs.launchpad.net/charm-glance/+bug/1711360

But the behavior I see in integration testing is the opposite of that
reported in the bug -- things work correctly when override=True is
passed in.

@thedac @ajkavanagh 

(Sorry, @johnsca -- I didn't add a "please don't merge this until I do some integration testing" on my last PR. This code has been integration tested, as well as unit tested.)