### PR TITLE
Ensure all keys checked when comparing broker obj

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1109,7 +1109,7 @@ class CephBrokerRq(object):
             for req_no in range(0, len(self.ops)):
                 for key in [
                         'replicas', 'name', 'op', 'pg_num', 'weight',
-                        'group', 'namespace', 'group-permission']:
+                        'group', 'group-namespace', 'group-permission']:
                     if self.ops[req_no].get(key) != other.ops[req_no].get(key):
                         return False
         else:

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1107,7 +1107,9 @@ class CephBrokerRq(object):
     def _ops_equal(self, other):
         if len(self.ops) == len(other.ops):
             for req_no in range(0, len(self.ops)):
-                for key in ['replicas', 'name', 'op', 'pg_num', 'weight']:
+                for key in [
+                        'replicas', 'name', 'op', 'pg_num', 'weight',
+                        'group', 'namespace', 'group-permission']:
                     if self.ops[req_no].get(key) != other.ops[req_no].get(key):
                         return False
         else:

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1112,6 +1112,23 @@ class CephUtilsTests(TestCase):
             self.assertEqual(request_dict['ops'][0][key], expected['ops'][0][key])
             self.assertEqual(request_dict['ops'][1][key], expected['ops'][1][key])
 
+    @patch.object(ceph_utils, 'service_name')
+    @patch.object(ceph_utils, 'uuid')
+    def test_ceph_broker_rq_class_test_not_equal(self, uuid, service_name):
+        service_name.return_value = 'service_test'
+        uuid.uuid1.return_value = 'uuid'
+        rq1 = ceph_utils.CephBrokerRq()
+        rq1.add_op_create_pool('pool1')
+        rq1.add_op_request_access_to_group(name='test')
+        rq1.add_op_request_access_to_group(name='objects',
+                                           permission='rwx')
+        rq2 = ceph_utils.CephBrokerRq()
+        rq2.add_op_create_pool('pool1')
+        rq2.add_op_request_access_to_group(name='test')
+        rq2.add_op_request_access_to_group(name='objects',
+                                           permission='r')
+        self.assertFalse(rq1 == rq2)
+
     def test_ceph_broker_rsp_class(self):
         rsp = ceph_utils.CephBrokerRsp(json.dumps({'exit-code': 0,
                                                    'stderr': "Success"}))


### PR DESCRIPTION
Charms check whether a broker request needs to be sent by
comparing previous broker requests with a new one. Currently
changes to permissions go undetected because not all keys are
checking in CephBrokerRq._ops_equal

Partial-Bug: #1696073