### PR TITLE
Fix for pool_set function and validator handling of strings

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -113,7 +113,7 @@ def validator(value, valid_type, valid_range=None):
         assert isinstance(valid_range, list), \
             "valid_range must be a list, was given {}".format(valid_range)
         # If we're dealing with strings
-        if valid_type is six.string_types:
+        if isinstance(value, six.string_types):
             assert value in valid_range, \
                 "{} is not in the list {}".format(value, valid_range)
         # Integer, float should have a min and max
@@ -517,7 +517,8 @@ def pool_set(service, pool_name, key, value):
     :param value:
     :return: None.  Can raise CalledProcessError
     """
-    cmd = ['ceph', '--id', service, 'osd', 'pool', 'set', pool_name, key, value]
+    cmd = ['ceph', '--id', service, 'osd', 'pool', 'set', pool_name, key,
+           str(value).lower()]
     try:
         check_call(cmd)
     except CalledProcessError:

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -212,6 +212,16 @@ class CephUtilsTests(TestCase):
                           valid_type=six.string_types,
                           valid_range=["valid", "list", "of", "strings"])
 
+    def test_validator_valid_string(self):
+        ceph_utils.validator(value="foo",
+                             valid_type=six.string_types,
+                             valid_range=["foo"])
+
+    def test_validator_valid_string_type(self):
+        ceph_utils.validator(value="foo",
+                             valid_type=str,
+                             valid_range=["foo"])
+
     def test_pool_add_cache_tier(self):
         p = ceph_utils.Pool(name='test', service='admin')
         p.add_cache_tier('cacher', 'readonly')
@@ -394,11 +404,25 @@ class CephUtilsTests(TestCase):
         return_value = ceph_utils.get_erasure_profile('admin', 'unknown')
         self.assertEqual(None, return_value)
 
-    def test_pool_set(self):
+    def test_pool_set_int(self):
         self.check_call.return_value = 0
         ceph_utils.pool_set(service='admin', pool_name='data', key='test', value=2)
         self.check_call.assert_has_calls([
-            call(['ceph', '--id', 'admin', 'osd', 'pool', 'set', 'data', 'test', 2])
+            call(['ceph', '--id', 'admin', 'osd', 'pool', 'set', 'data', 'test', '2'])
+        ])
+
+    def test_pool_set_bool(self):
+        self.check_call.return_value = 0
+        ceph_utils.pool_set(service='admin', pool_name='data', key='test', value=True)
+        self.check_call.assert_has_calls([
+            call(['ceph', '--id', 'admin', 'osd', 'pool', 'set', 'data', 'test', 'true'])
+        ])
+
+    def test_pool_set_str(self):
+        self.check_call.return_value = 0
+        ceph_utils.pool_set(service='admin', pool_name='data', key='test', value='two')
+        self.check_call.assert_has_calls([
+            call(['ceph', '--id', 'admin', 'osd', 'pool', 'set', 'data', 'test', 'two'])
         ])
 
     def test_pool_set_fails(self):


### PR DESCRIPTION
Fix non-string inputs for pool_set
 - New test for pool_set with bool
 - New test for pool_set with str
 - Fixed test for pool_set with int

Fix handling of strings in validator.
 - New test that six.string_type still works with this change
 - New test that type 'str' works, test fails w/o the above fix