### PR TITLE
Add support for snap branch usage

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2051,7 +2051,7 @@ def update_json_file(filename, items):
 def snap_install_requested():
     """ Determine if installing from snaps
 
-    If openstack-origin is of the form snap:track/channel
+    If openstack-origin is of the form snap:track/channel[/branch]
     and channel is in SNAPS_CHANNELS return True.
     """
     origin = config('openstack-origin') or ""
@@ -2060,9 +2060,9 @@ def snap_install_requested():
 
     _src = origin[5:]
     if '/' in _src:
-        _track, channel = _src.split('/')
+        channel = _src.split('/')[1]
     else:
-        # Hanlde snap:track with no channel
+        # Handle snap:track with no channel
         channel = 'stable'
     return valid_snap_channel(channel)
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1926,6 +1926,10 @@ class OpenStackHelpersTestCase(TestCase):
         config.return_value = 'snap:pike'
         self.assertTrue(openstack.snap_install_requested())
         valid_snap_channel.assert_called_with('stable')
+        flush('snap_install_requested')
+        config.return_value = 'snap:pike/stable/jamespage'
+        self.assertTrue(openstack.snap_install_requested())
+        valid_snap_channel.assert_called_with('stable')
         # Expect False
         flush('snap_install_requested')
         config.return_value = 'cloud:xenial-ocata'
@@ -1939,6 +1943,15 @@ class OpenStackHelpersTestCase(TestCase):
         src = 'snap:ocata/beta'
         expected = {snaps[0]: {'mode': mode,
                                'channel': '--channel=ocata/beta'}}
+        self.assertEqual(
+            expected,
+            openstack.get_snaps_install_info_from_origin(snaps, src,
+                                                         mode=mode))
+
+        # snap:track/channel/branch
+        src = 'snap:ocata/beta/jamespage'
+        expected = {snaps[0]: {'mode': mode,
+                               'channel': '--channel=ocata/beta/jamespage'}}
         self.assertEqual(
             expected,
             openstack.get_snaps_install_info_from_origin(snaps, src,


### PR DESCRIPTION
Allow use of snap branches in openstack-origin, for example:

   snap:pike/edge/jamespage
   snap:ocata/stable/thedac