### PR TITLE
Add funcs for listing & extending logical volumes

### DIFF
--- a/charmhelpers/contrib/storage/linux/lvm.py
+++ b/charmhelpers/contrib/storage/linux/lvm.py
@@ -140,10 +140,6 @@ list_thin_logical_volumes = functools.partial(
     list_logical_volumes,
     select_criteria='lv_attr =~ ^V')
 
-list_regular_logical_volumes = functools.partial(
-    list_logical_volumes,
-    select_criteria='lv_attr =~ ^-')
-
 
 def extend_logical_volume_by_device(lv_name, block_device):
     '''

--- a/charmhelpers/contrib/storage/linux/lvm.py
+++ b/charmhelpers/contrib/storage/linux/lvm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 from subprocess import (
     CalledProcessError,
     check_call,
@@ -101,3 +102,56 @@ def create_lvm_volume_group(volume_group, block_device):
     :block_device: str: Full path of PV-initialized block device.
     '''
     check_call(['vgcreate', volume_group, block_device])
+
+
+def list_logical_volumes(select_criteria=None, path_mode=False):
+    '''
+    List logical volumes
+
+    :param select_criteria: str: Limit list to those volumes matching this
+                                 criteria (see 'lvs -S help' for more details)
+    :param path_mode: bool: return logical volume name in 'vg/lv' format, this
+                            format is required for some commands like lvextend
+    :returns: [str]: List of logical volumes
+    '''
+    lv_diplay_attr = 'lv_name'
+    if path_mode:
+        # Parsing output logic relies on the column order
+        lv_diplay_attr = 'vg_name,' + lv_diplay_attr
+    cmd = ['lvs', '--options', lv_diplay_attr, '--noheadings']
+    if select_criteria:
+        cmd.extend(['--select', select_criteria])
+    lvs = []
+    for lv in check_output(cmd).decode('UTF-8').splitlines():
+        if not lv:
+            continue
+        if path_mode:
+            lvs.append('/'.join(lv.strip().split()))
+        else:
+            lvs.append(lv.strip())
+    return lvs
+
+
+list_thin_logical_volume_pools = functools.partial(
+    list_logical_volumes,
+    select_criteria='lv_attr =~ ^t')
+
+list_thin_logical_volumes = functools.partial(
+    list_logical_volumes,
+    select_criteria='lv_attr =~ ^V')
+
+list_regular_logical_volumes = functools.partial(
+    list_logical_volumes,
+    select_criteria='lv_attr =~ ^-')
+
+
+def extend_logical_volume_by_device(lv_name, block_device):
+    '''
+    Extends the size of logical volume lv_name by the amount of free space on
+    physical volume block_device.
+
+    :param lv_name: str: name of logical volume to be extended (vg/lv format)
+    :param block_device: str: name of block_device to be allocated to lv_name
+    '''
+    cmd = ['lvextend', lv_name, block_device]
+    check_call(cmd)

--- a/tests/contrib/storage/test_linux_storage_lvm.py
+++ b/tests/contrib/storage/test_linux_storage_lvm.py
@@ -32,6 +32,24 @@ EMPTY_VG_IN_PVDISPLAY = b"""
   PV UUID               fyVqlr-pyrL-89On-f6MD-U91T-dEfc-SL0V2V
 
 """
+LVS_DEFAULT = b"""
+  cinder-volumes-pool
+  testvol
+  volume-48be6ba0-84c3-4b8d-9be5-e68e47fc7682
+  volume-f8c1d2fd-1fa1-4d84-b4e0-431dba7d582e
+"""
+LVS_WITH_VG = b"""
+  cinder-volumes cinder-volumes-pool
+  cinder-volumes testvol
+  cinder-volumes volume-48be6ba0-84c3-4b8d-9be5-e68e47fc7682
+  cinder-volumes volume-f8c1d2fd-1fa1-4d84-b4e0-431dba7d582e
+"""
+LVS_THIN_POOLS = b"""
+  cinder-volumes-pool
+"""
+LVS_THIN_POOLS_WITH_VG = b"""
+  cinder-volumes cinder-volumes-pool
+"""
 
 # It's a mouthful.
 STORAGE_LINUX_LVM = 'charmhelpers.contrib.storage.linux.lvm'
