### PR TITLE
Drop OpenStack deploy-from-source helpers

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -97,8 +97,6 @@ from charmhelpers.contrib.network.ip import (
 from charmhelpers.contrib.openstack.utils import (
     config_flags_parser,
     get_host_ip,
-    git_determine_usr_bin,
-    git_determine_python_path,
     enable_memcache,
     snap_install_requested,
     CompareOpenStackReleases,
@@ -1385,8 +1383,6 @@ class WSGIWorkerConfigContext(WorkerConfigContext):
             "public_processes": int(math.ceil(self.public_process_weight *
                                               total_processes)),
             "threads": 1,
-            "usr_bin": git_determine_usr_bin(),
-            "python_path": git_determine_python_path(),
         }
         return ctxt
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -23,7 +23,6 @@ import sys
 import re
 import itertools
 import functools
-import shutil
 
 import six
 import traceback
@@ -47,7 +46,6 @@ from charmhelpers.core.hookenv import (
     related_units,
     relation_ids,
     relation_set,
-    service_name,
     status_set,
     hook_name,
     application_version_set,
@@ -68,11 +66,6 @@ from charmhelpers.contrib.network.ip import (
     port_has_listener,
 )
 
-from charmhelpers.contrib.python.packages import (
-    pip_create_virtualenv,
-    pip_install,
-)
-
 from charmhelpers.core.host import (
     lsb_release,
     mounts,
@@ -84,7 +77,6 @@ from charmhelpers.core.host import (
 )
 from charmhelpers.fetch import (
     apt_cache,
-    install_remote,
     import_key as fetch_import_key,
     add_source as fetch_add_source,
     SourceConfigError,
@@ -276,27 +268,6 @@ PACKAGE_CODENAMES = {
         ('13', 'queens'),
         ('14', 'rocky'),
     ]),
-}
-
-GIT_DEFAULT_REPOS = {
-    'requirements': 'git://github.com/openstack/requirements',
-    'cinder': 'git://github.com/openstack/cinder',
-    'glance': 'git://github.com/openstack/glance',
-    'horizon': 'git://github.com/openstack/horizon',
-    'keystone': 'git://github.com/openstack/keystone',
-    'networking-hyperv': 'git://github.com/openstack/networking-hyperv',
-    'neutron': 'git://github.com/openstack/neutron',
-    'neutron-fwaas': 'git://github.com/openstack/neutron-fwaas',
-    'neutron-lbaas': 'git://github.com/openstack/neutron-lbaas',
-    'neutron-vpnaas': 'git://github.com/openstack/neutron-vpnaas',
-    'nova': 'git://github.com/openstack/nova',
-}
-
-GIT_DEFAULT_BRANCHES = {
-    'liberty': 'stable/liberty',
-    'mitaka': 'stable/mitaka',
-    'newton': 'stable/newton',
-    'master': 'master',
 }
 
 DEFAULT_LOOPBACK_SIZE = '5G'
@@ -530,7 +501,6 @@ def os_release(package, base='essex', reset_cache=False):
     if _os_rel:
         return _os_rel
     _os_rel = (
-        git_os_codename_install_source(config('openstack-origin-git')) or
         get_os_codename_package(package, fatal=False) or
         get_os_codename_install_source(config('openstack-origin')) or
         base)
@@ -769,417 +739,6 @@ def os_requires_version(ostack_release, pkg):
             f(*args)
         return wrapped_f
     return wrap
-
-
-def git_install_requested():
-    """
-    Returns true if openstack-origin-git is specified.
-    """
-    return config('openstack-origin-git') is not None
-
-
-def git_os_codename_install_source(projects_yaml):
-    """
-    Returns OpenStack codename of release being installed from source.
-    """
-    if git_install_requested():
-        projects = _git_yaml_load(projects_yaml)
-
-        if projects in GIT_DEFAULT_BRANCHES.keys():
-            if projects == 'master':
-                return 'ocata'
-            return projects
-
-        if 'release' in projects:
-            if projects['release'] == 'master':
-                return 'ocata'
-            return projects['release']
-
-    return None
-
-
-def git_default_repos(projects_yaml):
-    """
-    Returns default repos if a default openstack-origin-git value is specified.
-    """
-    service = service_name()
-    core_project = service
-
-    for default, branch in six.iteritems(GIT_DEFAULT_BRANCHES):
-        if projects_yaml == default:
-
-            # add the requirements repo first
-            repo = {
-                'name': 'requirements',
-                'repository': GIT_DEFAULT_REPOS['requirements'],
-                'branch': branch,
-            }
-            repos = [repo]
-
-            # neutron-* and nova-* charms require some additional repos
-            if service in ['neutron-api', 'neutron-gateway',
-                           'neutron-openvswitch']:
-                core_project = 'neutron'
-                if service == 'neutron-api':
-                    repo = {
-                        'name': 'networking-hyperv',
-                        'repository': GIT_DEFAULT_REPOS['networking-hyperv'],
-                        'branch': branch,
-                    }
-                    repos.append(repo)
-                for project in ['neutron-fwaas', 'neutron-lbaas',
-                                'neutron-vpnaas', 'nova']:
-                    repo = {
-                        'name': project,
-                        'repository': GIT_DEFAULT_REPOS[project],
-                        'branch': branch,
-                    }
-                    repos.append(repo)
-
-            elif service in ['nova-cloud-controller', 'nova-compute']:
-                core_project = 'nova'
-                repo = {
-                    'name': 'neutron',
-                    'repository': GIT_DEFAULT_REPOS['neutron'],
-                    'branch': branch,
-                }
-                repos.append(repo)
-            elif service == 'openstack-dashboard':
-                core_project = 'horizon'
-
-            # finally add the current service's core project repo
-            repo = {
-                'name': core_project,
-                'repository': GIT_DEFAULT_REPOS[core_project],
-                'branch': branch,
-            }
-            repos.append(repo)
-
-            return yaml.dump(dict(repositories=repos, release=default))
-
-    return projects_yaml
-
-
-def _git_yaml_load(projects_yaml):
-    """
-    Load the specified yaml into a dictionary.
-    """
-    if not projects_yaml:
-        return None
-
-    return yaml.load(projects_yaml)
-
-
-requirements_dir = None
-
-
-def git_clone_and_install(projects_yaml, core_project):
-    """
-    Clone/install all specified OpenStack repositories.
-
-    The expected format of projects_yaml is:
-
-        repositories:
-          - {name: keystone,
-             repository: 'git://git.openstack.org/openstack/keystone.git',
-             branch: 'stable/icehouse'}
-          - {name: requirements,
-             repository: 'git://git.openstack.org/openstack/requirements.git',
-             branch: 'stable/icehouse'}
-
-        directory: /mnt/openstack-git
-        http_proxy: squid-proxy-url
-        https_proxy: squid-proxy-url
-
-    The directory, http_proxy, and https_proxy keys are optional.
-
-    """
-    global requirements_dir
-    parent_dir = '/mnt/openstack-git'
-    http_proxy = None
-
-    projects = _git_yaml_load(projects_yaml)
-    _git_validate_projects_yaml(projects, core_project)
-
-    old_environ = dict(os.environ)
-
-    if 'http_proxy' in projects.keys():
-        http_proxy = projects['http_proxy']
-        os.environ['http_proxy'] = projects['http_proxy']
-    if 'https_proxy' in projects.keys():
-        os.environ['https_proxy'] = projects['https_proxy']
-
-    if 'directory' in projects.keys():
-        parent_dir = projects['directory']
-
-    pip_create_virtualenv(os.path.join(parent_dir, 'venv'))
-
-    # Upgrade setuptools and pip from default virtualenv versions. The default
-    # versions in trusty break master OpenStack branch deployments.
-    for p in ['pip', 'setuptools']:
-        pip_install(p, upgrade=True, proxy=http_proxy,
-                    venv=os.path.join(parent_dir, 'venv'))
-
-    constraints = None
-    for p in projects['repositories']:
-        repo = p['repository']
-        branch = p['branch']
-        depth = '1'
-        if 'depth' in p.keys():
-            depth = p['depth']
-        if p['name'] == 'requirements':
-            repo_dir = _git_clone_and_install_single(repo, branch, depth,
-                                                     parent_dir, http_proxy,
-                                                     update_requirements=False)
-            requirements_dir = repo_dir
-            constraints = os.path.join(repo_dir, "upper-constraints.txt")
-            # upper-constraints didn't exist until after icehouse
-            if not os.path.isfile(constraints):
-                constraints = None
-            # use constraints unless project yaml sets use_constraints to false
-            if 'use_constraints' in projects.keys():
-                if not projects['use_constraints']:
-                    constraints = None
-        else:
-            repo_dir = _git_clone_and_install_single(repo, branch, depth,
-                                                     parent_dir, http_proxy,
-                                                     update_requirements=True,
-                                                     constraints=constraints)
-
-    os.environ = old_environ
-
-
-def _git_validate_projects_yaml(projects, core_project):
-    """
-    Validate the projects yaml.
-    """
-    _git_ensure_key_exists('repositories', projects)
-
-    for project in projects['repositories']:
-        _git_ensure_key_exists('name', project.keys())
-        _git_ensure_key_exists('repository', project.keys())
-        _git_ensure_key_exists('branch', project.keys())
-
-    if projects['repositories'][0]['name'] != 'requirements':
-        error_out('{} git repo must be specified first'.format('requirements'))
-
-    if projects['repositories'][-1]['name'] != core_project:
-        error_out('{} git repo must be specified last'.format(core_project))
-
-    _git_ensure_key_exists('release', projects)
-
-
-def _git_ensure_key_exists(key, keys):
-    """
-    Ensure that key exists in keys.
-    """
-    if key not in keys:
-        error_out('openstack-origin-git key \'{}\' is missing'.format(key))
-
-
-def _git_clone_and_install_single(repo, branch, depth, parent_dir, http_proxy,
-                                  update_requirements, constraints=None):
-    """
-    Clone and install a single git repository.
-    """
-    if not os.path.exists(parent_dir):
-        juju_log('Directory already exists at {}. '
-                 'No need to create directory.'.format(parent_dir))
-        os.mkdir(parent_dir)
-
-    juju_log('Cloning git repo: {}, branch: {}'.format(repo, branch))
-    repo_dir = install_remote(
-        repo, dest=parent_dir, branch=branch, depth=depth)
-
-    venv = os.path.join(parent_dir, 'venv')
-
-    if update_requirements:
-        if not requirements_dir:
-            error_out('requirements repo must be cloned before '
-                      'updating from global requirements.')
-        _git_update_requirements(venv, repo_dir, requirements_dir)
-
-    juju_log('Installing git repo from dir: {}'.format(repo_dir))
-    if http_proxy:
-        pip_install(repo_dir, proxy=http_proxy, venv=venv,
-                    constraints=constraints)
-    else:
-        pip_install(repo_dir, venv=venv, constraints=constraints)
-
-    return repo_dir
-
-
-def _git_update_requirements(venv, package_dir, reqs_dir):
-    """
-    Update from global requirements.
-
-    Update an OpenStack git directory's requirements.txt and
-    test-requirements.txt from global-requirements.txt.
-    """
-    orig_dir = os.getcwd()
-    os.chdir(reqs_dir)
-    python = os.path.join(venv, 'bin/python')
-    cmd = [python, 'update.py', package_dir]
-    try:
-        subprocess.check_call(cmd)
-    except subprocess.CalledProcessError:
-        package = os.path.basename(package_dir)
-        error_out("Error updating {} from "
-                  "global-requirements.txt".format(package))
-    os.chdir(orig_dir)
-
-
-def git_pip_venv_dir(projects_yaml):
-    """
-    Return the pip virtualenv path.
-    """
-    parent_dir = '/mnt/openstack-git'
-
-    projects = _git_yaml_load(projects_yaml)
-
-    if 'directory' in projects.keys():
-        parent_dir = projects['directory']
-
-    return os.path.join(parent_dir, 'venv')
-
-
-def git_src_dir(projects_yaml, project):
-    """
-    Return the directory where the specified project's source is located.
-    """
-    parent_dir = '/mnt/openstack-git'
-
-    projects = _git_yaml_load(projects_yaml)
-
-    if 'directory' in projects.keys():
-        parent_dir = projects['directory']
-
-    for p in projects['repositories']:
-        if p['name'] == project:
-            return os.path.join(parent_dir, os.path.basename(p['repository']))
-
-    return None
-
-
-def git_yaml_value(projects_yaml, key):
-    """
-    Return the value in projects_yaml for the specified key.
-    """
-    projects = _git_yaml_load(projects_yaml)
-
-    if key in projects.keys():
-        return projects[key]
-
-    return None
-
-
-def git_generate_systemd_init_files(templates_dir):
-    """
-    Generate systemd init files.
-
-    Generates and installs systemd init units and script files based on the
-    *.init.in files contained in the templates_dir directory.
-
-    This code is based on the openstack-pkg-tools package and its init
-    script generation, which is used by the OpenStack packages.
-    """
-    for f in os.listdir(templates_dir):
-        # Create the init script and systemd unit file from the template
-        if f.endswith(".init.in"):
-            init_in_file = f
-            init_file = f[:-8]
-            service_file = "{}.service".format(init_file)
-
-            init_in_source = os.path.join(templates_dir, init_in_file)
-            init_source = os.path.join(templates_dir, init_file)
-            service_source = os.path.join(templates_dir, service_file)
-
-            init_dest = os.path.join('/etc/init.d', init_file)
-            service_dest = os.path.join('/lib/systemd/system', service_file)
-
-            shutil.copyfile(init_in_source, init_source)
-            with open(init_source, 'a') as outfile:
-                template = ('/usr/share/openstack-pkg-tools/'
-                            'init-script-template')
-                with open(template) as infile:
-                    outfile.write('\n\n{}'.format(infile.read()))
-
-            cmd = ['pkgos-gen-systemd-unit', init_in_source]
-            subprocess.check_call(cmd)
-
-            if os.path.exists(init_dest):
-                os.remove(init_dest)
-            if os.path.exists(service_dest):
-                os.remove(service_dest)
-            shutil.copyfile(init_source, init_dest)
-            shutil.copyfile(service_source, service_dest)
-            os.chmod(init_dest, 0o755)
-
-    for f in os.listdir(templates_dir):
-        # If there's a service.in file, use it instead of the generated one
-        if f.endswith(".service.in"):
-            service_in_file = f
-            service_file = f[:-3]
-
-            service_in_source = os.path.join(templates_dir, service_in_file)
-            service_source = os.path.join(templates_dir, service_file)
-            service_dest = os.path.join('/lib/systemd/system', service_file)
-
-            shutil.copyfile(service_in_source, service_source)
-
-            if os.path.exists(service_dest):
-                os.remove(service_dest)
-            shutil.copyfile(service_source, service_dest)
-
-    for f in os.listdir(templates_dir):
-        # Generate the systemd unit if there's no existing .service.in
-        if f.endswith(".init.in"):
-            init_in_file = f
-            init_file = f[:-8]
-            service_in_file = "{}.service.in".format(init_file)
-            service_file = "{}.service".format(init_file)
-
-            init_in_source = os.path.join(templates_dir, init_in_file)
-            service_in_source = os.path.join(templates_dir, service_in_file)
-            service_source = os.path.join(templates_dir, service_file)
-            service_dest = os.path.join('/lib/systemd/system', service_file)
-
-            if not os.path.exists(service_in_source):
-                cmd = ['pkgos-gen-systemd-unit', init_in_source]
-                subprocess.check_call(cmd)
-
-                if os.path.exists(service_dest):
-                    os.remove(service_dest)
-                shutil.copyfile(service_source, service_dest)
-
-
-def git_determine_usr_bin():
-    """Return the /usr/bin path for Apache2 config.
-
-    The /usr/bin path will be located in the virtualenv if the charm
-    is configured to deploy from source.
-    """
-    if git_install_requested():
-        projects_yaml = config('openstack-origin-git')
-        projects_yaml = git_default_repos(projects_yaml)
-        return os.path.join(git_pip_venv_dir(projects_yaml), 'bin')
-    else:
-        return '/usr/bin'
-
-
-def git_determine_python_path():
-    """Return the python-path for Apache2 config.
-
-    Returns 'None' unless the charm is configured to deploy from source,
-    in which case the path of the virtualenv's site-packages is returned.
-    """
-    if git_install_requested():
-        projects_yaml = config('openstack-origin-git')
-        projects_yaml = git_default_repos(projects_yaml)
-        return os.path.join(git_pip_venv_dir(projects_yaml),
-                            'lib/python2.7/site-packages')
-    else:
-        return None
 
 
 def os_workload_status(configs, required_interfaces, charm_func=None):
@@ -1615,27 +1174,24 @@ def do_action_openstack_upgrade(package, upgrade_callback, configs):
     """
     ret = False
 
-    if git_install_requested():
-        action_set({'outcome': 'installed from source, skipped upgrade.'})
-    else:
-        if openstack_upgrade_available(package):
-            if config('action-managed-upgrade'):
-                juju_log('Upgrading OpenStack release')
+    if openstack_upgrade_available(package):
+        if config('action-managed-upgrade'):
+            juju_log('Upgrading OpenStack release')
 
-                try:
-                    upgrade_callback(configs=configs)
-                    action_set({'outcome': 'success, upgrade completed.'})
-                    ret = True
-                except Exception:
-                    action_set({'outcome': 'upgrade failed, see traceback.'})
-                    action_set({'traceback': traceback.format_exc()})
-                    action_fail('do_openstack_upgrade resulted in an '
-                                'unexpected error')
-            else:
-                action_set({'outcome': 'action-managed-upgrade config is '
-                                       'False, skipped upgrade.'})
+            try:
+                upgrade_callback(configs=configs)
+                action_set({'outcome': 'success, upgrade completed.'})
+                ret = True
+            except Exception:
+                action_set({'outcome': 'upgrade failed, see traceback.'})
+                action_set({'traceback': traceback.format_exc()})
+                action_fail('do_openstack_upgrade resulted in an '
+                            'unexpected error')
         else:
-            action_set({'outcome': 'no upgrade available.'})
+            action_set({'outcome': 'action-managed-upgrade config is '
+                                   'False, skipped upgrade.'})
+    else:
+        action_set({'outcome': 'no upgrade available.'})
 
     return ret
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -111,17 +111,6 @@ UCA_SOURCES = [
     ('cloud:precise-icehouse/updates', url + ' precise-updates/icehouse main'),
 ]
 
-openstack_origin_git = """
-  release: master
-  repositories:
-    - {name: requirements,
-       repository: 'git://git.openstack.org/openstack/requirements',
-       branch: master}
-    - {name: keystone,
-       repository: 'git://git.openstack.org/openstack/keystone',
-       branch: master}
-"""
-
 # Mock python-dnspython resolver used by get_host_ip()
 
 
@@ -425,16 +414,10 @@ class OpenStackHelpersTestCase(TestCase):
             )
 
     @patch.object(openstack, 'get_os_codename_package')
-    @patch.object(openstack, 'git_os_codename_install_source')
     @patch('charmhelpers.contrib.openstack.utils.config')
-    def test_os_release_uncached(self, config, git_cn, get_cn):
+    def test_os_release_uncached(self, config, get_cn):
         openstack._os_rel = None
         get_cn.return_value = 'folsom'
-        git_cn.return_value = None
-
-        # openstack-origin-git=None
-        config.side_effect = [None]
-
         self.assertEquals('folsom', openstack.os_release('nova-common'))
 
     def test_os_release_cached(self):
@@ -794,256 +777,6 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.get_matchmaker_map(),
             {}
         )
-
-    @patch.object(openstack, 'config')
-    def test_git_install_requested_none(self, config):
-        config.return_value = None
-        result = openstack.git_install_requested()
-        self.assertEquals(result, False)
-
-    @patch.object(openstack, 'config')
-    def test_git_install_requested_not_none(self, config):
-        config.return_value = openstack_origin_git
-        result = openstack.git_install_requested()
-        self.assertEquals(result, True)
-
-    def _test_key_error(self, os_origin_git, key, error_out):
-        try:
-            openstack.git_clone_and_install(os_origin_git, 'keystone')
-        except KeyError:
-            # KeyError expected because _git_ensure_key_exists() doesn't exit
-            # when mocked.
-            pass
-        error_out.assert_called_with(
-            'openstack-origin-git key \'%s\' is missing' % key)
-
-    @patch('os.path.isfile')
-    @patch('os.path.join')
-    @patch.object(openstack, 'error_out')
-    @patch.object(openstack, '_git_clone_and_install_single')
-    @patch.object(openstack, 'pip_install')
-    @patch.object(openstack, 'pip_create_virtualenv')
-    def test_git_clone_and_install_errors(self, pip_venv, pip_install,
-                                          git_install_single, error_out, join,
-                                          isfile):
-        isfile.return_value = True
-        git_missing_repos = """
-          repostories:
-             - {name: requirements,
-                repository: 'git://git.openstack.org/openstack/requirements',
-                branch: master}
-             - {name: keystone,
-                repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-          release: master"""
-        self._test_key_error(git_missing_repos, 'repositories', error_out)
-
-        git_missing_name = """
-          repositories:
-             - {name: requirements,
-                repository: 'git://git.openstack.org/openstack/requirements',
-                branch: master}
-             - {repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-          release: master"""
-        self._test_key_error(git_missing_name, 'name', error_out)
-
-        git_missing_repo = """
-          repositories:
-             - {name: requirements,
-                repoistroy: 'git://git.openstack.org/openstack/requirements',
-                branch: master}
-             - {name: keystone,
-                repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-          release: master"""
-        self._test_key_error(git_missing_repo, 'repository', error_out)
-
-        git_missing_branch = """
-          repositories:
-             - {name: requirements,
-                repository: 'git://git.openstack.org/openstack/requirements'}
-             - {name: keystone,
-                repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-          release: master"""
-        self._test_key_error(git_missing_branch, 'branch', error_out)
-
-        git_wrong_order_1 = """
-          repositories:
-             - {name: keystone,
-                repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-             - {name: requirements,
-                repository: 'git://git.openstack.org/openstack/requirements',
-                branch: master}
-          release: master"""
-        openstack.git_clone_and_install(git_wrong_order_1, 'keystone')
-        error_out.assert_called_with(
-            'keystone git repo must be specified last')
-
-        git_wrong_order_2 = """
-          repositories:
-             - {name: keystone,
-                repository: 'git://git.openstack.org/openstack/keystone',
-                branch: master}
-          release: master"""
-        openstack.git_clone_and_install(git_wrong_order_2, 'keystone')
-        error_out.assert_called_with(
-            'requirements git repo must be specified first')
-
-    @patch('os.path.join')
-    @patch.object(openstack, 'charm_dir')
-    @patch.object(openstack, 'error_out')
-    @patch.object(openstack, '_git_clone_and_install_single')
-    @patch.object(openstack, 'pip_install')
-    @patch.object(openstack, 'pip_create_virtualenv')
-    def test_git_clone_and_install_success(self, pip_venv, pip_install,
-                                           _git_install_single, error_out,
-                                           charm_dir, join):
-        proj = 'keystone'
-        charm_dir.return_value = '/var/lib/juju/units/testing-foo-0/charm'
-        # the following sets the global requirements_dir
-        _git_install_single.return_value = '/mnt/openstack-git/requirements'
-        join.return_value = 'joined-path'
-
-        openstack.git_clone_and_install(openstack_origin_git, proj)
-        self.assertTrue(pip_venv.called)
-        pip_install.assert_called_with('setuptools', upgrade=True,
-                                       proxy=None,
-                                       venv='joined-path')
-        self.assertTrue(_git_install_single.call_count == 2)
-        expected = [
-            call('git://git.openstack.org/openstack/requirements',
-                 'master', '1', '/mnt/openstack-git', None,
-                 update_requirements=False),
-            call('git://git.openstack.org/openstack/keystone',
-                 'master', '1', '/mnt/openstack-git', None,
-                 update_requirements=True, constraints=None)
-        ]
-        self.assertEquals(expected, _git_install_single.call_args_list)
-        assert not error_out.called
-
-    @patch('os.path.join')
-    @patch('os.mkdir')
-    @patch('os.path.exists')
-    @patch.object(openstack, 'juju_log')
-    @patch.object(openstack, 'install_remote')
-    @patch.object(openstack, 'pip_install')
-    @patch.object(openstack, '_git_update_requirements')
-    def test_git_clone_and_install_single(self, _git_update_reqs, pip_install,
-                                          install_remote, log, path_exists,
-                                          mkdir, join):
-        repo = 'git://git.openstack.org/openstack/requirements.git'
-        branch = 'master'
-        depth = 1
-        parent_dir = '/mnt/openstack-git/'
-        http_proxy = 'http://squid-proxy-url'
-        dest_dir = '/mnt/openstack-git'
-        join.return_value = dest_dir
-        path_exists.return_value = False
-        install_remote.return_value = dest_dir
-
-        openstack._git_clone_and_install_single(
-            repo, branch, depth, parent_dir, http_proxy, False)
-        mkdir.assert_called_with(parent_dir)
-        install_remote.assert_called_with(repo, dest=parent_dir, depth=1,
-                                          branch=branch)
-        assert not _git_update_reqs.called
-        pip_install.assert_called_with(dest_dir, venv='/mnt/openstack-git',
-                                       proxy='http://squid-proxy-url',
-                                       constraints=None)
-
-    @patch('os.path.join')
-    @patch('os.mkdir')
-    @patch('os.path.exists')
-    @patch.object(openstack, 'juju_log')
-    @patch.object(openstack, 'install_remote')
-    @patch.object(openstack, 'pip_install')
-    @patch.object(openstack, '_git_update_requirements')
-    def test_git_clone_and_install_single_with_update(
-            self, _git_update_reqs, pip_install, install_remote, log,
-            path_exists, mkdir, join):
-        repo = 'git://git.openstack.org/openstack/requirements.git'
-        branch = 'master'
-        depth = 1
-        parent_dir = '/mnt/openstack-git/'
-        http_proxy = 'http://squid-proxy-url'
-        dest_dir = '/mnt/openstack-git'
-        venv_dir = '/mnt/openstack-git'
-        reqs_dir = '/mnt/openstack-git/requirements-dir'
-        join.return_value = dest_dir
-        openstack.requirements_dir = reqs_dir
-        path_exists.return_value = False
-        install_remote.return_value = dest_dir
-
-        openstack._git_clone_and_install_single(
-            repo, branch, depth, parent_dir, http_proxy, True)
-        mkdir.assert_called_with(parent_dir)
-        install_remote.assert_called_with(repo, dest=parent_dir, depth=1,
-                                          branch=branch)
-        _git_update_reqs.assert_called_with(venv_dir, dest_dir, reqs_dir)
-        pip_install.assert_called_with(dest_dir, venv='/mnt/openstack-git',
-                                       proxy='http://squid-proxy-url',
-                                       constraints=None)
-
-    @patch('os.path.join')
-    @patch('os.getcwd')
-    @patch('os.chdir')
-    @patch('subprocess.check_call')
-    def test_git_update_requirements(self, check_call, chdir, getcwd, join):
-        pkg_dir = '/mnt/openstack-git/repo-dir'
-        reqs_dir = '/mnt/openstack-git/reqs-dir'
-        orig_dir = '/var/lib/juju/units/testing-foo-0/charm'
-        venv_dir = '/mnt/openstack-git/venv'
-        getcwd.return_value = orig_dir
-        join.return_value = '/mnt/openstack-git/venv/python'
-
-        openstack._git_update_requirements(venv_dir, pkg_dir, reqs_dir)
-        expected = [call(reqs_dir), call(orig_dir)]
-        self.assertEquals(expected, chdir.call_args_list)
-        check_call.assert_called_with(['/mnt/openstack-git/venv/python',
-                                      'update.py', pkg_dir])
-
-    @patch('os.path.join')
-    @patch('subprocess.check_call')
-    def test_git_src_dir(self, check_call, join):
-        openstack.git_src_dir(openstack_origin_git, 'keystone')
-        join.assert_called_with('/mnt/openstack-git', 'keystone')
-
-    @patch.object(openstack, 'config')
-    def test_git_determine_usr_bin(self, config):
-        config.return_value = None
-        result = openstack.git_determine_usr_bin()
-        self.assertEquals(result, '/usr/bin')
-
-    @patch('os.path.join')
-    @patch.object(openstack, 'git_default_repos')
-    @patch.object(openstack, 'config')
-    def test_git_determine_usr_bin_git(self, config, git_default, join):
-        venv_bin = '/mnt/openstack/.venv/bin'
-        join.return_value = venv_bin
-        config.return_value = openstack_origin_git
-        git_default.return_value = openstack_origin_git
-        result = openstack.git_determine_usr_bin()
-        self.assertEquals(result, venv_bin)
-
-    @patch.object(openstack, 'config')
-    def test_git_determine_python_path(self, config):
-        config.return_value = None
-        result = openstack.git_determine_python_path()
-        self.assertEquals(result, None)
-
-    @patch('os.path.join')
-    @patch.object(openstack, 'git_default_repos')
-    @patch.object(openstack, 'config')
-    def test_git_determine_python_path_git(self, config, git_default, join):
-        venv_site = '/mnt/openstack/.venv/lib/python2.7/site-packages'
-        join.return_value = venv_site
-        config.return_value = openstack_origin_git
-        git_default.return_value = openstack_origin_git
-        result = openstack.git_determine_python_path()
-        self.assertEquals(result, venv_site)
 
     def test_incomplete_relation_data(self):
         configs = MagicMock()
@@ -1787,8 +1520,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         openstack_upgrade_available.return_value = True
 
-        # openstack-origin-git=None, action-managed-upgrade=True
-        config.side_effect = [None, True]
+        # action-managed-upgrade=True
+        config.side_effect = [True]
 
         openstack.do_action_openstack_upgrade('package-xyz',
                                               do_openstack_upgrade,
@@ -1804,30 +1537,6 @@ class OpenStackHelpersTestCase(TestCase):
     @patch.object(openstack, 'action_fail')
     @patch.object(openstack, 'openstack_upgrade_available')
     @patch('charmhelpers.contrib.openstack.utils.config')
-    def test_openstack_upgrade_git(self, config, openstack_upgrade_available,
-                                   action_fail, action_set, log):
-        def do_openstack_upgrade(configs):
-            pass
-
-        openstack_upgrade_available.return_value = True
-
-        # openstack-origin-git=xyz
-        config.side_effect = ['openstack-origin-git: xyz']
-
-        openstack.do_action_openstack_upgrade('package-xyz',
-                                              do_openstack_upgrade,
-                                              None)
-
-        self.assertFalse(openstack_upgrade_available.called)
-        msg = ('installed from source, skipped upgrade.')
-        action_set.assert_called_with({'outcome': msg})
-        self.assertFalse(action_fail.called)
-
-    @patch.object(openstack, 'juju_log')
-    @patch.object(openstack, 'action_set')
-    @patch.object(openstack, 'action_fail')
-    @patch.object(openstack, 'openstack_upgrade_available')
-    @patch('charmhelpers.contrib.openstack.utils.config')
     def test_openstack_upgrade_not_avail(self, config,
                                          openstack_upgrade_available,
                                          action_fail, action_set, log):
@@ -1835,9 +1544,6 @@ class OpenStackHelpersTestCase(TestCase):
             pass
 
         openstack_upgrade_available.return_value = False
-
-        # openstack-origin-git=None
-        config.side_effect = [None]
 
         openstack.do_action_openstack_upgrade('package-xyz',
                                               do_openstack_upgrade,
@@ -1861,8 +1567,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         openstack_upgrade_available.return_value = True
 
-        # openstack-origin-git=None, action-managed-upgrade=False
-        config.side_effect = [None, False]
+        # action-managed-upgrade=False
+        config.side_effect = [False]
 
         openstack.do_action_openstack_upgrade('package-xyz',
                                               do_openstack_upgrade,
@@ -1887,8 +1593,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         openstack_upgrade_available.return_value = True
 
-        # openstack-origin-git=None, action-managed-upgrade=False
-        config.side_effect = [None, True]
+        # action-managed-upgrade=False
+        config.side_effect = [True]
 
         openstack.do_action_openstack_upgrade('package-xyz',
                                               do_openstack_upgrade,

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2653,14 +2653,9 @@ class ContextTests(unittest.TestCase):
         self.assertEquals(result, expected)
 
     @patch.object(context, '_calculate_workers')
-    @patch.object(context, 'git_determine_python_path')
-    @patch.object(context, 'git_determine_usr_bin')
-    def test_wsgi_worker_config_context(self, usr_bin, python_path,
+    def test_wsgi_worker_config_context(self,
                                         _calculate_workers):
         self.config.return_value = 2  # worker-multiplier=2
-        usr_bin_path = '/usr/bin'
-        usr_bin.return_value = usr_bin_path
-        python_path.return_value = None
         _calculate_workers.return_value = 8
         service_name = 'service-name'
         script = '/usr/bin/script'
@@ -2677,8 +2672,6 @@ class ContextTests(unittest.TestCase):
             "admin_processes": 2,
             "public_processes": 6,
             "threads": 1,
-            "usr_bin": usr_bin_path,
-            "python_path": None,
         }
         self.assertEqual(expect, ctxt())
 

--- a/tests/contrib/openstack/test_os_utils.py
+++ b/tests/contrib/openstack/test_os_utils.py
@@ -123,48 +123,37 @@ class UtilsTests(unittest.TestCase):
         )
 
     @mock.patch.object(utils, 'config')
-    @mock.patch('charmhelpers.contrib.openstack.utils.'
-                'git_os_codename_install_source')
     @mock.patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
     @mock.patch('charmhelpers.contrib.openstack.utils.'
                 'get_os_codename_install_source')
     def test_os_release(self, mock_get_os_codename_install_source,
                         mock_get_os_codename_package,
-                        mock_git_os_codename_install_source,
                         mock_config):
         # Wipe the modules cached os_rel
         utils._os_rel = None
         mock_get_os_codename_install_source.return_value = None
         mock_get_os_codename_package.return_value = None
-        mock_git_os_codename_install_source.return_value = None
         mock_config.return_value = 'cloud-pocket'
         self.assertEqual(utils.os_release('my-pkg'), 'essex')
         mock_get_os_codename_install_source.assert_called_once_with(
             'cloud-pocket')
         mock_get_os_codename_package.assert_called_once_with(
             'my-pkg', fatal=False)
-        mock_git_os_codename_install_source.assert_called_once_with(
-            'cloud-pocket')
         # Next call to os_release should pickup cached version
         mock_get_os_codename_install_source.reset_mock()
         mock_get_os_codename_package.reset_mock()
-        mock_git_os_codename_install_source.reset_mock()
         self.assertEqual(utils.os_release('my-pkg'), 'essex')
         self.assertFalse(mock_get_os_codename_install_source.called)
         self.assertFalse(mock_get_os_codename_package.called)
-        self.assertFalse(mock_git_os_codename_install_source.called)
         # Call os_release and bypass cache
         mock_get_os_codename_install_source.reset_mock()
         mock_get_os_codename_package.reset_mock()
-        mock_git_os_codename_install_source.reset_mock()
         self.assertEqual(utils.os_release('my-pkg', reset_cache=True),
                          'essex')
         mock_get_os_codename_install_source.assert_called_once_with(
             'cloud-pocket')
         mock_get_os_codename_package.assert_called_once_with(
             'my-pkg', fatal=False)
-        mock_git_os_codename_install_source.assert_called_once_with(
-            'cloud-pocket')
 
     @mock.patch.object(utils, 'os_release')
     @mock.patch.object(utils, 'get_os_codename_install_source')


### PR DESCRIPTION
DFS has gradually bitrotted since is was originally written; inline
with agreed deprecation a few cycles back, drop deploy from source
helpers in preparation for remove from OpenStack charms.