### PR TITLE
Add helpers for hacluster interface type

### DIFF
--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -23,6 +23,8 @@
 Helpers for high availability.
 """
 
+import json
+
 import re
 
 from charmhelpers.core.hookenv import (
@@ -32,6 +34,7 @@ from charmhelpers.core.hookenv import (
     config,
     status_set,
     DEBUG,
+    WARNING,
 )
 
 from charmhelpers.core.host import (
@@ -40,6 +43,23 @@ from charmhelpers.core.host import (
 
 from charmhelpers.contrib.openstack.ip import (
     resolve_address,
+    is_ipv6,
+)
+
+from charmhelpers.contrib.network.ip import (
+    get_iface_for_address,
+    get_netmask_for_address,
+)
+
+from charmhelpers.contrib.hahelpers.cluster import (
+    get_hacluster_config
+)
+
+JSON_ENCODE_OPTIONS = dict(
+    sort_keys=True,
+    allow_nan=False,
+    indent=None,
+    separators=(',', ':'),
 )
 
 
@@ -53,8 +73,8 @@ class DNSHAException(Exception):
 def update_dns_ha_resource_params(resources, resource_params,
                                   relation_id=None,
                                   crm_ocf='ocf:maas:dns'):
-    """ Check for os-*-hostname settings and update resource dictionaries for
-    the HA relation.
+    """ Configure DNS-HA resources based on provided configuration and
+    update resource dictionaries for the HA relation.
 
     @param resources: Pointer to dictionary of resources.
                       Usually instantiated in ha_joined().
@@ -64,7 +84,85 @@ def update_dns_ha_resource_params(resources, resource_params,
     @param crm_ocf: Corosync Open Cluster Framework resource agent to use for
                     DNS HA
     """
+    _relation_data = {'resources': {}, 'resource_params': {}}
+    update_hacluster_dns_ha(charm_name(),
+                            _relation_data,
+                            crm_ocf)
+    resources.update(_relation_data['resources'])
+    resource_params.update(_relation_data['resource_params'])
+    relation_set(relation_id=relation_id, groups=_relation_data['groups'])
 
+
+def assert_charm_supports_dns_ha():
+    """Validate prerequisites for DNS HA
+    The MAAS client is only available on Xenial or greater
+
+    :raises DNSHAException: if release is < 16.04
+    """
+    if lsb_release().get('DISTRIB_RELEASE') < '16.04':
+        msg = ('DNS HA is only supported on 16.04 and greater '
+               'versions of Ubuntu.')
+        status_set('blocked', msg)
+        raise DNSHAException(msg)
+    return True
+
+
+def expect_ha():
+    """ Determine if the unit expects to be in HA
+
+    Check for VIP or dns-ha settings which indicate the unit should expect to
+    be related to hacluster.
+
+    @returns boolean
+    """
+    return config('vip') or config('dns-ha')
+
+
+def generate_ha_relation_data(service):
+    """ Generate relation data for ha relation
+
+    Based on configuration options and unit interfaces, generate a json
+    encoded dict of relation data items for the hacluster relation,
+    providing configuration for DNS HA or VIP's + haproxy clone sets.
+
+    @returns dict: json encoded data for use with relation_set
+    """
+    _haproxy_res = 'res_{}_haproxy'.format(service)
+    _relation_data = {
+        'resources': {
+            _haproxy_res: 'lsb:haproxy',
+        },
+        'resource_params': {
+            _haproxy_res: 'op monitor interval="5s"'
+        },
+        'init_services': {
+            _haproxy_res: 'haproxy'
+        },
+        'clones': {
+            'cl_{}_haproxy'.format(service): _haproxy_res
+        },
+    }
+
+    if config('dns-ha'):
+        update_hacluster_dns_ha(service, _relation_data)
+    else:
+        update_hacluster_vip(service, _relation_data)
+
+    return {
+        'json_{}'.format(k): json.dumps(v, **JSON_ENCODE_OPTIONS)
+        for k, v in _relation_data.items() if v
+    }
+
+
+def update_hacluster_dns_ha(service, relation_data,
+                            crm_ocf='ocf:maas:dns'):
+    """ Configure DNS-HA resources based on provided configuration
+
+    @param service: Name of the service being configured
+    @param relation_data: Pointer to dictionary of relation data.
+    @param crm_ocf: Corosync Open Cluster Framework resource agent to use for
+                    DNS HA
+    """
     # Validate the charm environment for DNS HA
     assert_charm_supports_dns_ha()
 
