### PR TITLE
py3: Ensure haproxy backends are sorted

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import glob
 import json
 import math
@@ -578,11 +579,14 @@ class HAProxyContext(OSContextGenerator):
             laddr = get_address_in_network(config(cfg_opt))
             if laddr:
                 netmask = get_netmask_for_address(laddr)
-                cluster_hosts[laddr] = {'network': "{}/{}".format(laddr,
-                                                                  netmask),
-                                        'backends': {l_unit: laddr}}
+                cluster_hosts[laddr] = {
+                    'network': "{}/{}".format(laddr,
+                                              netmask),
+                    'backends': collections.OrderedDict([(l_unit,
+                                                          laddr)])
+                }
                 for rid in relation_ids('cluster'):
-                    for unit in related_units(rid):
+                    for unit in sorted(related_units(rid)):
                         _laddr = relation_get('{}-address'.format(addr_type),
                                               rid=rid, unit=unit)
                         if _laddr:
@@ -594,10 +598,13 @@ class HAProxyContext(OSContextGenerator):
         # match in the frontend
         cluster_hosts[addr] = {}
         netmask = get_netmask_for_address(addr)
-        cluster_hosts[addr] = {'network': "{}/{}".format(addr, netmask),
-                               'backends': {l_unit: addr}}
+        cluster_hosts[addr] = {
+            'network': "{}/{}".format(addr, netmask),
+            'backends': collections.OrderedDict([(l_unit,
+                                                  addr)])
+        }
         for rid in relation_ids('cluster'):
-            for unit in related_units(rid):
+            for unit in sorted(related_units(rid)):
                 _laddr = relation_get('private-address',
                                       rid=rid, unit=unit)
                 if _laddr:

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1,3 +1,4 @@
+import collections
 import charmhelpers.contrib.openstack.context as context
 import yaml
 import json
@@ -1769,35 +1770,35 @@ class ContextTests(unittest.TestCase):
             'frontends': {
                 'cluster-peer0.admin': {
                     'network': 'cluster-peer0.admin/255.255.0.0',
-                    'backends': {
-                        'peer-0': 'cluster-peer0.admin',
-                        'peer-1': 'cluster-peer1.admin',
-                        'peer-2': 'cluster-peer2.admin',
-                    }
+                    'backends': collections.OrderedDict([
+                        ('peer-0', 'cluster-peer0.admin'),
+                        ('peer-1', 'cluster-peer1.admin'),
+                        ('peer-2', 'cluster-peer2.admin'),
+                    ]),
                 },
                 'cluster-peer0.internal': {
                     'network': 'cluster-peer0.internal/255.255.0.0',
-                    'backends': {
-                        'peer-0': 'cluster-peer0.internal',
-                        'peer-1': 'cluster-peer1.internal',
-                        'peer-2': 'cluster-peer2.internal',
-                    }
+                    'backends': collections.OrderedDict([
+                        ('peer-0', 'cluster-peer0.internal'),
+                        ('peer-1', 'cluster-peer1.internal'),
+                        ('peer-2', 'cluster-peer2.internal'),
+                    ]),
                 },
                 'cluster-peer0.public': {
                     'network': 'cluster-peer0.public/255.255.0.0',
-                    'backends': {
-                        'peer-0': 'cluster-peer0.public',
-                        'peer-1': 'cluster-peer1.public',
-                        'peer-2': 'cluster-peer2.public',
-                    }
+                    'backends': collections.OrderedDict([
+                        ('peer-0', 'cluster-peer0.public'),
+                        ('peer-1', 'cluster-peer1.public'),
+                        ('peer-2', 'cluster-peer2.public'),
+                    ]),
                 },
                 'cluster-peer0.localnet': {
                     'network': 'cluster-peer0.localnet/255.255.0.0',
-                    'backends': {
-                        'peer-0': 'cluster-peer0.localnet',
-                        'peer-1': 'cluster-peer1.localnet',
-                        'peer-2': 'cluster-peer2.localnet',
-                    }
+                    'backends': collections.OrderedDict([
+                        ('peer-0', 'cluster-peer0.localnet'),
+                        ('peer-1', 'cluster-peer1.localnet'),
+                        ('peer-2', 'cluster-peer2.localnet'),
+                    ]),
                 }
             },
             'default_backend': 'cluster-peer0.localnet',


### PR DESCRIPTION
Python 3 makes no guarantee about iteration order in dicts;
ensure that an OrderedDict is used instead to ensure that the
ordering of haproxy backend units is consistent between hook
executions, avoiding restarts of haproxy due to changes in
the ordering of units.