### PR TITLE
Bug/1761305/ensure apache ssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,16 @@ userinstall:
 	scripts/update-revno
 	python setup.py install --user
 
+
 .venv:
-	dpkg -l gcc python-dev python-virtualenv python-apt > /dev/null || sudo apt-get install -y gcc python-dev python-virtualenv python-apt
+	dpkg-query -W -f='$${status}' gcc python-dev python-virtualenv python-apt 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python-dev python-virtualenv python-apt
 	virtualenv .venv --system-site-packages
 	.venv/bin/pip install -U pip
 	.venv/bin/pip install -I -r test_requirements.txt
 	.venv/bin/pip install bzr
 
 .venv3:
-	dpkg -l gcc python3-dev python-virtualenv python3-apt > /dev/null || sudo apt-get install -y gcc python3-dev python-virtualenv python3-apt
+	dpkg-query -W -f='$${status}' gcc python3-dev python-virtualenv python3-apt 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python3-dev python-virtualenv python3-apt
 	virtualenv .venv3 --python=python3 --system-site-packages
 	.venv3/bin/pip install -U pip
 	.venv3/bin/pip install -I -r test_requirements.txt

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -797,9 +797,9 @@ class ApacheSSLContext(OSContextGenerator):
             key_filename = 'key'
 
         write_file(path=os.path.join(ssl_dir, cert_filename),
-                   content=b64decode(cert))
+                   content=b64decode(cert), perms=0o640)
         write_file(path=os.path.join(ssl_dir, key_filename),
-                   content=b64decode(key))
+                   content=b64decode(key), perms=0o640)
 
     def configure_ca(self):
         ca_cert = get_ca_cert()

--- a/charmhelpers/core/unitdata.py
+++ b/charmhelpers/core/unitdata.py
@@ -166,6 +166,10 @@ class Storage(object):
 
     To support dicts, lists, integer, floats, and booleans values
     are automatically json encoded/decoded.
+
+    Note: to facilitate unit testing, ':memory:' can be passed as the
+    path parameter which causes sqlite3 to only build the db in memory.
+    This should only be used for testing purposes.
     """
     def __init__(self, path=None):
         self.db_path = path
@@ -175,8 +179,9 @@ class Storage(object):
             else:
                 self.db_path = os.path.join(
                     os.environ.get('CHARM_DIR', ''), '.unit-state.db')
-        with open(self.db_path, 'a') as f:
-            os.fchmod(f.fileno(), 0o600)
+        if self.db_path != ':memory:':
+            with open(self.db_path, 'a') as f:
+                os.fchmod(f.fileno(), 0o600)
         self.conn = sqlite3.connect('%s' % self.db_path)
         self.cursor = self.conn.cursor()
         self.revision = None

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2250,14 +2250,14 @@ class ContextTests(unittest.TestCase):
         self.assertTrue(apache.configure_cert.called)
 
     def test_https_context_loads_correct_apache_mods(self):
-        '''Test apache2 context also loads required apache modules'''
+        # Test apache2 context also loads required apache modules
         apache = context.ApacheSSLContext()
         apache.enable_modules()
         ex_cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers']
         self.check_call.assert_called_with(ex_cmd)
 
     def test_https_configure_cert(self):
-        '''Test apache2 properly installs certs and keys to disk'''
+        # Test apache2 properly installs certs and keys to disk
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = [b'SSL_CERT', b'SSL_KEY']
         apache = context.ApacheSSLContext()
@@ -2267,16 +2267,16 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert_test-cn',
-                      content=b'SSL_CERT'),
+                      content=b'SSL_CERT', perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key_test-cn',
-                      content=b'SSL_KEY')]
+                      content=b'SSL_KEY', perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]
         self.assertEquals(decode, self.b64decode.call_args_list)
 
     def test_https_configure_cert_deprecated(self):
-        '''Test apache2 properly installs certs and keys to disk'''
+        # Test apache2 properly installs certs and keys to disk
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = ['SSL_CERT', 'SSL_KEY']
         apache = context.ApacheSSLContext()
@@ -2286,9 +2286,9 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert',
-                      content='SSL_CERT'),
+                      content='SSL_CERT', perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key',
-                      content='SSL_KEY')]
+                      content='SSL_KEY', perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]


### PR DESCRIPTION
This is due to related bug in that the SSL files were world readable
and thus, a security risk.  They have been changed to 640 to allow
the user and group to read them.

Related-Bug: #1761305 on launchpad

Also, clean-up some areas around testing.