### PR TITLE
Do not parse config state file if empty

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -290,7 +290,7 @@ class Config(dict):
         self.implicit_save = True
         self._prev_dict = None
         self.path = os.path.join(charm_dir(), Config.CONFIG_FILE_NAME)
-        if os.path.exists(self.path):
+        if os.path.exists(self.path) and os.stat(self.path).st_size:
             self.load_previous()
         atexit(self._implicit_save)
 
@@ -310,7 +310,11 @@ class Config(dict):
         """
         self.path = path or self.path
         with open(self.path) as f:
-            self._prev_dict = json.load(f)
+            try:
+                self._prev_dict = json.load(f)
+            except ValueError as e:
+                log('Unable to parse previous config data - {}'.format(str(e)),
+                    level=ERROR)
         for k, v in copy.deepcopy(self._prev_dict).items():
             if k not in self:
                 self[k] = v

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -60,6 +60,26 @@ class ConfigTest(TestCase):
         self.assertEqual(c['foo'], 'bar')
         self.assertEqual(c._prev_dict, None)
 
+    def test_init_empty_state_file(self):
+        d = dict(foo='bar')
+        c = hookenv.Config(d)
+
+        with open(c.path, 'w') as f:
+            f.close()
+
+        self.assertEqual(c['foo'], 'bar')
+        self.assertEqual(c._prev_dict, None)
+
+    def test_init_invalid_state_file(self):
+        d = dict(foo='bar')
+        c = hookenv.Config(d)
+
+        with open(c.path, 'w') as f:
+            f.write('blah')
+
+        self.assertEqual(c['foo'], 'bar')
+        self.assertEqual(c._prev_dict, None)
+
     def test_load_previous(self):
         d = dict(foo='bar')
         c = hookenv.Config()


### PR DESCRIPTION
Also catch Value exception in case the output cannot be parsed.

Closes-Bug: #1768018

#167 