### PR TITLE
Add goal_state_filter_self_relations()

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1004,6 +1004,22 @@ def goal_state():
     return json.loads(subprocess.check_output(cmd).decode('UTF-8'))
 
 
+def goal_state_filter_self_relations():
+    """Juju goal state values with own application units filtered out from
+    relations data.
+
+    :returns: Juju goal-state data
+    :rtype: dict
+    """
+    _goal_state = goal_state()
+    for rel in _goal_state.get('relations', []):
+        app = application_name()
+        if app in _goal_state['relations'][rel]:
+            del _goal_state['relations'][rel][app]
+
+    return _goal_state
+
+
 @translate_exc(from_exc=OSError, to_exc=NotImplementedError)
 def is_leader():
     """Does the current unit hold the juju leadership

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1371,6 +1371,34 @@ class HelpersTest(TestCase):
         self.assertEqual(result, expect)
         check_output_.assert_called_with(['goal-state', '--format=json'])
 
+    @patch('charmhelpers.core.hookenv.goal_state')
+    @patch('charmhelpers.core.hookenv.application_name')
+    def test_goal_state_filter_self_relations(self, application_name_,
+                                              goal_state_):
+        application_name_.return_value = 'keystone'
+        goal_state_.return_value = {
+            'units': {'keystone/0': {}, 'keystone/1': {}},
+            'relations': {
+                'identity-service': {
+                    'glance': {},
+                    'keystone': {},
+                },
+            },
+        }
+        expect = {
+            'units': {'keystone/0': {}, 'keystone/1': {}},
+            'relations': {
+                'identity-service': {
+                    'glance': {},
+                },
+            },
+        }
+        result = hookenv.goal_state_filter_self_relations()
+
+        self.assertEqual(result, expect)
+        application_name_.assert_called_with()
+        goal_state_.assert_called_with()
+
     @patch('subprocess.check_output')
     def test_is_leader_unsupported(self, check_output_):
         check_output_.side_effect = OSError(2, 'is-leader')


### PR DESCRIPTION
When Juju `goal-state` lists expected relations the list
includes your own application.

In some cases a charm is only interested in what other
applications will be joining the relation and it is useful
to have a common way of doing that.