### PR TITLE
Update IdentityService context for service_domain_id

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -384,6 +384,7 @@ class IdentityServiceContext(OSContextGenerator):
                     # so a missing value just indicates keystone needs
                     # upgrading
                     ctxt['admin_tenant_id'] = rdata.get('service_tenant_id')
+                    ctxt['admin_domain_id'] = rdata.get('service_domain_id')
                     return ctxt
 
         return {}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -192,6 +192,7 @@ IDENTITY_SERVICE_RELATION_VERSIONED.update(IDENTITY_SERVICE_RELATION_HTTPS)
 
 IDENTITY_CREDENTIALS_RELATION_VERSIONED = {
     'api_version': '3',
+    'service_domain_id': '567890',
 }
 IDENTITY_CREDENTIALS_RELATION_VERSIONED.update(IDENTITY_CREDENTIALS_RELATION_UNSET)
 
@@ -900,6 +901,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -948,6 +950,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -971,6 +974,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -994,6 +998,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': '123456',
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -1015,6 +1020,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -1038,6 +1044,7 @@ class ContextTests(unittest.TestCase):
             'admin_domain_name': 'admin_domain',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -1084,6 +1091,7 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': '123456',
+            'admin_domain_id': None,
             'admin_user': 'adam',
             'auth_host': '[2001:db8:1::1]',
             'auth_port': '35357',


### PR DESCRIPTION
Newer keystone charm versions will set the service_domain_id on
an identity-service relation; update context to pick this new
data item from the relation.