### PR TITLE
Enable proxy header parsing

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-oslo-middleware
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-middleware
@@ -1,0 +1,5 @@
+[oslo_middleware]
+
+# Bug #1758675
+enable_proxy_headers_parsing = true
+


### PR DESCRIPTION
Ensure that oslo.middleware parses any proxy information
forwarded from haproxy/apache with regards to protocol;
this ensures that https connections are correctly detected.
Needed for mitaka+ deployments.