### PR TITLE
Update c.storage.linux.ceph to support Py3 properly _+ pep8

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -285,7 +285,7 @@ class NRPE(object):
         try:
             nagios_uid = pwd.getpwnam('nagios').pw_uid
             nagios_gid = grp.getgrnam('nagios').gr_gid
-        except:
+        except Exception:
             log("Nagios user not set up, nrpe checks not updated")
             return
 

--- a/charmhelpers/contrib/mellanox/infiniband.py
+++ b/charmhelpers/contrib/mellanox/infiniband.py
@@ -146,7 +146,7 @@ def ipoib_interfaces():
 
             if driver in IPOIB_DRIVERS:
                 interfaces.append(interface)
-        except:
+        except Exception:
             log("Skipping interface %s" % interface, level=INFO)
             continue
 

--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -490,7 +490,7 @@ def get_host_ip(hostname, fallback=None):
     if not ip_addr:
         try:
             ip_addr = socket.gethostbyname(hostname)
-        except:
+        except Exception:
             log("Failed to resolve hostname '%s'" % (hostname),
                 level=WARNING)
             return fallback
@@ -518,7 +518,7 @@ def get_hostname(address, fqdn=True):
         if not result:
             try:
                 result = socket.gethostbyaddr(address)[0]
-            except:
+            except Exception:
                 return None
     else:
         result = address

--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -617,7 +617,7 @@ class OpenStackAmuletUtils(AmuletUtils):
             self.log.debug('Keypair ({}) already exists, '
                            'using it.'.format(keypair_name))
             return _keypair
-        except:
+        except Exception:
             self.log.debug('Keypair ({}) does not exist, '
                            'creating it.'.format(keypair_name))
 

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1179,7 +1179,7 @@ class SubordinateConfigContext(OSContextGenerator):
                 if sub_config and sub_config != '':
                     try:
                         sub_config = json.loads(sub_config)
-                    except:
+                    except Exception:
                         log('Could not parse JSON from '
                             'subordinate_configuration setting from %s'
                             % rid, level=ERROR)

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -426,7 +426,7 @@ def get_os_codename_package(package, fatal=True):
 
     try:
         pkg = cache[package]
-    except:
+    except Exception:
         if not fatal:
             return None
         # the package is unknown to the current apt cache.
@@ -1618,7 +1618,7 @@ def do_action_openstack_upgrade(package, upgrade_callback, configs):
                     upgrade_callback(configs=configs)
                     action_set({'outcome': 'success, upgrade completed.'})
                     ret = True
