### PR TITLE
Fix cached not JSON serializable errors

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -68,7 +68,10 @@ def cached(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         global cache
-        key = json.dumps((str(func), args, kwargs), sort_keys=True)
+        try:
+            key = json.dumps((str(func), args, kwargs), sort_keys=True)
+        except TypeError:
+            key = str((func, args, kwargs))
         try:
             return cache[key]
         except KeyError:


### PR DESCRIPTION
After the change at 2aab46ca4ae95c6c5ec8d28b3b39b768f034c179, OpenStack
charms are failing with errors similar to this:
TypeError: <charm.openstack.designate.DesignateConfigurationAdapter
object at 0x7f7e00f83c88> is not JSON serializable

This change guards the json.dumps in a try/except block. Do the former
behavior if json.dumps fails.