### PR TITLE
Fixing incorrect definition

### DIFF
--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -28,7 +28,7 @@ from charmhelpers.contrib.network.ip import (
 from charmhelpers.contrib.hahelpers.cluster import is_clustered
 
 PUBLIC = 'public'
-INTERNAL = 'int'
+INTERNAL = 'internal'
 ADMIN = 'admin'
 ACCESS = 'access'
 


### PR DESCRIPTION
'int' should be 'internal' to avoid KeyError when deploying with DNS-HA
set to True.