### PR TITLE
Update bytes_from_string to default toi bytes

### DIFF
--- a/charmhelpers/core/strutils.py
+++ b/charmhelpers/core/strutils.py
@@ -61,13 +61,19 @@ def bytes_from_string(value):
     if isinstance(value, six.string_types):
         value = six.text_type(value)
     else:
-        msg = "Unable to interpret non-string value '%s' as boolean" % (value)
+        msg = "Unable to interpret non-string value '%s' as bytes" % (value)
         raise ValueError(msg)
     matches = re.match("([0-9]+)([a-zA-Z]+)", value)
-    if not matches:
-        msg = "Unable to interpret string value '%s' as bytes" % (value)
-        raise ValueError(msg)
-    return int(matches.group(1)) * (1024 ** BYTE_POWER[matches.group(2)])
+    if matches:
+        size = int(matches.group(1)) * (1024 ** BYTE_POWER[matches.group(2)])
+    else:
+        # Assume that value passed in is bytes
+        try:
+            size = int(value)
+        except ValueError:
+            msg = "Unable to interpret string value '%s' as bytes" % (value)
+            raise ValueError(msg)
+    return size
 
 
 class BasicStringComparator(object):

--- a/tests/core/test_strutils.py
+++ b/tests/core/test_strutils.py
@@ -34,6 +34,7 @@ class TestStrUtils(unittest.TestCase):
         self.assertRaises(ValueError, strutils.bool_from_string, 'foo')
 
     def test_bytes_from_string(self):
+        self.assertEqual(strutils.bytes_from_string('10'), 10)
         self.assertEqual(strutils.bytes_from_string('3K'), 3072)
         self.assertEqual(strutils.bytes_from_string('3KB'), 3072)
         self.assertEqual(strutils.bytes_from_string('3M'), 3145728)


### PR DESCRIPTION
This change updates the bytes_from_string function so that it
assumes a number without a suffix is in bytes.

Partial-Bug: #1732413