@@ -93,7 +191,7 @@ def update_dns_ha_resource_params(resources, resource_params,
             status_set('blocked', msg)
             raise DNSHAException(msg)
 
-        hostname_key = 'res_{}_{}_hostname'.format(charm_name(), endpoint_type)
+        hostname_key = 'res_{}_{}_hostname'.format(service, endpoint_type)
         if hostname_key in hostname_group:
             log('DNS HA: Resource {}: {} already exists in '
                 'hostname group - skipping'.format(hostname_key, hostname),
@@ -101,42 +199,67 @@ def update_dns_ha_resource_params(resources, resource_params,
             continue
 
         hostname_group.append(hostname_key)
-        resources[hostname_key] = crm_ocf
-        resource_params[hostname_key] = (
-            'params fqdn="{}" ip_address="{}" '
-            ''.format(hostname, resolve_address(endpoint_type=endpoint_type,
-                                                override=False)))
+        relation_data['resources'][hostname_key] = crm_ocf
+        relation_data['resource_params'][hostname_key] = (
+            'params fqdn="{}" ip_address="{}"'
+            .format(hostname, resolve_address(endpoint_type=endpoint_type,
+                                              override=False)))
 
     if len(hostname_group) >= 1:
         log('DNS HA: Hostname group is set with {} as members. '
             'Informing the ha relation'.format(' '.join(hostname_group)),
             DEBUG)
-        relation_set(relation_id=relation_id, groups={
-            'grp_{}_hostnames'.format(charm_name()): ' '.join(hostname_group)})
+        relation_data['groups'] = {
+            'grp_{}_hostnames'.format(service): ' '.join(hostname_group)
+        }
     else:
         msg = 'DNS HA: Hostname group has no members.'
         status_set('blocked', msg)
         raise DNSHAException(msg)
 
 
-def assert_charm_supports_dns_ha():
-    """Validate prerequisites for DNS HA
-    The MAAS client is only available on Xenial or greater
+def update_hacluster_vip(service, relation_data):
+    """ Configure VIP resources based on provided configuration
+
+    @param service: Name of the service being configured
+    @param relation_data: Pointer to dictionary of relation data.
     """
-    if lsb_release().get('DISTRIB_RELEASE') < '16.04':
-        msg = ('DNS HA is only supported on 16.04 and greater '
-               'versions of Ubuntu.')
-        status_set('blocked', msg)
-        raise DNSHAException(msg)
-    return True
+    cluster_config = get_hacluster_config()
+    vip_group = []
+    for vip in cluster_config['vip'].split():
+        if is_ipv6(vip):
+            res_neutron_vip = 'ocf:heartbeat:IPv6addr'
+            vip_params = 'ipv6addr'
+        else:
+            res_neutron_vip = 'ocf:heartbeat:IPaddr2'
+            vip_params = 'ip'
 
+        iface = (get_iface_for_address(vip) or
+                 config('vip_iface'))
+        netmask = (get_netmask_for_address(vip) or
+                   config('vip_cidr'))
 
-def expect_ha():
-    """ Determine if the unit expects to be in HA
+        if iface is not None:
+            vip_key = 'res_{}_{}_vip'.format(service, iface)
+            if vip_key in vip_group:
+                if vip not in relation_data['resource_params'][vip_key]:
+                    vip_key = '{}_{}'.format(vip_key, vip_params)
+                else:
+                    log("Resource '%s' (vip='%s') already exists in "
+                        "vip group - skipping" % (vip_key, vip), WARNING)
+                    continue
 
-    Check for VIP or dns-ha settings which indicate the unit should expect to
-    be related to hacluster.
+            relation_data['resources'][vip_key] = res_neutron_vip
+            relation_data['resource_params'][vip_key] = (
+                'params {ip}="{vip}" cidr_netmask="{netmask}" '
+                'nic="{iface}"'.format(ip=vip_params,
+                                       vip=vip,
+                                       iface=iface,
+                                       netmask=netmask)
+            )
+            vip_group.append(vip_key)
 
-    @returns boolean
-    """
-    return config('vip') or config('dns-ha')
+    if len(vip_group) >= 1:
+        relation_data['groups'] = {
+            'grp_{}_vips'.format(service): ' '.join(vip_group)
+        }

--- a/tests/contrib/openstack/ha/test_ha_utils.py
+++ b/tests/contrib/openstack/ha/test_ha_utils.py
@@ -1,7 +1,20 @@
 from mock import patch
 import unittest
+import json
 
 from charmhelpers.contrib.openstack.ha import utils as ha
+
+IFACE_LOOKUPS = {
+    '10.5.100.1': 'eth1',
+    'ffff::1': 'eth1',
+    'ffaa::1': 'eth2',
+}
+
+NETMASK_LOOKUPS = {
+    '10.5.100.1': '255.255.255.0',
+    'ffff::1': '64',
+    'ffaa::1': '32',
+}
 
 
 class HATests(unittest.TestCase):
@@ -13,11 +26,19 @@ class HATests(unittest.TestCase):
             'relation_set',
             'resolve_address',
             'status_set',
+            'get_hacluster_config',
+            'get_iface_for_address',
+            'get_netmask_for_address',
         ]]
         self.resources = {'res_test_haproxy': 'lsb:haproxy'}
         self.resource_params = {'res_test_haproxy': 'op monitor interval="5s"'}
         self.conf = {}
         self.config.side_effect = lambda key: self.conf.get(key)
+        self.maxDiff = None
+        self.get_iface_for_address.side_effect = \
+            lambda x: IFACE_LOOKUPS.get(x)
+        self.get_netmask_for_address.side_effect = \
+            lambda x: NETMASK_LOOKUPS.get(x)
 
     def _patch(self, method):
         _m = patch.object(ha, method)
@@ -47,7 +68,7 @@ class HATests(unittest.TestCase):
                               'res_test_haproxy': 'lsb:haproxy'}
         EXPECTED_RESOURCE_PARAMS = {
             'res_test_public_hostname': ('params fqdn="test.maas" '
-                                         'ip_address="10.0.0.1" '),
+                                         'ip_address="10.0.0.1"'),
             'res_test_haproxy': 'op monitor interval="5s"'}
 
         self.conf = {
@@ -76,11 +97,11 @@ class HATests(unittest.TestCase):
                               'res_test_haproxy': 'lsb:haproxy'}
         EXPECTED_RESOURCE_PARAMS = {
             'res_test_admin_hostname': ('params fqdn="test.admin.maas" '
-                                        'ip_address="10.0.0.1" '),
+                                        'ip_address="10.0.0.1"'),
             'res_test_int_hostname': ('params fqdn="test.internal.maas" '
-                                      'ip_address="10.0.0.1" '),
+                                      'ip_address="10.0.0.1"'),
             'res_test_public_hostname': ('params fqdn="test.public.maas" '
-                                         'ip_address="10.0.0.1" '),
+                                         'ip_address="10.0.0.1"'),
             'res_test_haproxy': 'op monitor interval="5s"'}
 
         self.conf = {
@@ -126,3 +147,146 @@ class HATests(unittest.TestCase):
         self.conf = {'vip': None,
                      'dns-ha': True}
         self.assertTrue(ha.expect_ha())
+
+    def test_update_hacluster_vip_single_vip(self):
+        self.get_hacluster_config.return_value = {
+            'vip': '10.5.100.1'
+        }
+        test_data = {'resources': {}, 'resource_params': {}}
+        expected = {
+            'groups': {
+                'grp_testservice_vips': 'res_testservice_eth1_vip'
+            },
+            'resource_params': {
+                'res_testservice_eth1_vip': ('params ip="10.5.100.1"'
+                                             ' cidr_netmask="255.255.255.0"'
+                                             ' nic="eth1"')
+            },
+            'resources': {
+                'res_testservice_eth1_vip': 'ocf:heartbeat:IPaddr2'
+            }
+        }
+        ha.update_hacluster_vip('testservice', test_data)
+        self.assertEqual(test_data, expected)
+
+    def test_update_hacluster_vip_multiple_vip(self):
+        self.get_hacluster_config.return_value = {
+            'vip': '10.5.100.1 ffff::1 ffaa::1'
+        }
+        test_data = {'resources': {}, 'resource_params': {}}
+        expected = {
+            'groups': {
+                'grp_testservice_vips': ('res_testservice_eth1_vip '
+                                         'res_testservice_eth1_vip_ipv6addr '
+                                         'res_testservice_eth2_vip')
+            },
+            'resource_params': {
+                'res_testservice_eth1_vip': ('params ip="10.5.100.1"'
+                                             ' cidr_netmask="255.255.255.0"'
+                                             ' nic="eth1"'),
+                'res_testservice_eth1_vip_ipv6addr': ('params ipv6addr="ffff::1"'
+                                                      ' cidr_netmask="64"'
+                                                      ' nic="eth1"'),
+                'res_testservice_eth2_vip': ('params ipv6addr="ffaa::1"'
+                                             ' cidr_netmask="32"'
+                                             ' nic="eth2"'),
+            },
+            'resources': {
+                'res_testservice_eth1_vip': 'ocf:heartbeat:IPaddr2',
+                'res_testservice_eth1_vip_ipv6addr': 'ocf:heartbeat:IPv6addr',
+                'res_testservice_eth2_vip': 'ocf:heartbeat:IPv6addr',
+            }
+        }
+        ha.update_hacluster_vip('testservice', test_data)
+        self.assertEqual(test_data, expected)
+
+    def test_generate_ha_relation_data(self):
+        self.get_hacluster_config.return_value = {
+            'vip': '10.5.100.1 ffff::1 ffaa::1'
+        }
+        expected = {
+            'groups': {
+                'grp_testservice_vips': ('res_testservice_eth1_vip '
+                                         'res_testservice_eth1_vip_ipv6addr '
+                                         'res_testservice_eth2_vip')
+            },
+            'resource_params': {
+                'res_testservice_eth1_vip': ('params ip="10.5.100.1"'
+                                             ' cidr_netmask="255.255.255.0"'
+                                             ' nic="eth1"'),
+                'res_testservice_eth1_vip_ipv6addr': ('params ipv6addr="ffff::1"'
+                                                      ' cidr_netmask="64"'
+                                                      ' nic="eth1"'),
+                'res_testservice_eth2_vip': ('params ipv6addr="ffaa::1"'
+                                             ' cidr_netmask="32"'
+                                             ' nic="eth2"'),
+                'res_testservice_haproxy': 'op monitor interval="5s"',
+            },
+            'resources': {
+                'res_testservice_eth1_vip': 'ocf:heartbeat:IPaddr2',
+                'res_testservice_eth1_vip_ipv6addr': 'ocf:heartbeat:IPv6addr',
+                'res_testservice_eth2_vip': 'ocf:heartbeat:IPv6addr',
+                'res_testservice_haproxy': 'lsb:haproxy',
+            },
+            'clones': {
+                'cl_testservice_haproxy': 'res_testservice_haproxy',
+            },
+            'init_services': {
+                'res_testservice_haproxy': 'haproxy'
+            },
+        }
+        expected = {
+            'json_{}'.format(k): json.dumps(v, **ha.JSON_ENCODE_OPTIONS)
+            for k, v in expected.items() if v
+        }
+        self.assertEqual(ha.generate_ha_relation_data('testservice'),
+                         expected)
+
+    @patch.object(ha, 'assert_charm_supports_dns_ha')
+    def test_generate_ha_relation_data_dns_ha(self,
+                                              assert_charm_supports_dns_ha):
+        self.get_hacluster_config.return_value = {
+            'vip': '10.5.100.1 ffff::1 ffaa::1'
+        }
+        self.conf = {
+            'os-admin-hostname': 'test.admin.maas',
+            'os-internal-hostname': 'test.internal.maas',
+            'os-public-hostname': 'test.public.maas',
+            'dns-ha': True,
+        }
+        self.resolve_address.return_value = '10.0.0.1'
+        assert_charm_supports_dns_ha.return_value = True
+        expected = {
+            'groups': {
+                'grp_testservice_hostnames': ('res_testservice_admin_hostname'
+                                              ' res_testservice_int_hostname'
+                                              ' res_testservice_public_hostname')
+            },
+            'resource_params': {
+                'res_testservice_admin_hostname': ('params fqdn="test.admin.maas"'
+                                                   ' ip_address="10.0.0.1"'),
+                'res_testservice_int_hostname': ('params fqdn="test.internal.maas"'
+                                                 ' ip_address="10.0.0.1"'),
+                'res_testservice_public_hostname': ('params fqdn="test.public.maas"'
+                                                    ' ip_address="10.0.0.1"'),
+                'res_testservice_haproxy': 'op monitor interval="5s"',
+            },
+            'resources': {
+                'res_testservice_admin_hostname': 'ocf:maas:dns',
+                'res_testservice_int_hostname': 'ocf:maas:dns',
+                'res_testservice_public_hostname': 'ocf:maas:dns',
+                'res_testservice_haproxy': 'lsb:haproxy',
+            },
+            'clones': {
+                'cl_testservice_haproxy': 'res_testservice_haproxy',
+            },
+            'init_services': {
+                'res_testservice_haproxy': 'haproxy'
+            },
+        }
+        expected = {
+            'json_{}'.format(k): json.dumps(v, **ha.JSON_ENCODE_OPTIONS)
+            for k, v in expected.items() if v
+        }
+        self.assertEqual(ha.generate_ha_relation_data('testservice'),
+                         expected)


### PR DESCRIPTION
Most OpenStack API charms that make use of the hacluster charm
follow the same model with regards to ha resource configuration.

Provide a helper function to support generic generation of the
data set used when charms are deployed in HA configurations with
the hacluster charm.