### PR TITLE
add extra-policy context and section

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1779,3 +1779,25 @@ class MemcacheContext(OSContextGenerator):
                     ctxt['memcache_server_formatted'],
                     ctxt['memcache_port'])
         return ctxt
+
+
+class ExtraPolicyContext(OSContextGenerator):
+    """A context to render extra policy for a service"""
+
+    def __init__(self, policyd):
+        """
+        @param policyd: an absolute path to a policy directory which is
+        configured in policy_dirs oslo.policy option.
+        """
+        self.policyd = policyd
+
+    def __call__(self):
+        # make it if it's not there
+        mkdir(self.policyd)
+
+        ctxt = {}
+        # if a charm uses this context it should define this config option
+        extra_policy = config('extra-policy')
+        # some oslo.policy versions error out if an empty file is used
+        ctxt['extra_policy'] = extra_policy if extra_policy else '{}'
+        return ctxt

--- a/charmhelpers/contrib/openstack/templates/section-extra-policy
+++ b/charmhelpers/contrib/openstack/templates/section-extra-policy
@@ -1,0 +1,1 @@
+{{ extra_policy }}


### PR DESCRIPTION
* Extra policy context is added to render service-specific policy
drop-in files (newer yaml or json format);
* section-extra-policy is trivial but is included in service-specific
policy-drop-in templates - this is mainly for naming policy files
differently to allow primary and subordinate charm policy files to
co-exist in a single directory without collisions;
* every classic charm to use this context will need to get extra-policy
config option;
* a policy directory is created if not present (policy.d is used by
default but it is intentionally passed as an __init__ argument to allow
potential overrides.

See pad.lv/1741723.