### PR TITLE
Add 'ovs-vsctl set' interface function

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -134,6 +134,20 @@ def set_manager(manager):
                            'ssl:{}'.format(manager)])
 
 
+def set_Open_vSwitch_column_value(column_value):
+    """
+    Calls ovs-vsctl and sets the 'column_value' in the Open_vSwitch table.
+
+    :param column_value:
+            See http://www.openvswitch.org//ovs-vswitchd.conf.db.5.pdf for
+            details of the relevant values.
+    :type str
+    :raises CalledProcessException: possibly ovsdb-server is not running
+    """
+    log('Setting {} in the Open_vSwitch table'.format(column_value))
+    subprocess.check_call(['ovs-vsctl', 'set', 'Open_vSwitch', '.', column_value])
+
+
 CERT_PATH = '/etc/openvswitch/ovsclient-cert.pem'
 
 

--- a/tests/contrib/network/test_ovs.py
+++ b/tests/contrib/network/test_ovs.py
@@ -205,6 +205,13 @@ class OVSHelpersTest(unittest.TestCase):
                                        'ssl:manager'])
         self.assertTrue(self.log.call_count == 1)
 
+    @patch('subprocess.check_call')
+    def test_set_Open_vSwitch_column_value(self, check_call):
+        ovs.set_Open_vSwitch_column_value('other_config:foo=bar')
+        check_call.assert_called_with(['ovs-vsctl', 'set',
+                                       'Open_vSwitch', '.', 'other_config:foo=bar'])
+        self.assertTrue(self.log.call_count == 1)
+
     @patch('os.path.exists')
     def test_get_certificate_good_cert(self, exists):
         exists.return_value = True


### PR DESCRIPTION
The added functions allow direct amnipulation of the OVSDB tables
and setting specific values.
 * set_value - set entries in an arbitrary table
 * set_value_Open_vSwitch - a shortcut to Open_vSwitch table

Signed-off-by: Nikolay Nikolaev <nikolay.nikolaev@canonical.com>