### PR TITLE
Update get_ca to include identity-credentials

### DIFF
--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -65,7 +65,8 @@ def get_ca_cert():
     if ca_cert is None:
         log("Inspecting identity-service relations for CA SSL certificate.",
             level=INFO)
-        for r_id in relation_ids('identity-service'):
+        for r_id in (relation_ids('identity-service') +
+                     relation_ids('identity-credentials')):
             for unit in relation_list(r_id):
                 if ca_cert is None:
                     ca_cert = relation_get('ca_cert',

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import patch, call
 
 from testtools import TestCase
 from tests.helpers import patch_open, FakeRelation
@@ -101,12 +101,15 @@ class ApacheUtilsTests(TestCase):
 
     def test_get_ca_cert_from_relation(self):
         self.config_get.return_value = None
-        self.relation_ids.return_value = 'identity-service:0'
+        self.relation_ids.side_effect = [['identity-service:0'],
+                                         ['identity-credentials:1']]
         self.relation_list.return_value = 'keystone/0'
         self.relation_get.side_effect = [
             'keystone_provided_ca',
         ]
         result = apache_utils.get_ca_cert()
+        self.relation_ids.assert_has_calls([call('identity-service'),
+                                            call('identity-credentials')])
         self.assertEquals('keystone_provided_ca',
                           result)
 


### PR DESCRIPTION
When using keystone generated SSL with the identity-credentials
relation get_ca was ignoring ca data. Check both identity-service and
identity-credentials.