### PR TITLE
Use volumev3 for Openstack >= Pike (#65) (#66)

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -101,6 +101,8 @@ from charmhelpers.contrib.openstack.utils import (
     git_determine_python_path,
     enable_memcache,
     snap_install_requested,
+    CompareOpenStackReleases,
+    os_release,
 )
 from charmhelpers.core.unitdata import kv
 
@@ -1577,8 +1579,18 @@ class InternalEndpointContext(OSContextGenerator):
     endpoints by default so this allows admins to optionally use internal
     endpoints.
     """
+    def __init__(self, ost_rel_check_pkg_name):
+        self.ost_rel_check_pkg_name = ost_rel_check_pkg_name
+
     def __call__(self):
-        return {'use_internal_endpoints': config('use-internal-endpoints')}
+        ctxt = {'use_internal_endpoints': config('use-internal-endpoints')}
+        rel = os_release(self.ost_rel_check_pkg_name, base='icehouse')
+        if CompareOpenStackReleases(rel) >= 'pike':
+            ctxt['volume_api_version'] = '3'
+        else:
+            ctxt['volume_api_version'] = '2'
+
+        return ctxt
 
 
 class AppArmorContext(OSContextGenerator):

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3273,14 +3273,20 @@ class ContextTests(unittest.TestCase):
         self.relation_get.side_effect = relation.get
         self.assertEquals(context.NetworkServiceContext()(), data_result)
 
-    def test_internal_endpoint_context(self):
+    @patch.object(context, 'os_release')
+    def test_internal_endpoint_context(self, mock_os_release):
+        mock_os_release.return_value = 'ocata'
         config = {'use-internal-endpoints': False}
         self.config.side_effect = fake_config(config)
-        ctxt = context.InternalEndpointContext()
-        self.assertFalse(ctxt()['use_internal_endpoints'])
-        config = {'use-internal-endpoints': True}
-        self.config.side_effect = fake_config(config)
-        self.assertTrue(ctxt()['use_internal_endpoints'])
+        ctxt = context.InternalEndpointContext('cinder-common')
+        c = ctxt()
+        self.assertFalse(c['use_internal_endpoints'])
+        self.assertEqual(c['volume_api_version'], '2')
+        mock_os_release.return_value = 'pike'
+        config['use-internal-endpoints'] = True
+        c = ctxt()
+        self.assertTrue(c['use_internal_endpoints'])
+        self.assertEqual(c['volume_api_version'], '3')
 
     def test_apparmor_context_call_not_valid(self):
         ''' Tests for the apparmor context'''


### PR DESCRIPTION
The InternalEndpointContext() should select volume
api version based on which version of Openstack is
used.

(cherry picked from commit 3aa436da7151770e104df7d2ff013fbca3cb4367)