### PR TITLE
Retry importing key on failure.

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -315,7 +315,7 @@ def import_key(key):
         cmd = ['apt-key', 'adv', '--keyserver',
                'hkp://keyserver.ubuntu.com:80', '--recv-keys', key]
         try:
-            subprocess.check_call(cmd)
+            _run_with_retries(cmd)
         except subprocess.CalledProcessError:
             error = "Error importing PGP key '{}'".format(key)
             log(error)


### PR DESCRIPTION
Sometimes fetching a key from a keyserver fails sporadically.

For example, timeouts related to this issue have been causing
soradic failures lately:

https://bitbucket.org/skskeyserver/sks-keyserver/issues/60/denial-of-service-via-large-uid-packets

By retrying key fetching, the impact of these sporadic failures can
be reduced.