### PR TITLE
Increase timeout in _deploy() to 1800 for snap packaged charm payloads

### DIFF
--- a/charmhelpers/contrib/amulet/deployment.py
+++ b/charmhelpers/contrib/amulet/deployment.py
@@ -78,7 +78,7 @@ class AmuletDeployment(object):
 
     def _deploy(self):
         """Deploy environment and wait for all hooks to finish executing."""
-        timeout = int(os.environ.get('AMULET_SETUP_TIMEOUT', 900))
+        timeout = int(os.environ.get('AMULET_SETUP_TIMEOUT', 1800))
         try:
             self.d.setup(timeout=timeout)
             self.d.sentry.wait(timeout=timeout)


### PR DESCRIPTION
The timeout increase allows the gate-basic-snap-xenial-ocata to pass with Python 3 which needs extended timescales as there is a manager file that gets called multiple times.  Due to how snaps don't allow cached python files (readonly fs), this means that the tests run much more slowly.