### PR TITLE
Fix mismatch between 'internal' and 'int' in DNSHA

### DIFF
--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -82,15 +82,18 @@ def update_dns_ha_resource_params(resources, resource_params,
             continue
         m = re.search('os-(.+?)-hostname', setting)
         if m:
-            networkspace = m.group(1)
+            endpoint_type = m.group(1)
+            # resolve_address's ADDRESS_MAP uses 'int' not 'internal'
+            if endpoint_type == 'internal':
+                endpoint_type = 'int'
         else:
             msg = ('Unexpected DNS hostname setting: {}. '
-                   'Cannot determine network space name'
+                   'Cannot determine endpoint_type name'
                    ''.format(setting))
             status_set('blocked', msg)
             raise DNSHAException(msg)
 
-        hostname_key = 'res_{}_{}_hostname'.format(charm_name(), networkspace)
+        hostname_key = 'res_{}_{}_hostname'.format(charm_name(), endpoint_type)
         if hostname_key in hostname_group:
             log('DNS HA: Resource {}: {} already exists in '
                 'hostname group - skipping'.format(hostname_key, hostname),
@@ -101,7 +104,7 @@ def update_dns_ha_resource_params(resources, resource_params,
         resources[hostname_key] = crm_ocf
         resource_params[hostname_key] = (
             'params fqdn="{}" ip_address="{}" '
-            ''.format(hostname, resolve_address(endpoint_type=networkspace,
+            ''.format(hostname, resolve_address(endpoint_type=endpoint_type,
                                                 override=False)))
 
     if len(hostname_group) >= 1:

--- a/tests/contrib/openstack/ha/test_ha_utils.py
+++ b/tests/contrib/openstack/ha/test_ha_utils.py
@@ -71,14 +71,14 @@ class HATests(unittest.TestCase):
     def test_update_dns_ha_resource_params_all(self,
                                                assert_charm_supports_dns_ha):
         EXPECTED_RESOURCES = {'res_test_admin_hostname': 'ocf:maas:dns',
-                              'res_test_internal_hostname': 'ocf:maas:dns',
+                              'res_test_int_hostname': 'ocf:maas:dns',
                               'res_test_public_hostname': 'ocf:maas:dns',
                               'res_test_haproxy': 'lsb:haproxy'}
         EXPECTED_RESOURCE_PARAMS = {
             'res_test_admin_hostname': ('params fqdn="test.admin.maas" '
                                         'ip_address="10.0.0.1" '),
-            'res_test_internal_hostname': ('params fqdn="test.internal.maas" '
-                                           'ip_address="10.0.0.1" '),
+            'res_test_int_hostname': ('params fqdn="test.internal.maas" '
+                                      'ip_address="10.0.0.1" '),
             'res_test_public_hostname': ('params fqdn="test.public.maas" '
                                          'ip_address="10.0.0.1" '),
             'res_test_haproxy': 'op monitor interval="5s"'}
@@ -99,7 +99,7 @@ class HATests(unittest.TestCase):
         self.relation_set.assert_called_with(
             groups={'grp_test_hostnames':
                     ('res_test_admin_hostname '
-                     'res_test_internal_hostname '
+                     'res_test_int_hostname '
                      'res_test_public_hostname')},
             relation_id='ha:1')
 


### PR DESCRIPTION
DNSHA keys off the string in configuration variables os-*-hostname.
os-internal-hostname is the name of the config variable. However,
resolve_address uses a long standing constant ADDRESS_MAP that refers
to this as 'int'.

This change handles this and hands resolve_address what it expects.
Also, use a clearer variable name for endpoint_type.