### PR TITLE
py3: Encode template before writing to file

### DIFF
--- a/charmhelpers/contrib/openstack/templating.py
+++ b/charmhelpers/contrib/openstack/templating.py
@@ -272,6 +272,8 @@ class OSConfigRenderer(object):
             raise OSConfigException
 
         _out = self.render(config_file)
+        if six.PY3:
+            _out = _out.encode('UTF-8')
 
         with open(config_file, 'wb') as out:
             out.write(_out)


### PR DESCRIPTION
Ensure that under Python 3, the rended template content is encoded
before writing to the target file.