### PR TITLE
Support the goal-state command

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -973,6 +973,13 @@ def application_version_set(version):
 
 
 @translate_exc(from_exc=OSError, to_exc=NotImplementedError)
+def goal_state():
+    """Juju goal state values"""
+    cmd = ['goal-state', '--format=json']
+    return json.loads(subprocess.check_output(cmd).decode('UTF-8'))
+
+
+@translate_exc(from_exc=OSError, to_exc=NotImplementedError)
 def is_leader():
     """Does the current unit hold the juju leadership
 

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1354,6 +1354,23 @@ class HelpersTest(TestCase):
         self.assertFalse(hookenv.resource_get(None))
 
     @patch('subprocess.check_output')
+    def test_goal_state_unsupported(self, check_output_):
+        check_output_.side_effect = OSError(2, 'goal-state')
+        self.assertRaises(NotImplementedError, hookenv.goal_state)
+
+    @patch('subprocess.check_output')
+    def test_goal_state(self, check_output_):
+        expect = {
+            'units': {},
+            'relations': {},
+        }
+        check_output_.return_value = json.dumps(expect).encode('UTF-8')
+        result = hookenv.goal_state()
+
+        self.assertEqual(result, expect)
+        check_output_.assert_called_with(['goal-state', '--format=json'])
+
+    @patch('subprocess.check_output')
     def test_is_leader_unsupported(self, check_output_):
         check_output_.side_effect = OSError(2, 'is-leader')
         self.assertRaises(NotImplementedError, hookenv.is_leader)


### PR DESCRIPTION
- Returns json provided by the goal-state hook command
- Raises NotImplementedError when goal-state is not available (< Juju 2.4)

Fixes #178 