### PR TITLE
Add helpers for vaultlocker

### DIFF
--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -1,0 +1,84 @@
+# Copyright 2018 Canonical Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import charmhelpers.contrib.openstack.alternatives as alternatives
+import charmhelpers.contrib.openstack.context as context
+
+import charmhelpers.core.hookenv as hookenv
+import charmhelpers.core.host as host
+import charmhelpers.core.templating as templating
+
+
+class VaultKVContext(context.OSContextGenerator):
+    """Vault KV context for interaction with vault-kv interfaces"""
+    interfaces = ['secrets-storage']
+
+    def __init__(self, secret_backend=None):
+        super(context.OSContextGenerator, self).__init__()
+        self.secret_backend = (
+            secret_backend or 'charm-{}'.format(hookenv.service_name())
+        )
+
+    def __call__(self):
+        for relation_id in hookenv.relation_ids(self.interfaces[0]):
+            for unit in hookenv.related_units(relation_id):
+                vault_url = hookenv.relation_get(
+                    'vault_url',
+                    unit=unit,
+                    rid=relation_id
+                )
+                role_id = hookenv.relation_get(
+                    '{}_role_id'.format(hookenv.local_unit()),
+                    unit=unit,
+                    rid=relation_id
+                )
+
+                if vault_url and role_id:
+                    ctxt = {
+                        'vault_url': json.loads(vault_url),
+                        'role_id': json.loads(role_id),
+                        'secret_backend': self.secret_backend,
+                    }
+                    vault_ca = hookenv.relation_get(
+                        'vault_ca',
+                        unit=unit,
+                        rid=relation_id
+                    )
+                    if vault_ca:
+                        ctxt['vault_ca'] = json.loads(vault_ca)
+                    self.complete = True
+                    return ctxt
+        return {}
+
+
+def write_vaultlocker_conf(context, priority=100):
+    """Write vaultlocker configuration to disk and install alternative
+
+    :param context: Dict of data from vault-kv relation
+    :ptype: context: dict
+    :param priority: Priority of alternative configuration
+    :ptype: priority: int"""
+    charm_vl_path = "/var/lib/charm/{}/vaultlocker.conf".format(
+        hookenv.service_name()
+    )
+    host.mkdir(os.path.dirname(charm_vl_path), perms=0o700)
+    templating.render(source='vaultlocker.conf.j2',
+                      target=charm_vl_path,
+                      context=context, perms=0o600),
+    alternatives.install_alternative('vaultlocker.conf',
+                                     '/etc/vaultlocker/vaultlocker.conf',
+                                     charm_vl_path, priority)

--- a/tests/contrib/openstack/test_vaultlocker.py
+++ b/tests/contrib/openstack/test_vaultlocker.py
@@ -1,0 +1,149 @@
+# Copyright 2018 Canonical Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import mock
+import os
+import unittest
+
+import charmhelpers.contrib.openstack.vaultlocker as vaultlocker
+
+
+INCOMPLETE_RELATION = {
+    'secrets-storage:1': {
+        'vault/0': {}
+    }
+}
+
+COMPLETE_RELATION = {
+    'secrets-storage:1': {
+        'vault/0': {
+            'vault_url': json.dumps('http://vault:8200'),
+            'test-service/0_role_id': json.dumps('test-role-from-vault'),
+        }
+    }
+}
+
+COMPLETE_WITH_CA_RELATION = {
+    'secrets-storage:1': {
+        'vault/0': {
+            'vault_url': json.dumps('http://vault:8200'),
+            'test-service/0_role_id': json.dumps('test-role-from-vault'),
+            'vault_ca': json.dumps('test-ca-data'),
+        }
+    }
+}
+
+
+class VaultLockerTestCase(unittest.TestCase):
+
+    to_patch = [
+        'hookenv',
+        'templating',
+        'alternatives',
+        'host'
+    ]
+
+    _target_path = '/var/lib/charm/test-service/vaultlocker.conf'
+
+    def setUp(self):
+        for m in self.to_patch:
+            setattr(self, m, self._patch(m))
+        self.hookenv.service_name.return_value = 'test-service'
+        self.hookenv.local_unit.return_value = 'test-service/0'
+
+    def _patch(self, target):
+        _m = mock.patch.object(vaultlocker, target)
+        _mock = _m.start()
+        self.addCleanup(_m.stop)
+        return _mock
+
+    def test_write_vl_config(self):
+        ctxt = {'test': 'data'}
+        vaultlocker.write_vaultlocker_conf(context=ctxt)
+        self.hookenv.service_name.assert_called_once_with()
+        self.host.mkdir.assert_called_once_with(
+            os.path.dirname(self._target_path),
+            perms=0o700
+        )
+        self.templating.render.assert_called_once_with(
+            source='vaultlocker.conf.j2',
+            target=self._target_path,
+            context=ctxt,
+            perms=0o600,
+        )
+        self.alternatives.install_alternative.assert_called_once_with(
+            'vaultlocker.conf',
+            '/etc/vaultlocker/vaultlocker.conf',
+            self._target_path,
+            100
+        )
+
+    def test_write_vl_config_priority(self):
+        ctxt = {'test': 'data'}
+        vaultlocker.write_vaultlocker_conf(context=ctxt, priority=200)
+        self.hookenv.service_name.assert_called_once_with()
+        self.host.mkdir.assert_called_once_with(
+            os.path.dirname(self._target_path),
+            perms=0o700
+        )
+        self.templating.render.assert_called_once_with(
+            source='vaultlocker.conf.j2',
+            target=self._target_path,
+            context=ctxt,
+            perms=0o600,
+        )
+        self.alternatives.install_alternative.assert_called_once_with(
+            'vaultlocker.conf',
+            '/etc/vaultlocker/vaultlocker.conf',
+            self._target_path,
+            200
+        )
+
+    def _setup_relation(self, relation):
+        self.hookenv.relation_ids.side_effect = (
+            lambda _: relation.keys()
+        )
+        self.hookenv.related_units.side_effect = (
+            lambda rid: relation[rid].keys()
+        )
+        self.hookenv.relation_get.side_effect = (
+            lambda attribute, unit, rid:
+                relation[rid][unit].get(attribute)
+        )
+
+    def test_context_incomplete(self):
+        self._setup_relation(INCOMPLETE_RELATION)
+        context = vaultlocker.VaultKVContext('charm-test')
+        self.assertEqual(context(), {})
+        self.hookenv.relation_ids.assert_called_with('secrets-storage')
+
+    def test_context_complete(self):
+        self._setup_relation(COMPLETE_RELATION)
+        context = vaultlocker.VaultKVContext('charm-test')
+        self.assertEqual(context(),
+                         {'role_id': 'test-role-from-vault',
+                          'secret_backend': 'charm-test',
+                          'vault_url': 'http://vault:8200'})
+        self.hookenv.relation_ids.assert_called_with('secrets-storage')
+
+    def test_context_complete_with_ca(self):
+        self._setup_relation(COMPLETE_WITH_CA_RELATION)
+        context = vaultlocker.VaultKVContext('charm-test')
+        self.assertEqual(context(),
+                         {'role_id': 'test-role-from-vault',
+                          'secret_backend': 'charm-test',
+                          'vault_url': 'http://vault:8200',
+                          'vault_ca': 'test-ca-data'})
+        self.hookenv.relation_ids.assert_called_with('secrets-storage')


### PR DESCRIPTION
Add a new context and utility function to help charms make use of
vault and vaultlocker for storage and retrieval of dmcrypt keys
in Hashicorp Vault.