### PR TITLE
Add support for more arguments in EnsureDirContext

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1873,10 +1873,11 @@ class EnsureDirContext(OSContextGenerator):
     context is needed to do that before rendering a template.
    '''
 
-    def __init__(self, dirname):
+    def __init__(self, dirname, **kwargs):
         '''Used merely to ensure that a given directory exists.'''
         self.dirname = dirname
+        self.kwargs = kwargs
 
     def __call__(self):
-        mkdir(self.dirname)
+        mkdir(self.dirname, **self.kwargs)
         return {}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3505,6 +3505,13 @@ class ContextTests(unittest.TestCase):
     @patch('charmhelpers.contrib.openstack.context.mkdir')
     def test_ensure_dir_ctx(self, mkdir):
         dirname = '/etc/keystone/policy.d'
-        ctxt = context.EnsureDirContext(dirname)
+        owner = 'someuser'
+        group = 'somegroup'
+        perms = 0o555
+        force = False
+        ctxt = context.EnsureDirContext(dirname, owner=owner,
+                                        group=group, perms=perms,
+                                        force=force)
         ctxt()
-        mkdir.assert_called_with(dirname)
+        mkdir.assert_called_with(dirname, owner=owner, group=group,
+                                 perms=perms, force=force)


### PR DESCRIPTION
Dirname is not always sufficient enough.