-                except:
+                except Exception:
                     action_set({'outcome': 'upgrade failed, see traceback.'})
                     action_set({'traceback': traceback.format_exc()})
                     action_fail('do_openstack_upgrade resulted in an '
@@ -1723,7 +1723,7 @@ def is_unit_paused_set():
             kv = t[0]
             # transform something truth-y into a Boolean.
             return not(not(kv.get('unit-paused')))
-    except:
+    except Exception:
         return False
 
 

--- a/charmhelpers/contrib/python/debug.py
+++ b/charmhelpers/contrib/python/debug.py
@@ -49,6 +49,6 @@ def set_trace(addr=DEFAULT_ADDR, port=DEFAULT_PORT):
         open_port(port)
         debugger = Rpdb(addr=addr, port=port)
         debugger.set_trace(sys._getframe().f_back)
-    except:
+    except Exception:
         _error("Cannot start a remote debug session on %s:%s" % (addr,
                                                                  port))

--- a/charmhelpers/contrib/storage/linux/lvm.py
+++ b/charmhelpers/contrib/storage/linux/lvm.py
@@ -74,10 +74,10 @@ def list_lvm_volume_group(block_device):
     '''
     vg = None
     pvd = check_output(['pvdisplay', block_device]).splitlines()
-    for l in pvd:
-        l = l.decode('UTF-8')
-        if l.strip().startswith('VG Name'):
-            vg = ' '.join(l.strip().split()[2:])
+    for lvm in pvd:
+        lvm = lvm.decode('UTF-8')
+        if lvm.strip().startswith('VG Name'):
+            vg = ' '.join(lvm.strip().split()[2:])
     return vg
 
 

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -64,6 +64,6 @@ def is_device_mounted(device):
     '''
     try:
         out = check_output(['lsblk', '-P', device]).decode('UTF-8')
-    except:
+    except Exception:
         return False
     return bool(re.search(r'MOUNTPOINT=".+"', out))

--- a/charmhelpers/contrib/unison/__init__.py
+++ b/charmhelpers/contrib/unison/__init__.py
@@ -283,7 +283,7 @@ def sync_path_to_host(path, host, user, verbose=False, cmd=None, gid=None,
     try:
         log('Syncing local path %s to %s@%s:%s' % (path, user, host, path))
         run_as_user(user, cmd, gid)
-    except:
+    except Exception:
         log('Error syncing remote files')
         if fatal:
             raise

--- a/charmhelpers/coordinator.py
+++ b/charmhelpers/coordinator.py
@@ -408,8 +408,8 @@ class BaseCoordinator(with_metaclass(Singleton, object)):
         for u in self.requests:
             if u in granted:
                 continue  # In the granted set. Not wanted in the req list.
-            for l, ts in self.requests[u].items():
-                if l == lock:
+            for _lock, ts in self.requests[u].items():
+                if _lock == lock:
                     reqs.add((ts, u))
         queue = [t[1] for t in sorted(reqs)]
         if unit not in queue:

--- a/charmhelpers/core/unitdata.py
+++ b/charmhelpers/core/unitdata.py
@@ -358,7 +358,7 @@ class Storage(object):
         try:
             yield self.revision
             self.revision = None
-        except:
+        except Exception:
             self.flush(False)
             self.revision = None
             raise

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -572,7 +572,7 @@ def get_upstream_version(package):
     cache = apt_cache()
     try:
         pkg = cache[package]
-    except:
+    except Exception:
         # the package is unknown to the current apt cache.
         return None
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -330,7 +330,7 @@ class OpenStackHelpersTestCase(TestCase):
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_codename_package('foo')
-            except:
+            except Exception:
                 # ignore exceptions that raise when error_out is mocked
                 # and doesn't sys.exit(1)
                 pass
@@ -360,7 +360,7 @@ class OpenStackHelpersTestCase(TestCase):
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_codename_package('cinder-common', fatal=True)
-            except:
+            except Exception:
                 pass
             e = ('Could not determine version of uninstalled package: '
                  'cinder-common')
@@ -404,7 +404,7 @@ class OpenStackHelpersTestCase(TestCase):
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_version_package('foo')
-            except:
+            except Exception:
                 # ignore exceptions that raise when error_out is mocked
                 # and doesn't sys.exit(1)
                 pass
@@ -610,7 +610,7 @@ class OpenStackHelpersTestCase(TestCase):
         """Test configuring installation source from bad UCA source"""
         try:
             openstack.configure_installation_source('cloud:foo-bar')
-        except:
+        except Exception:
             # ignore exceptions that raise when error_out is mocked
             # and doesn't sys.exit(1)
             pass

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -36,7 +36,7 @@ bar
 baz
 """
 # Vastly abbreviated output from ceph osd dump --format=json
-OSD_DUMP = """
+OSD_DUMP = b"""
 {
     "pools": [
         {
@@ -85,7 +85,7 @@ OSD_DUMP = """
 }
 """
 
-MONMAP_DUMP = """{
+MONMAP_DUMP = b"""{
     "name": "ip-172-31-13-119", "rank": 0, "state": "leader",
     "election_epoch": 18, "quorum": [0, 1, 2],
     "outside_quorum": [],
@@ -550,7 +550,10 @@ class CephUtilsTests(TestCase):
             '010d57d581604d411b315dd64112bff832ab92c7323fa06077134b50',
             '8e0a9705c1aeafa1ce250cc9f1bb443fc6e5150e5edcbeb6eeb82e3c',
             'c3f8d36ba098c23ee920cb08cfb9beda6b639f8433637c190bdd56ec']
-        monmap.return_value = json.loads(MONMAP_DUMP)
+        _monmap_dump = MONMAP_DUMP
+        if six.PY3:
+            _monmap_dump = _monmap_dump.decode('UTF-8')
+        monmap.return_value = json.loads(_monmap_dump)
         hashed_mon_list = ceph_utils.hash_monitor_names(service='admin')
         self.assertEqual(expected=expected_hash_list, observed=hashed_mon_list)
 

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -132,11 +132,11 @@ class ConfigTest(TestCase):
         # it gets copied into our current dictionary. If this is not
         # a deep copy, then mappings and lists will be shared instances
         # and changes will not be detected.
-        c = hookenv.Config(dict(l=[]))
+        c = hookenv.Config(dict(ll=[]))
         c.save()
         c = hookenv.Config()
-        c['l'].append(42)
-        self.assertTrue(c.changed('l'), 'load_previous() did not deepcopy')
+        c['ll'].append(42)
+        self.assertTrue(c.changed('ll'), 'load_previous() did not deepcopy')
 
     def test_getitem(self):
         c = hookenv.Config(dict(foo='bar'))

--- a/tests/core/test_unitdata.py
+++ b/tests/core/test_unitdata.py
@@ -7,7 +7,7 @@
 #
 try:
     from StringIO import StringIO
-except:
+except Exception:
     from io import StringIO
 
 import os


### PR DESCRIPTION
A few changes to just bring charm-helpers ceph utils into Py3 land
as well as Py2.

Plus, recent PEP8 is more stringent, so just updates to make PEP8
happy.

Part of the migrating OpenStack charms to Python3 work.