### PR TITLE
Enable the repo: line for charm-helpers sync to take a branch

### DIFF
--- a/tools/charm_helpers_sync/charm_helpers_sync.py
+++ b/tools/charm_helpers_sync/charm_helpers_sync.py
@@ -42,7 +42,13 @@ def parse_config(conf_file):
 def clone_helpers(work_dir, repo):
     dest = os.path.join(work_dir, 'charm-helpers')
     logging.info('Cloning out %s to %s.' % (repo, dest))
-    cmd = ['git', 'clone', '--depth=1', repo, dest]
+    branch = None
+    if '@' in repo:
+        repo, branch = repo.split('@', 1)
+    cmd = ['git', 'clone', '--depth=1']
+    if branch is not None:
+        cmd += ['--branch', branch]
+    cmd += [repo, dest]
     subprocess.check_call(cmd)
     return dest
 


### PR DESCRIPTION
This change enables the repo line for a git sync to take a branch
in the form of:

repo: https://github.com/some-name/charm-helpers@branch-name

This is handy for testing, if making changes to charmhelpers and wanting
to sync those changes into the charm during development.