### PR TITLE
Revert "Adds operator.socket (#115)"

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -6,7 +6,6 @@ global
     group haproxy
     spread-checks 0
     stats socket /var/run/haproxy/admin.sock mode 600 level admin
-    stats socket /var/run/haproxy/operator.sock mode 600 level operator
     stats timeout 2m
 
 defaults


### PR DESCRIPTION
Reverting due to https://github.com/juju/charm-helpers/issues/172
The admin socket already provides all the information required. The
addition of the operator socket is superfluous.

This reverts commit 4abc9cdc1dba442c0e283bc34a2e7d0c27c26fcd.