### PR TITLE
Ensure that unison users do not password expire

### DIFF
--- a/charmhelpers/contrib/unison/__init__.py
+++ b/charmhelpers/contrib/unison/__init__.py
@@ -69,6 +69,7 @@ from charmhelpers.core.host import (
     adduser,
     add_user_to_group,
     pwgen,
+    remove_password_expiry,
 )
 
 from charmhelpers.core.hookenv import (
@@ -177,6 +178,7 @@ def ensure_user(user, group=None):
     adduser(user, pwgen())
     if group:
         add_user_to_group(user, group)
+    remove_password_expiry(user)
 
 
 def ssh_authorized_peers(peer_interface, user, group=None,

--- a/charmhelpers/contrib/unison/__init__.py
+++ b/charmhelpers/contrib/unison/__init__.py
@@ -178,6 +178,7 @@ def ensure_user(user, group=None):
     adduser(user, pwgen())
     if group:
         add_user_to_group(user, group)
+    # Remove password expiry (Bug #1686085)
     remove_password_expiry(user)
 
 

--- a/tests/contrib/unison/test_unison.py
+++ b/tests/contrib/unison/test_unison.py
@@ -194,10 +194,12 @@ class UnisonHelperTests(TestCase):
             for k in keys:
                 self.assertIn(call('%s\n' % k), _file.write.call_args_list)
 
+    @patch.object(unison, 'remove_password_expiry')
     @patch.object(unison, 'pwgen')
     @patch.object(unison, 'add_user_to_group')
     @patch.object(unison, 'adduser')
-    def test_ensure_user(self, adduser, to_group, pwgen):
+    def test_ensure_user(self, adduser, to_group, pwgen,
+                         remove_password_expiry):
         pwgen.return_value = sentinel.password
         unison.ensure_user('foo', group='foobar')
         adduser.assert_called_with('foo', sentinel.password)

--- a/tests/contrib/unison/test_unison.py
+++ b/tests/contrib/unison/test_unison.py
@@ -204,6 +204,7 @@ class UnisonHelperTests(TestCase):
         unison.ensure_user('foo', group='foobar')
         adduser.assert_called_with('foo', sentinel.password)
         to_group.assert_called_with('foo', 'foobar')
+        remove_password_expiry.assert_called_with('foo')
 
     @patch.object(unison, '_run_as_user')
     def test_run_as_user(self, _run):


### PR DESCRIPTION
Ensure that the user that is setup to use unison to sync data
does not have an expiring password.

Partial-Bug: #1686085