### PR TITLE
Fixes LP#1761840: add_ovsbridge_linuxbridge fails for missing `source` in e/n/i 

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -102,6 +102,10 @@ def add_ovsbridge_linuxbridge(name, bridge):
             log('Interface {} already exists'.format(interface), level=INFO)
             return
 
+    # Juju removes this line when setting up interfaces
+    with open('/etc/network/interfaces', 'a') as eni:
+        eni.write('\nsource /etc/network/interfaces.d/*')
+
     with open('/etc/network/interfaces.d/{}.cfg'.format(
             linuxbridge_port), 'w') as config:
         config.write(BRIDGE_TEMPLATE.format(linuxbridge_port=linuxbridge_port,

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -102,9 +102,7 @@ def add_ovsbridge_linuxbridge(name, bridge):
             log('Interface {} already exists'.format(interface), level=INFO)
             return
 
-    # Juju removes this line when setting up interfaces
-    with open('/etc/network/interfaces', 'a') as eni:
-        eni.write('\nsource /etc/network/interfaces.d/*')
+    check_for_eni_source()
 
     with open('/etc/network/interfaces.d/{}.cfg'.format(
             linuxbridge_port), 'w') as config:
@@ -157,6 +155,18 @@ def get_certificate():
     else:
         log('Certificate not found', level=WARNING)
         return None
+
+
+def check_for_eni_source():
+    ''' Juju removes the source line when setting up interfaces,
+    replace if missing '''
+
+    with open('/etc/network/interfaces', 'r') as eni:
+        for line in eni:
+            if line == 'source /etc/network/interfaces.d/*':
+                return
+    with open('/etc/network/interfaces', 'a') as eni:
+        eni.write('\nsource /etc/network/interfaces.d/*')
 
 
 def full_restart():


### PR DESCRIPTION
When Juju runs its network setup it replaces the contents of e/n/i and does not re-add a line to `source /etc/network/interfaces.d/*` which is required by add_ovsbridge_linuxbridge in order to `ifup` the veth it creates. 

This PR adds a call to open e/n/i and append that line to the end of the file to enable this functionality.