### PR TITLE
Ingress address function

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import copy
 from distutils.version import LooseVersion
 from functools import wraps
+from collections import namedtuple
 import glob
 import os
 import json
@@ -1135,28 +1136,6 @@ def network_get(endpoint, relation_id=None):
     return yaml.safe_load(response)
 
 
-def ingress_address(rid=None, unit=None):
-    """
-    Retrieve the ingress-address from a relation when available. Otherwise,
-    return the private-address. This function is to be used on the consuming
-    side of the relation.
-
-    Usage:
-    addresses = []
-    for rid in relation_ids(relation_name):
-        for unit in related_units(rid):
-             addresses.append(ingress_address(rid=rid, unit=unit))
-
-    :param rid: string relation id
-    :param unit: string unit name
-    :side effect: calls relation_get
-    :return: string IP address
-    """
-    settings = relation_get(rid=rid, unit=unit)
-    return (settings.get('ingress-address') or
-            settings.get('private-address'))
-
-
 def add_metric(*args, **kwargs):
     """Add metric values. Values may be expressed with keyword arguments. For
     metric names containing dashes, these may be expressed as one or more
@@ -1186,3 +1165,42 @@ def meter_info():
     """Get the meter status information, if running in the meter-status-changed
     hook."""
     return os.environ.get('JUJU_METER_INFO')
+
+
+def iter_units_for_relation_name(relation_name):
+    """Iterate through all units in a relation
+
+    Generator that iterates through all the units in a relation and yields
+    a named tuple with rid and unit field names.
+
+    Usage:
+    data = [(u.rid, u.unit)
+            for u in iter_units_for_relation_name(relation_name)]
+
+    :param relation_name: string relation name
+    :yield: Named Tuple with rid and unit field names
+    """
+    RelatedUnit = namedtuple('RelatedUnit', 'rid, unit')
+    for rid in relation_ids(relation_name):
+        for unit in related_units(rid):
+            yield RelatedUnit(rid, unit)
+
+
+def ingress_address(rid=None, unit=None):
+    """
+    Retrieve the ingress-address from a relation when available. Otherwise,
+    return the private-address. This function is to be used on the consuming
+    side of the relation.
+
+    Usage:
+    addresses = [ingress_address(rid=u.rid, unit=u.unit)
+                 for u in iter_units_for_relation_name(relation_name)]
+
+    :param rid: string relation id
+    :param unit: string unit name
+    :side effect: calls relation_get
+    :return: string IP address
+    """
+    settings = relation_get(rid=rid, unit=unit)
+    return (settings.get('ingress-address') or
+            settings.get('private-address'))

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1135,6 +1135,28 @@ def network_get(endpoint, relation_id=None):
     return yaml.safe_load(response)
 
 
+def ingress_address(rid=None, unit=None):
+    """
+    Retrieve the ingress-address from a relation when available. Otherwise,
+    return the private-address. This function is to be used on the consuming
+    side of the relation.
+
+    Usage:
+    addresses = []
+    for rid in relation_ids(relation_name):
+        for unit in related_units(rid):
+             addresses.append(ingress_address(rid=rid, unit=unit))
+
+    :param rid: string relation id
+    :param unit: string unit name
+    :side effect: calls relation_get
+    :return: string IP address
+    """
+    settings = relation_get(rid=rid, unit=unit)
+    return (settings.get('ingress-address') or
+            settings.get('private-address'))
+
+
 def add_metric(*args, **kwargs):
     """Add metric values. Values may be expressed with keyword arguments. For
     metric names containing dashes, these may be expressed as one or more

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1674,18 +1674,14 @@ class HooksTest(TestCase):
 
     @patch.object(hookenv, 'relation_get')
     def test_ingress_address(self, relation_get):
-        """Ensure ingress_address returns the ingress-address when availble
-        and returns the private-address when ingress-address is not availabe.
+        """Ensure ingress_address returns the ingress-address when available
+        and returns the private-address when not.
         """
-        _with_ingress = {
-                'egress-subnets': '10.5.0.23/32',
-                'ingress-address': '10.5.0.23',
-                'private-address': '172.16.5.10',
-                }
+        _with_ingress = {'egress-subnets': '10.5.0.23/32',
+                         'ingress-address': '10.5.0.23',
+                         'private-address': '172.16.5.10'}
 
-        _without_ingress = {
-                'private-address': '172.16.5.10',
-                }
+        _without_ingress = {'private-address': '172.16.5.10'}
 
         # Return the ingress-address
         relation_get.return_value = _with_ingress

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1672,6 +1672,31 @@ class HooksTest(TestCase):
             ['network-get', '--primary-address', 'mybinding'])
         self.assertEqual(ip, '192.168.22.1')
 
+    @patch.object(hookenv, 'relation_get')
+    def test_ingress_address(self, relation_get):
+        """Ensure ingress_address returns the ingress-address when availble
+        and returns the private-address when ingress-address is not availabe.
+        """
+        _with_ingress = {
+                'egress-subnets': '10.5.0.23/32',
+                'ingress-address': '10.5.0.23',
+                'private-address': '172.16.5.10',
+                }
+
+        _without_ingress = {
+                'private-address': '172.16.5.10',
+                }
+
+        # Return the ingress-address
+        relation_get.return_value = _with_ingress
+        self.assertEqual(hookenv.ingress_address(rid='test:1', unit='unit/1'),
+                         '10.5.0.23')
+        relation_get.assert_called_with(rid='test:1', unit='unit/1')
+        # Return the private-address
+        relation_get.return_value = _without_ingress
+        self.assertEqual(hookenv.ingress_address(rid='test:1'),
+                         '172.16.5.10')
+
     @patch('subprocess.check_output')
     def test_network_get_primary_unsupported(self, check_output):
         """Ensure that NotImplementedError is thrown when run on Juju < 2.0"""


### PR DESCRIPTION
The new features in Juju set ingress-address and egress-networks on all
relations based on network spaces. Ingress-address should be used
over private-address when it is available. As this is a new feature we
fall back to private-address when ingress-address is not available.

This new function consumes the relation data and returns the
ingress-address when available or the private-address when not.

The code is relatively simple. As a review, I request input on the nomenclature as well. Is ingress_address too vague? Some other options:
get_ingress_address
get_relation_ingress_address
get_remote_ingress_address
etc.