### PR TITLE
HAProxyContext: deploy configs that work at boot time on trusty

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -5,8 +5,10 @@ global
     user haproxy
     group haproxy
     spread-checks 0
+{%- if init_is_systemd %}
     stats socket /var/run/haproxy/admin.sock mode 600 level admin
     stats timeout 2m
+{%- endif %}
 
 defaults
     log global

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -642,6 +642,7 @@ TO_PATCH = [
     'resolve_address',
     'is_ipv6_disabled',
     'snap_install_requested',
+    'init_is_systemd',
 ]
 
 
@@ -697,6 +698,7 @@ class ContextTests(unittest.TestCase):
         self.network_get_primary_address.side_effect = NotImplementedError()
         self.resolve_address.return_value = '10.5.1.50'
         self.snap_install_requested.return_value = False
+        self.init_is_systemd.return_value = True
         self.maxDiff = None
 
     def _patch(self, method):
@@ -1736,6 +1738,7 @@ class ContextTests(unittest.TestCase):
             'default_backend': 'cluster-peer0.localnet',
             'local_host': '127.0.0.1',
             'haproxy_host': '0.0.0.0',
+            'init_is_systemd': True,
             'ipv6_enabled': False,
             'stat_password': 'testpassword',
             'stat_port': '8888',
@@ -1797,6 +1800,7 @@ class ContextTests(unittest.TestCase):
             'default_backend': 'cluster-peer0.localnet',
             'local_host': '127.0.0.1',
             'haproxy_host': '0.0.0.0',
+            'init_is_systemd': True,
             'ipv6_enabled': False,
             'stat_password': 'testpassword',
             'stat_port': '8888',
@@ -1890,6 +1894,7 @@ class ContextTests(unittest.TestCase):
             'default_backend': 'cluster-peer0.localnet',
             'local_host': '127.0.0.1',
             'haproxy_host': '0.0.0.0',
+            'init_is_systemd': True,
             'ipv6_enabled': False,
             'stat_password': 'testpassword',
             'stat_port': '8888',
@@ -1965,6 +1970,7 @@ class ContextTests(unittest.TestCase):
             'default_backend': 'cluster-peer0.localnet',
             'local_host': '127.0.0.1',
             'haproxy_host': '0.0.0.0',
+            'init_is_systemd': True,
             'ipv6_enabled': False,
             'stat_password': 'testpassword',
             'stat_port': '8888',
@@ -2030,6 +2036,7 @@ class ContextTests(unittest.TestCase):
             'haproxy_server_timeout': 50000,
             'haproxy_client_timeout': 50000,
             'haproxy_host': '::',
+            'init_is_systemd': True,
             'ipv6_enabled': True,
             'stat_password': 'testpassword',
             'stat_port': '8888',
@@ -2152,6 +2159,7 @@ class ContextTests(unittest.TestCase):
             'default_backend': 'lonely.clusterpeer.howsad',
             'haproxy_host': '0.0.0.0',
             'local_host': '127.0.0.1',
+            'init_is_systemd': True,
             'ipv6_enabled': False,
             'stat_port': '8888',
             'stat_password': 'testpassword',


### PR DESCRIPTION
admin.sock was added to the default config file so that haproxy
would always start, even without any listeners defined, which
prevents systemd from marking the unit as failed[1].  On xenial,
/var/run/haproxy is created at boot time by the init script,
since /var/run (really /run) is a tmpfs.  On trusty, this seems
to work, because the charm also creates /var/run/haproxy, but
since the trusty init script does not create /var/run/haproxy,
following a reboot, haproxy will not start until charm hooks have
run and created the missing directory.  Since the admin socket
does not otherwise exist on trusty haproxy deploys, and we already
create a stats listener on 127.0.0.1:8888, the simplest thing to
do is to only add the directive if may be expected or needed.

Fixes: https://bugs.launchpad.net/charm-helpers/+bug/1755061
Footnotes:
 1: https://anonscm.debian.org/cgit/pkg-haproxy/haproxy.git/commit/?id=8b77d5e324bb11466a3e10cd4885234f9cbf8a61