### PR TITLE
Service catalogue validators to convert to v3

### DIFF
--- a/charmhelpers/contrib/openstack/amulet/deployment.py
+++ b/charmhelpers/contrib/openstack/amulet/deployment.py
@@ -21,6 +21,9 @@ from collections import OrderedDict
 from charmhelpers.contrib.amulet.deployment import (
     AmuletDeployment
 )
+from charmhelpers.contrib.openstack.amulet.utils import (
+    OPENSTACK_RELEASES_PAIRS
+)
 
 DEBUG = logging.DEBUG
 ERROR = logging.ERROR
@@ -271,11 +274,8 @@ class OpenStackAmuletDeployment(AmuletDeployment):
            release.
            """
         # Must be ordered by OpenStack release (not by Ubuntu release):
-        (self.trusty_icehouse, self.trusty_kilo, self.trusty_liberty,
-         self.trusty_mitaka, self.xenial_mitaka, self.xenial_newton,
-         self.yakkety_newton, self.xenial_ocata, self.zesty_ocata,
-         self.xenial_pike, self.artful_pike, self.xenial_queens,
-         self.bionic_queens,) = range(13)
+        for i, os_pair in enumerate(OPENSTACK_RELEASES_PAIRS):
+            setattr(self, b, i)
 
         releases = {
             ('trusty', None): self.trusty_icehouse,

--- a/charmhelpers/contrib/openstack/amulet/deployment.py
+++ b/charmhelpers/contrib/openstack/amulet/deployment.py
@@ -275,7 +275,7 @@ class OpenStackAmuletDeployment(AmuletDeployment):
            """
         # Must be ordered by OpenStack release (not by Ubuntu release):
         for i, os_pair in enumerate(OPENSTACK_RELEASES_PAIRS):
-            setattr(self, b, i)
+            setattr(self, os_pair, i)
 
         releases = {
             ('trusty', None): self.trusty_icehouse,

--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -51,11 +51,12 @@ ERROR = logging.ERROR
 NOVA_CLIENT_VERSION = "2"
 
 OPENSTACK_RELEASES_PAIRS = [
-     'trusty_icehouse', 'trusty_kilo', 'trusty_liberty',
-     'trusty_mitaka', 'xenial_mitaka', 'xenial_newton',
-     'yakkety_newton', 'xenial_ocata', 'zesty_ocata',
-     'xenial_pike', 'artful_pike', 'xenial_queens',
-     'bionic_queens']
+    'trusty_icehouse', 'trusty_kilo', 'trusty_liberty',
+    'trusty_mitaka', 'xenial_mitaka', 'xenial_newton',
+    'yakkety_newton', 'xenial_ocata', 'zesty_ocata',
+    'xenial_pike', 'artful_pike', 'xenial_queens',
+    'bionic_queens']
+
 
 class OpenStackAmuletUtils(AmuletUtils):
     """OpenStack amulet utilities.

--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -312,9 +312,7 @@ class OpenStackAmuletUtils(AmuletUtils):
         """
         self.log.debug('Validating v3 service catalog endpoint data...')
         self.log.debug('actual: {}'.format(repr(actual)))
-        self.log.debug('expected: {}'.format(repr(expected,)))
         for k, v in six.iteritems(expected):
-            self.log.debug('    {} {}'.format(k, v))
             if k in actual:
                 l_expected = sorted(v, key=lambda x: x['interface'])
                 l_actual = sorted(actual[k], key=lambda x: x['interface'])
@@ -329,7 +327,6 @@ class OpenStackAmuletUtils(AmuletUtils):
                     if ret:
                         return self.endpoint_error(k, ret)
             else:
-                self.log.debug('    {} not in {}'.format(k, actual))
                 return "endpoint {} does not exist".format(k)
         return ret
 

--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -50,6 +50,12 @@ ERROR = logging.ERROR
 
 NOVA_CLIENT_VERSION = "2"
 
+OPENSTACK_RELEASES_PAIRS = [
+     'trusty_icehouse', 'trusty_kilo', 'trusty_liberty',
+     'trusty_mitaka', 'xenial_mitaka', 'xenial_newton',
+     'yakkety_newton', 'xenial_ocata', 'zesty_ocata',
+     'xenial_pike', 'artful_pike', 'xenial_queens',
+     'bionic_queens']
 
 class OpenStackAmuletUtils(AmuletUtils):
     """OpenStack amulet utilities.
@@ -76,8 +82,8 @@ class OpenStackAmuletUtils(AmuletUtils):
 
            """
         validation_function = self.validate_v2_endpoint_data
-        # 11 => xenial_queens
-        if openstack_release and openstack_release >= 11:
+        xenial_queens = OPENSTACK_RELEASES_PAIRS.index('xenial_queens')
+        if openstack_release and openstack_release >= xenial_queens:
                 validation_function = self.validate_v3_endpoint_data
                 expected = {
                     'id': expected['id'],
@@ -241,8 +247,8 @@ class OpenStackAmuletUtils(AmuletUtils):
 
            """
         validation_function = self.validate_v2_svc_catalog_endpoint_data
-        # 11 => xenial_queens
-        if openstack_release and openstack_release >= 11:
+        xenial_queens = OPENSTACK_RELEASES_PAIRS.index('xenial_queens')
+        if openstack_release and openstack_release >= xenial_queens:
             validation_function = self.validate_v3_svc_catalog_endpoint_data
             expected = self.convert_svc_catalog_endpoint_data_to_v3(expected)
         return validation_function(expected, actual)


### PR DESCRIPTION
Update the service catalogue validator methods to accept v2 formatted
data and convert to v3 as necessary and call the correct subsequent
validator.