### PR TITLE
Make get_os_codename_install_source() independent of the series where  it's executed

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -306,7 +306,7 @@ def get_os_codename_install_source(src):
 
     if src.startswith('cloud:'):
         ca_rel = src.split(':')[1]
-        ca_rel = ca_rel.split('%s-' % ubuntu_rel)[1].split('/')[0]
+        ca_rel = ca_rel.split('-')[1].split('/')[0]
         return ca_rel
 
     # Best guess match based on deb string provided


### PR DESCRIPTION
When upgrading the ubuntu series (e.g from Trusty to Xenial)
get_os_codename_install_source() will try to figure out the OpenStack
version splitting the value in openstack-origin (or source) by the
ubuntu series, for cases where the configured value is trusty-mitaka and
the series running is xenial this split gets broken, spliting by '-'
make it reliable.

Fixes LP: #1765805