### PR TITLE
Handle non-zero unit numbered leader

### DIFF
--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -386,6 +386,12 @@ def distributed_wait(modulo=None, wait=None, operation_name='operation'):
     if wait is None:
         wait = config_get('known-wait')
     calculated_wait = modulo_distribution(modulo=modulo, wait=wait)
+    if juju_is_leader():
+        # The leader should never wait
+        calculated_wait = 0
+    elif calculated_wait == 0:
+        # The non-leader who gets modulo 0 should wait
+        calculated_wait = (modulo + 1) * wait
     msg = "Waiting {} seconds for {} ...".format(calculated_wait,
                                                  operation_name)
     log(msg, DEBUG)

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -371,6 +371,7 @@ def distributed_wait(modulo=None, wait=None, operation_name='operation'):
     ''' Distribute operations by waiting based on modulo_distribution
 
     If modulo and or wait are not set, check config_get for those values.
+    If config values are not set, default to modulo=3 and wait=30.
 
     :param modulo: int The modulo number creates the group distribution
     :param wait: int The constant time wait value
@@ -382,16 +383,17 @@ def distributed_wait(modulo=None, wait=None, operation_name='operation'):
     :side effect: Calls time.sleep()
     '''
     if modulo is None:
-        modulo = config_get('modulo-nodes')
+        modulo = config_get('modulo-nodes') or 3
     if wait is None:
-        wait = config_get('known-wait')
-    calculated_wait = modulo_distribution(modulo=modulo, wait=wait)
+        wait = config_get('known-wait') or 30
     if juju_is_leader():
         # The leader should never wait
         calculated_wait = 0
-    elif calculated_wait == 0:
-        # The non-leader who gets modulo 0 should wait
-        calculated_wait = modulo * wait
+    else:
+        # non_zero_wait=True guarantees the non-leader who gets modulo 0
+        # will still wait
+        calculated_wait = modulo_distribution(modulo=modulo, wait=wait,
+                                              non_zero_wait=True)
     msg = "Waiting {} seconds for {} ...".format(calculated_wait,
                                                  operation_name)
     log(msg, DEBUG)

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -391,7 +391,7 @@ def distributed_wait(modulo=None, wait=None, operation_name='operation'):
         calculated_wait = 0
     elif calculated_wait == 0:
         # The non-leader who gets modulo 0 should wait
-        calculated_wait = (modulo + 1) * wait
+        calculated_wait = modulo * wait
     msg = "Waiting {} seconds for {} ...".format(calculated_wait,
                                                  operation_name)
     log(msg, DEBUG)

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -993,7 +993,7 @@ def updatedb(updatedb_text, new_path):
     return output
 
 
-def modulo_distribution(modulo=3, wait=30):
+def modulo_distribution(modulo=3, wait=30, non_zero_wait=False):
     """ Modulo distribution
 
     This helper uses the unit number, a modulo value and a constant wait time
@@ -1015,7 +1015,14 @@ def modulo_distribution(modulo=3, wait=30):
 
     @param modulo: int The modulo number creates the group distribution
     @param wait: int The constant time wait value
+    @param non_zero_wait: boolean Override unit % modulo == 0,
+                          return modulo * wait. Used to avoid collisions with
+                          leader nodes which are often given priority.
     @return: int Calculated time to wait for unit operation
     """
     unit_number = int(local_unit().split('/')[1])
-    return (unit_number % modulo) * wait
+    calculated_wait_time = (unit_number % modulo) * wait
+    if non_zero_wait and calculated_wait_time == 0:
+        return modulo * wait
+    else:
+        return calculated_wait_time

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -546,10 +546,10 @@ class ClusterUtilsTests(TestCase):
         modulo_distribution.assert_called_with(modulo=3, wait=45)
 
         # Non-Leader with modulo 0 should still wait
-        # (modulo + 1) * wait
+        # modulo * wait
         modulo_distribution.return_value = 0
         cluster_utils.distributed_wait(modulo=2, wait=5)
-        sleep.assert_called_with(15)
+        sleep.assert_called_with(10)
 
         # Leader regardless of modulo should not wait
         is_leader.return_value = True

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1858,7 +1858,17 @@ class HelpersTest(TestCase):
     @patch.object(host, 'local_unit')
     def test_modulo_distribution(self, local_unit):
         local_unit.return_value = 'test/7'
+
+        # unit % modulo * wait
         self.assertEqual(host.modulo_distribution(modulo=6, wait=10), 10)
+
+        # Zero wait when unit % modulo == 0
+        self.assertEqual(host.modulo_distribution(modulo=7, wait=10), 0)
+
+        # modulo * wait when unit % modulo == 0 and non_zero_wait=True
+        self.assertEqual(host.modulo_distribution(modulo=7, wait=10,
+                                                  non_zero_wait=True),
+                         70)
 
 
 class TestHostCompator(TestCase):


### PR DESCRIPTION
When the distributed_wait function is called and the leader does not
happen to have 0 unit number, the leader winds up waiting while the
non-leader modulo 0 does not. Also when there are units > modulo
there may be conflicts with the leader when multiple units get modulo
0 and do not wait. Neither of these are desired behavior.

This change makes sure the leader, regardless of modulo, never waits.
And forces non-leaders which happen to get modulo 0 to wait.

For applications where the original behavior is desirable,
modulo_distribution can be used directly.