### PR TITLE
open/close_port supports ICMP protocol; network_get supports Juju 2.0.2

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -654,7 +654,7 @@ def _port_op(op_name, port, protocol="TCP"):
         _args.append('{}/{}'.format(port, protocol))
     try:
         subprocess.check_call(_args)
-    except:
+    except subprocess.CalledProcessError:
         # Older Juju pre 2.3 doesn't support ICMP
         # so treat it as a no-op if it fails.
         if not icmp:


### PR DESCRIPTION
Juju open/close_port hook tools now supports ICMP protocol, so we modify the API here to match.

The recently landed network_get enhancement fails with Juju 2.0.2 so that is fixed also.

This code has been tested live by being embedded in the cs:~wallyworld/nrpe-charm