@@ -89,3 +107,84 @@ class LVMStorageUtilsTests(unittest.TestCase):
         with patch(STORAGE_LINUX_LVM + '.check_call') as check_call:
             lvm.create_lvm_volume_group('foo-vg', '/dev/foo')
             check_call.assert_called_with(['vgcreate', 'foo-vg', '/dev/foo'])
+
+    def test_list_logical_volumes(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = LVS_DEFAULT
+            self.assertEqual(lvm.list_logical_volumes(), [
+                'cinder-volumes-pool',
+                'testvol',
+                'volume-48be6ba0-84c3-4b8d-9be5-e68e47fc7682',
+                'volume-f8c1d2fd-1fa1-4d84-b4e0-431dba7d582e'])
+            check_output.assert_called_with([
+                'lvs',
+                '--options',
+                'lv_name',
+                '--noheadings'])
+
+    def test_list_logical_volumes_empty(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = b''
+            self.assertEqual(lvm.list_logical_volumes(), [])
+
+    def test_list_logical_volumes_path_mode(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = LVS_WITH_VG
+            self.assertEqual(lvm.list_logical_volumes(path_mode=True), [
+                'cinder-volumes/cinder-volumes-pool',
+                'cinder-volumes/testvol',
+                'cinder-volumes/volume-48be6ba0-84c3-4b8d-9be5-e68e47fc7682',
+                'cinder-volumes/volume-f8c1d2fd-1fa1-4d84-b4e0-431dba7d582e'])
+            check_output.assert_called_with([
+                'lvs',
+                '--options',
+                'vg_name,lv_name',
+                '--noheadings'])
+
+    def test_list_logical_volumes_select_criteria(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = LVS_THIN_POOLS
+            self.assertEqual(
+                lvm.list_logical_volumes(select_criteria='lv_attr =~ ^t'),
+                ['cinder-volumes-pool'])
+            check_output.assert_called_with([
+                'lvs',
+                '--options',
+                'lv_name',
+                '--noheadings',
+                '--select',
+                'lv_attr =~ ^t'])
+
+    def test_list_thin_logical_volume_pools(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = LVS_THIN_POOLS
+            self.assertEqual(
+                lvm.list_thin_logical_volume_pools(),
+                ['cinder-volumes-pool'])
+            check_output.assert_called_with([
+                'lvs',
+                '--options',
+                'lv_name',
+                '--noheadings',
+                '--select',
+                'lv_attr =~ ^t'])
+
+    def test_list_thin_logical_volume_pools_path_mode(self):
+        with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
+            check_output.return_value = LVS_THIN_POOLS_WITH_VG
+            self.assertEqual(
+                lvm.list_thin_logical_volume_pools(path_mode=True),
+                ['cinder-volumes/cinder-volumes-pool'])
+            check_output.assert_called_with([
+                'lvs',
+                '--options',
+                'vg_name,lv_name',
+                '--noheadings',
+                '--select',
+                'lv_attr =~ ^t'])
+
+    def test_extend_logical_volume_by_device(self):
+        """It correctly calls pvcreate for a given block dev"""
+        with patch(STORAGE_LINUX_LVM + '.check_call') as check_call:
+            lvm.extend_logical_volume_by_device('mylv', '/dev/foo')
+            check_call.assert_called_with(['lvextend', 'mylv', '/dev/foo'])


### PR DESCRIPTION
This patch adds two new functions list_logical_volumes and
extend_logical_volume_by_device. It also adds 3 functools.partial
based functions for common use cases for list_logical_volumes.

These new functions are needed by the cinder charm to resolve
Bug #1735931.

Partial-Bug: #1735931