### PR TITLE
Don't update updatedb.conf file if not available

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -972,6 +972,20 @@ def is_container():
 
 
 def add_to_updatedb_prunepath(path, updatedb_path=UPDATEDB_PATH):
+    """Adds the specified path to the mlocate's udpatedb.conf PRUNEPATH list.
+
+    This method has no effect if the path specified by updatedb_path does not
+    exist or is not a file.
+
+    @param path: string the path to add to the updatedb.conf PRUNEPATHS value
+    @param updatedb_path: the path the updatedb.conf file
+    """
+    if not os.path.exists(updatedb_path) or os.path.isdir(updatedb_path):
+        # If the updatedb.conf file doesn't exist then don't attempt to update
+        # the file as the package providing mlocate may not be installed on
+        # the local system
+        return
+
     with open(updatedb_path, 'r+') as f_id:
         updatedb_text = f_id.read()
         output = updatedb(updatedb_text, path)

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1855,6 +1855,27 @@ class HelpersTest(TestCase):
         handle.write.assert_called_once_with(
             'PRUNEPATHS="/tmp /srv/node /tmp/test"')
 
+    @patch.object(host, 'os')
+    def test_prunepaths_no_updatedb_conf_file(self, mock_os):
+        mock_os.path.exists.return_value = False
+        _open = mock_open(read_data='PRUNEPATHS="/tmp /srv/node"')
+        with patch('charmhelpers.core.host.open', _open, create=True):
+            host.add_to_updatedb_prunepath("/tmp/test")
+        handle = _open()
+
+        self.assertTrue(handle.call_count == 0)
+
+    @patch.object(host, 'os')
+    def test_prunepaths_updatedb_conf_file_isdir(self, mock_os):
+        mock_os.path.exists.return_value = True
+        mock_os.path.isdir.return_value = True
+        _open = mock_open(read_data='PRUNEPATHS="/tmp /srv/node"')
+        with patch('charmhelpers.core.host.open', _open, create=True):
+            host.add_to_updatedb_prunepath("/tmp/test")
+        handle = _open()
+
+        self.assertTrue(handle.call_count == 0)
+
     @patch.object(host, 'local_unit')
     def test_modulo_distribution(self, local_unit):
         local_unit.return_value = 'test/7'


### PR DESCRIPTION
The charmhelpers.core.host.add_to_updatedb_prunepath assumes that
the /etc/updatedb.conf file exists. This patch adds a check to
ensure that the path exists and is not a directory before attempting
to read or write the contents of the file.

Related-Bug: LP#1759145
Fixes: #179