### PR TITLE
Update HAProxy default timeout values

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -17,22 +17,22 @@ defaults
 {%- if haproxy_queue_timeout %}
     timeout queue {{ haproxy_queue_timeout }}
 {%- else %}
-    timeout queue 5000
+    timeout queue 9000
 {%- endif %}
 {%- if haproxy_connect_timeout %}
     timeout connect {{ haproxy_connect_timeout }}
 {%- else %}
-    timeout connect 5000
+    timeout connect 9000
 {%- endif %}
 {%- if haproxy_client_timeout %}
     timeout client {{ haproxy_client_timeout }}
 {%- else %}
-    timeout client 30000
+    timeout client 90000
 {%- endif %}
 {%- if haproxy_server_timeout %}
     timeout server {{ haproxy_server_timeout }}
 {%- else %}
-    timeout server 30000
+    timeout server 90000
 {%- endif %}
 
 listen stats


### PR DESCRIPTION
The default HAProxy timeout values are fairly strict. On a busy cloud
it is common to exceed one or more of these timeouts. The only
indication that HAProxy has exceeded a timeout and dropped the
connection is errors such as "BadStatusLine" or "EOF." These can be
very difficult to diagnose when intermittent.

This change updates the default timeout values to more real world
settings. These values have been extensively tested in ServerStack.
Configured values will not be overridden.