### PR TITLE
Fix network get

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1205,9 +1205,23 @@ def iter_units_for_relation_name(relation_name):
 
 def ingress_address(rid=None, unit=None):
     """
-    Retrieve the ingress-address from a relation when available. Otherwise,
-    return the private-address. This function is to be used on the consuming
-    side of the relation.
+    Retrieve the ingress-address from a relation when available.
+    Otherwise, return the private-address.
+
+    When used on the consuming side of the relation (unit is a remote
+    unit), the ingress-address is the IP address that this unit needs
+    to use to reach the provided service on the remote unit.
+
+    When used on the providing side of the relation (unit == local_unit()),
+    the ingress-address is the IP address that is advertised to remote
+    units on this relation. Remote units need to use this address to
+    reach the local provided service on this unit.
+
+    Note that charms may document some other method to use in
+    preference to the ingress_address(), such as an address provided
+    on a different relation attribute or a service discovery mechanism.
+    This allows charms to redirect inbound connections to their peers
+    or different applications such as load balancers.
 
     Usage:
     addresses = [ingress_address(rid=u.rid, unit=u.unit)
@@ -1225,9 +1239,12 @@ def ingress_address(rid=None, unit=None):
 
 def egress_subnets(rid=None, unit=None):
     """
-    Retrieve the egress-subnets from a relation. This function is to
-    be used on the providing sude of the relation, and provides the
-    ranges of addresses that client connections may come from.
+    Retrieve the egress-subnets from a relation.
+
+    This function is to be used on the providing side of the
+    relation, and provides the ranges of addresses that client
+    connections may come from. The result is uninteresting on
+    the consuming side of a relation (unit == local_unit()).
 
     Returns a stable list of subnets in CIDR format.
     eg. ['192.168.1.0/24', '2001::F00F/128']

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1241,7 +1241,7 @@ def egress_subnets(rid=None, unit=None):
     :return: list of subnets in CIDR format. eg. ['192.168.1.0/24', '2001::F00F/128']
     """
     def _to_range(addr):
-        if re.search(r'^(?:\d{1,3}\.){3}\d{1,3}$', addr, re.A) is not None:
+        if re.search(r'^(?:\d{1,3}\.){3}\d{1,3}$', addr) is not None:
             addr += '/32'
         elif ':' in addr and '/' not in addr:  # IPv6
             addr += '/128'

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1484,9 +1484,10 @@ class HooksTest(TestCase):
 
         juju_version.return_value = '1.24-beta5.1-trusty-amd64'
         self.assertTrue(hookenv.has_juju_version('1.23'))
-        self.assertFalse(hookenv.has_juju_version('1.24'))
+        self.assertTrue(hookenv.has_juju_version('1.24'))  # Better if this was false!
         self.assertTrue(hookenv.has_juju_version('1.24-beta5'))
         self.assertTrue(hookenv.has_juju_version('1.24-beta5.1'))
+        self.assertFalse(hookenv.has_juju_version('1.25'))
         self.assertTrue(hookenv.has_juju_version('1.18-backport6'))
 
     @patch.object(hookenv, 'relation_to_role_and_interface')
@@ -1704,34 +1705,45 @@ class HooksTest(TestCase):
                           hookenv.network_get_primary_address,
                           'mybinding')
 
+    @patch('charmhelpers.core.hookenv.juju_version')
     @patch('subprocess.check_output')
-    def test_network_get_primary_required(self, check_output):
-        """Ensure that NotImplementedError is thrown when run on Juju < 2.1"""
-        check_output.side_effect = CalledProcessError(
-            2, 'network_get',
-            output='--primary-address is currently required'.encode('UTF-8'))
-        self.assertRaises(NotImplementedError, hookenv.network_get, 'binding')
-
-    @patch('subprocess.check_output')
-    def test_network_get(self, check_output):
+    def test_network_get(self, check_output, juju_version):
         """Ensure that network-get is called correctly"""
-        check_output.return_value = b'192l.l168.22.1'
-        hookenv.network_get('mybinding')
+        juju_version.return_value = '2.2.0'
+        check_output.return_value = b'result'
+        hookenv.network_get('endpoint')
         check_output.assert_called_with(
-            ['network-get', 'mybinding', '--format', 'yaml'], stderr=-2)
+            ['network-get', 'endpoint', '--format', 'yaml'], stderr=-2)
 
+    @patch('charmhelpers.core.hookenv.juju_version')
     @patch('subprocess.check_output')
-    def test_network_get_relation_bound(self, check_output):
-        """Ensure that network-get supports relation context"""
-        check_output.return_value = b'192l.l168.22.1'
-        hookenv.network_get('mybinding', 'db')
+    def test_network_get_primary_required(self, check_output, juju_version):
+        """Ensure that NotImplementedError is thrown with Juju < 2.2.0"""
+        check_output.return_value = b'result'
+
+        juju_version.return_value = '2.1.4'
+        self.assertRaises(NotImplementedError, hookenv.network_get, 'binding')
+        juju_version.return_value = '2.2.0'
+        self.assertEquals(hookenv.network_get('endpoint'), 'result')
+
+    @patch('charmhelpers.core.hookenv.juju_version')
+    @patch('subprocess.check_output')
+    def test_network_get_relation_bound(self, check_output, juju_version):
+        """Ensure that network-get supports relation context, requires Juju 2.3"""
+        juju_version.return_value = '2.3.0'
+        check_output.return_value = b'result'
+        hookenv.network_get('endpoint', 'db')
         check_output.assert_called_with(
-            ['network-get', 'mybinding', '--format', 'yaml', '-r', 'db'],
+            ['network-get', 'endpoint', '--format', 'yaml', '-r', 'db'],
             stderr=-2)
+        juju_version.return_value = '2.2.8'
+        self.assertRaises(NotImplementedError, hookenv.network_get, 'endpoint', 'db')
 
+    @patch('charmhelpers.core.hookenv.juju_version')
     @patch('subprocess.check_output')
-    def test_network_get_parses_yaml(self, check_output):
+    def test_network_get_parses_yaml(self, check_output, juju_version):
         """network-get returns loaded YAML output."""
+        juju_version.return_value = '2.3.0'
         check_output.return_value = b"""
 bind-addresses:
 - macaddress: ""


### PR DESCRIPTION
Per https://github.com/juju/charm-helpers/issues/112, the network_get implementation is failing with Juju < 2.3. In particular, exception interception was failing to rewrite the failure under Juju 1.25, and the '-r' argument is only available with Juju 2.3 onwards.