### PR TITLE
Add common cache section for OpenStack services

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-oslo-cache
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-cache
@@ -1,0 +1,6 @@
+[cache]
+{% if memcache_url %}
+enabled = true
+backend = oslo_cache.memcache_pool
+memcache_servers = {{ memcache_url }}
+{% endif %}


### PR DESCRIPTION
Add a template fragment for the oslo cache section of OpenStack
configuration files.

Partial-Bug: #1722541