### PR TITLE
Fix keystone_wait_for_propagation test helper

### DIFF
--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -441,7 +441,7 @@ class OpenStackAmuletUtils(AmuletUtils):
             if rel.get('api_version') != str(api_version):
                 raise Exception("api_version not propagated through relation"
                                 " data yet ('{}' != '{}')."
-                                "".format(rel['api_version'], api_version))
+                                "".format(rel.get('api_version'), api_version))
 
     def keystone_configure_api_version(self, sentry_relation_pairs, deployment,
                                        api_version):


### PR DESCRIPTION
keystone_wait_for_propagation had a key error when raising
a custom exception message because it was trying to use a
dict key which may not always exist.

Use dict.get instead of dict explicit key reference, as
dict.get returns None when the key does not exist.

Fixes #143