### PR TITLE
Update pools returned by get_ceph_expected_pools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - pip install -r test_requirements.txt
 script:
   - nosetests -s --nologcapture --with-coverage --cover-package=charmhelpers tests/
-  - flake8 --ignore=E501 charmhelpers tests tools
+  - flake8 --ignore=E501,E741,E722 charmhelpers tests tools

--- a/charmhelpers/contrib/openstack/amulet/deployment.py
+++ b/charmhelpers/contrib/openstack/amulet/deployment.py
@@ -307,7 +307,7 @@ class OpenStackAmuletDeployment(AmuletDeployment):
             # Kilo or later
             pools = [
                 'rbd',
-                'cinder',
+                'cinder-ceph',
                 'glance'
             ]
         else:
@@ -316,7 +316,7 @@ class OpenStackAmuletDeployment(AmuletDeployment):
                 'data',
                 'metadata',
                 'rbd',
-                'cinder',
+                'cinder-ceph',
                 'glance'
             ]
 


### PR DESCRIPTION
Test deployments should use the cinder-ceph subordinate and
relate ceph-mon to that. Subsequently the pool created by
cinder will be named 'cinder-ceph' and not 'cinder'.

Update charm-helpers to support this change.