### PR TITLE
Restart apache2 on SSL certificate change

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -62,6 +62,7 @@ from charmhelpers.core.host import (
     lsb_release,
     CompareHostReleases,
     is_container,
+    service_reload,
 )
 from charmhelpers.contrib.hahelpers.cluster import (
     determine_apache_port,
@@ -799,6 +800,8 @@ class ApacheSSLContext(OSContextGenerator):
                    content=b64decode(cert))
         write_file(path=os.path.join(ssl_dir, key_filename),
                    content=b64decode(key))
+
+        service_reload('apache2')
 
     def configure_ca(self):
         ca_cert = get_ca_cert()


### PR DESCRIPTION
This patchset implements a logic to restart apache2 on SSL
certificate change.

Closes-Bug: #1745985