### PR TITLE
Handle no network binding exception gracefully

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -27,6 +27,7 @@ from charmhelpers.core.hookenv import (
     network_get_primary_address,
     unit_get,
     WARNING,
+    NoNetworkBinding,
 )
 
 from charmhelpers.core.host import (
@@ -577,6 +578,9 @@ def get_relation_ip(interface, cidr_network=None):
         address = network_get_primary_address(interface)
     except NotImplementedError:
         # If network-get is not available
+        address = get_host_ip(unit_get('private-address'))
+    except NoNetworkBinding:
+        log("No network binding for {}".format(interface), WARNING)
         address = get_host_ip(unit_get('private-address'))
 
     if config('prefer-ipv6'):

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -821,6 +821,9 @@ class IPTest(unittest.TestCase):
         network_get_primary_address.side_effect = NotImplementedError
         self.assertEqual(DEFAULT_IP, net_ip.get_relation_ip('amqp'))
 
+        network_get_primary_address.side_effect = net_ip.NoNetworkBinding
+        self.assertEqual(DEFAULT_IP, net_ip.get_relation_ip('doesnotexist'))
+
         network_get_primary_address.side_effect = None
         self.assertEqual(AMQP_IP, net_ip.get_relation_ip('amqp'))
 

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1685,8 +1685,8 @@ class HooksTest(TestCase):
     def test_network_get_primary_no_binding_found(self, check_output):
         """Ensure that NotImplementedError when no binding is found"""
         check_output.side_effect = CalledProcessError(
-                1, 'network-get',
-                output='no network config found for binding'.encode('UTF-8'))
+            1, 'network-get',
+            output='no network config found for binding'.encode('UTF-8'))
         self.assertRaises(hookenv.NoNetworkBinding,
                           hookenv.network_get_primary_address,
                           'doesnotexist')
@@ -1698,8 +1698,8 @@ class HooksTest(TestCase):
         """Ensure that CalledProcessError still thrown when not
         a missing binding"""
         check_output.side_effect = CalledProcessError(
-                1, 'network-get',
-                output='any other message'.encode('UTF-8'))
+            1, 'network-get',
+            output='any other message'.encode('UTF-8'))
         self.assertRaises(CalledProcessError,
                           hookenv.network_get_primary_address,
                           'mybinding')


### PR DESCRIPTION
When network_get_primary_address is called with a binding name that
does not exist a subprocess.CalledProcessError is thrown.

There are times when get_relation_ip will be called with a binding that
may or may not exist. It would be better if this exception is handled
gracefully.

An example is the HAProxyContext in openstack-dahsboard. The dashboard
charm does not have the typical extra bindings: admin, internal, public.
Rather than make this an exception, make get_relation_ip handle a
non-existent binding gracefully.

This change updates network_get_primary_address to throw a
NoNetworkBinding exception when a binding does not exist.
get_relation_ip will then handle this exception by using the default
address.