### PR TITLE
Fix presentation use of domain for identity-credentials

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -439,7 +439,7 @@ class IdentityCredentialsContext(IdentityServiceContext):
 
                 if float(api_version) > 2:
                     ctxt.update({'admin_domain_name':
-                                 rdata.get('credentials_domain')})
+                                 rdata.get('domain')})
 
                 if self.context_complete(ctxt):
                     return ctxt

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -148,7 +148,7 @@ IDENTITY_CREDENTIALS_RELATION_UNSET = {
     'auth_host': 'keystone-host.local',
     'auth_port': '35357',
     'auth_protocol': 'https',
-    'credentials_domain': 'admin_domain',
+    'domain': 'admin_domain',
     'credentials_project': 'admin',
     'credentials_project_id': '123456',
     'credentials_password': 'foo',


### PR DESCRIPTION
The configured domain is presented via the 'domain' key, not
'credentials_domain' as previously committed.