### PR TITLE
add string template rendering to core/templating

### DIFF
--- a/tests/core/test_templating.py
+++ b/tests/core/test_templating.py
@@ -61,6 +61,28 @@ class TestTemplating(unittest.TestCase):
     @mock.patch.object(templating.host.os, 'fchown')
     @mock.patch.object(templating.host, 'mkdir')
     @mock.patch.object(templating.host, 'log')
+    def test_render_from_string(self, log, mkdir, fchown):
+        with tempfile.NamedTemporaryFile() as fn:
+            context = {
+                'foo': 'bar'
+            }
+
+            config_template = '{{ foo }}'
+            templating.render('somefile.txt', fn.name,
+                              context, templates_dir=TEMPLATES_DIR,
+                              config_template=config_template)
+            contents = open(fn.name).read()
+            self.assertRegexpMatches(contents, 'bar')
+
+            self.assertEqual(fchown.call_count, 1)
+            # Not called, because the target directory exists. Calling
+            # it would make the target directory world readable and
+            # expose your secrets (!).
+            self.assertEqual(mkdir.call_count, 0)
+
+    @mock.patch.object(templating.host.os, 'fchown')
+    @mock.patch.object(templating.host, 'mkdir')
+    @mock.patch.object(templating.host, 'log')
     def test_render_loader(self, log, mkdir, fchown):
         with tempfile.NamedTemporaryFile() as fn1:
             context = {


### PR DESCRIPTION
Another change to allow rendering a template from a specified string but
now to core/templating.py which is used by all reactive OpenStack
charms.

This change is required to allow a charm writer to support specifying
config template parts in config options or render config files based on
templates passed via relation data from other charms.

The main use-case is drop-in files which contain custom logic not
possible to predict or model in the charm code by providing relevant
config options.

For example, RBAC rules are subjective and some operators have
to implement policy based on those subjective rules which may
differ from defaults. If those rules cannot be provided via an API
to a given service and are stored in config files this is the only way
to provide desired customization options.

Related to pad.lv/1741723
In addition to https://github.com/juju/charm-helpers/pull/87 but for
reactive charms which mainly use this render function.