### PR TITLE
ovs: long interface names and existing wiring

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ''' Helpers for interacting with OpenvSwitch '''
+import hashlib
 import subprocess
 import os
 import six
@@ -38,6 +39,8 @@ iface {linuxbridge_port} inet manual
     up ip link set {linuxbridge_port} up
     down ip link del {linuxbridge_port}
 """
+
+MAX_KERNEL_INTERFACE_NAME_LEN = 15
 
 
 def add_bridge(name, datapath_type=None):
@@ -92,15 +95,38 @@ def add_ovsbridge_linuxbridge(name, bridge):
             apt_install('python3-netifaces', fatal=True)
         import netifaces
 
+    # NOTE(jamespage):
+    # Older code supported addition of a linuxbridge directly
+    # to an OVS bridge; ensure we don't break uses on upgrade
+    existing_ovs_bridge = port_to_br(bridge)
+    if existing_ovs_bridge is not None:
+        log('Linuxbridge {} is already directly in use'
+            ' by OVS bridge {}'.format(bridge, existing_ovs_bridge),
+            level=INFO)
+        return
+
+    # NOTE(jamespage):
+    # preserve existing naming because interfaces may already exist.
     ovsbridge_port = "veth-" + name
     linuxbridge_port = "veth-" + bridge
-    log('Adding linuxbridge {} to ovsbridge {}'.format(bridge, name),
-        level=INFO)
+    if (len(ovsbridge_port) > MAX_KERNEL_INTERFACE_NAME_LEN or
+            len(linuxbridge_port) > MAX_KERNEL_INTERFACE_NAME_LEN):
+        # NOTE(jamespage):
+        # use parts of hashed bridgename (openstack style) when
+        # a bridge name exceeds 15 chars
+        hashed_bridge = hashlib.sha256(bridge.encode('UTF-8')).hexdigest()
+        base = '{}-{}'.format(hashed_bridge[:8], hashed_bridge[-2:])
+        ovsbridge_port = "cvo{}".format(base)
+        linuxbridge_port = "cvb{}".format(base)
+
     interfaces = netifaces.interfaces()
     for interface in interfaces:
         if interface == ovsbridge_port or interface == linuxbridge_port:
             log('Interface {} already exists'.format(interface), level=INFO)
             return
+
+    log('Adding linuxbridge {} to ovsbridge {}'.format(bridge, name),
+        level=INFO)
 
     check_for_eni_source()
 
@@ -208,3 +234,16 @@ def disable_ipfix(bridge):
     '''
     cmd = ['ovs-vsctl', 'clear', 'Bridge', bridge, 'ipfix']
     subprocess.check_call(cmd)
+
+
+def port_to_br(port):
+    '''Determine the bridge that contains a port
+    :param port: Name of port to check for
+    :returns str: OVS bridge containing port or None if not found
+    '''
+    try:
+        return subprocess.check_output(
+            ['ovs-vsctl', 'port-to-br', port]
+        ).decode('UTF-8').strip()
+    except subprocess.CalledProcessError:
+        return None


### PR DESCRIPTION
Linux interface names are a maximum of 15 characters; ensure that
when wiring an ovs bridge to a linux bridge, the generated veth
pair naming is below this limit by using parts of the hash of
the bridge name.

Any existing use of this feature will remain unchanged as this
is only used when the generated bridge name is > 15 characters.

This commit also fixes an issue when a linuxbridge was previously
directly wired into ovs bridge - this was supported in older
code versions, and we need to ensure we don't break users who
have leveraged this feature on upgrades.