### PR TITLE
Read in ca certificate as binary for PY3

### DIFF
--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -77,7 +77,7 @@ def get_ca_cert():
 def retrieve_ca_cert(cert_file):
     cert = None
     if os.path.isfile(cert_file):
-        with open(cert_file, 'r') as crt:
+        with open(cert_file, 'rb') as crt:
             cert = crt.read()
     return cert
 

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -121,7 +121,7 @@ class ApacheUtilsTests(TestCase):
             self.assertEqual(
                 apache_utils.retrieve_ca_cert('mycertfile'),
                 cert)
-            _open.assert_called_once_with('mycertfile', 'r')
+            _open.assert_called_once_with('mycertfile', 'rb')
 
     @patch.object(apache_utils.os.path, 'isfile')
     def test_retrieve_ca_cert_no_file(self, _isfile):


### PR DESCRIPTION
The comparison of bytes vs string of the CA certificate produces a
false negative. This leads to rewriting certificates and affecting
connectivity to services. The writing of the file was changed to bytes
in https://github.com/juju/charm-helpers/pull/58/.

Read in the certificate as bytes as well for a bytes vs bytes
comparison.

Closes-Issue: https://github.com/juju/charm-helpers/issues/86
Closes-Bug: #1762431