### PR TITLE
dfs: drop venv specific parts from wsgi template

### DIFF
--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -15,9 +15,6 @@ Listen {{ public_port }}
 {% if port -%}
 <VirtualHost *:{{ port }}>
     WSGIDaemonProcess {{ service_name }} processes={{ processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
-{% if python_path -%}
-                      python-path={{ python_path }} \
-{% endif -%}
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}
     WSGIScriptAlias / {{ script }}
@@ -29,7 +26,7 @@ Listen {{ public_port }}
     ErrorLog /var/log/apache2/{{ service_name }}_error.log
     CustomLog /var/log/apache2/{{ service_name }}_access.log combined
 
-    <Directory {{ usr_bin }}>
+    <Directory /usr/bin>
         <IfVersion >= 2.4>
             Require all granted
         </IfVersion>
@@ -44,9 +41,6 @@ Listen {{ public_port }}
 {% if admin_port -%}
 <VirtualHost *:{{ admin_port }}>
     WSGIDaemonProcess {{ service_name }}-admin processes={{ admin_processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
-{% if python_path -%}
-                      python-path={{ python_path }} \
-{% endif -%}
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}-admin
     WSGIScriptAlias / {{ admin_script }}
@@ -58,7 +52,7 @@ Listen {{ public_port }}
     ErrorLog /var/log/apache2/{{ service_name }}_error.log
     CustomLog /var/log/apache2/{{ service_name }}_access.log combined
 
-    <Directory {{ usr_bin }}>
+    <Directory /usr/bin>
         <IfVersion >= 2.4>
             Require all granted
         </IfVersion>
@@ -73,9 +67,6 @@ Listen {{ public_port }}
 {% if public_port -%}
 <VirtualHost *:{{ public_port }}>
     WSGIDaemonProcess {{ service_name }}-public processes={{ public_processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
-{% if python_path -%}
-                      python-path={{ python_path }} \
-{% endif -%}
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}-public
     WSGIScriptAlias / {{ public_script }}
@@ -87,7 +78,7 @@ Listen {{ public_port }}
     ErrorLog /var/log/apache2/{{ service_name }}_error.log
     CustomLog /var/log/apache2/{{ service_name }}_access.log combined
 
-    <Directory {{ usr_bin }}>
+    <Directory /usr/bin>
         <IfVersion >= 2.4>
             Require all granted
         </IfVersion>


### PR DESCRIPTION
Drop /usr/bin and python path template values from wsgi template
for OpenStack API services; this is only required for deploy
from source which has been removed from the charms and charmhelpers.