### PR TITLE
Fix regression in NRPE haproxy check

### DIFF
--- a/charmhelpers/contrib/openstack/files/check_haproxy.sh
+++ b/charmhelpers/contrib/openstack/files/check_haproxy.sh
@@ -9,7 +9,7 @@
 CRITICAL=0
 NOTACTIVE=''
 LOGFILE=/var/log/nagios/check_haproxy.log
-AUTH=$(grep -r "stats auth" /etc/haproxy/haproxy.cfg | awk 'NR=1{print $4}')
+AUTH=$(grep -r "stats auth" /etc/haproxy/haproxy.cfg | awk 'NR=1{print $3}')
 
 typeset -i N_INSTANCES=0
 for appserver in $(awk '/^\s+server/{print $2}' /etc/haproxy/haproxy.cfg)

--- a/charmhelpers/contrib/openstack/files/check_haproxy_queue_depth.sh
+++ b/charmhelpers/contrib/openstack/files/check_haproxy_queue_depth.sh
@@ -10,7 +10,7 @@
 CURRQthrsh=0
 MAXQthrsh=100
 
-AUTH=$(grep -r "stats auth" /etc/haproxy | head -1 | awk '{print $4}')
+AUTH=$(grep -r "stats auth" /etc/haproxy/haproxy.cfg | awk 'NR=1{print $3}')
 
 HAPROXYSTATS=$(/usr/lib/nagios/plugins/check_http -a ${AUTH} -I 127.0.0.1 -p 8888 -u '/;csv' -v)
 


### PR DESCRIPTION
These changes fix a regression in the haproxy NRPE checks when
gathering credentials for querying the admin haproxy endpoint,
to determine haproxy backend server health via the admin API.