### PR TITLE
Support multiple WSGI vhosts in Openstack

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1389,11 +1389,12 @@ class WorkerConfigContext(OSContextGenerator):
 class WSGIWorkerConfigContext(WorkerConfigContext):
 
     def __init__(self, name=None, script=None, admin_script=None,
-                 public_script=None, process_weight=1.00,
+                 public_script=None, user=None, group=None,
+                 process_weight=1.00,
                  admin_process_weight=0.25, public_process_weight=0.75):
         self.service_name = name
-        self.user = name
-        self.group = name
+        self.user = user or name
+        self.group = group or name
         self.script = script
         self.admin_script = admin_script
         self.public_script = public_script

--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -14,7 +14,7 @@ Listen {{ public_port }}
 
 {% if port -%}
 <VirtualHost *:{{ port }}>
-    WSGIDaemonProcess {{ service_name }} processes={{ processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
+    WSGIDaemonProcess {{ service_name }} processes={{ processes }} threads={{ threads }} user={{ user }} group={{ group }} \
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}
     WSGIScriptAlias / {{ script }}
@@ -40,7 +40,7 @@ Listen {{ public_port }}
 
 {% if admin_port -%}
 <VirtualHost *:{{ admin_port }}>
-    WSGIDaemonProcess {{ service_name }}-admin processes={{ admin_processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
+    WSGIDaemonProcess {{ service_name }}-admin processes={{ admin_processes }} threads={{ threads }} user={{ user }} group={{ group }} \
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}-admin
     WSGIScriptAlias / {{ admin_script }}
@@ -66,7 +66,7 @@ Listen {{ public_port }}
 
 {% if public_port -%}
 <VirtualHost *:{{ public_port }}>
-    WSGIDaemonProcess {{ service_name }}-public processes={{ public_processes }} threads={{ threads }} user={{ service_name }} group={{ service_name }} \
+    WSGIDaemonProcess {{ service_name }}-public processes={{ public_processes }} threads={{ threads }} user={{ user }} group={{ group }} \
                       display-name=%{GROUP}
     WSGIProcessGroup {{ service_name }}-public
     WSGIScriptAlias / {{ public_script }}

--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-metadata.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-metadata.conf
@@ -1,0 +1,1 @@
+wsgi-openstack-api.conf

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2893,6 +2893,33 @@ class ContextTests(unittest.TestCase):
         }
         self.assertEqual(expect, ctxt())
 
+    @patch.object(context, '_calculate_workers')
+    def test_wsgi_worker_config_context_user_and_group(self,
+                                                       _calculate_workers):
+        self.config.return_value = 1
+        _calculate_workers.return_value = 1
+        service_name = 'service-name'
+        script = '/usr/bin/script'
+        user = 'nova'
+        group = 'nobody'
+        ctxt = context.WSGIWorkerConfigContext(name=service_name,
+                                               user=user,
+                                               group=group,
+                                               script=script)
+        expect = {
+            "service_name": service_name,
+            "user": user,
+            "group": group,
+            "script": script,
+            "admin_script": None,
+            "public_script": None,
+            "processes": 1,
+            "admin_processes": 1,
+            "public_processes": 1,
+            "threads": 1,
+        }
+        self.assertEqual(expect, ctxt())
+
     def test_zeromq_context_unrelated(self):
         self.is_relation_made.return_value = False
         self.assertEquals(context.ZeroMQContext()(), {})


### PR DESCRIPTION
The current WSGIWorkerConfigContext cannot be used to support
multiple wsgi vhosts for the same user because the WSGIDaemonProcess
'name' attribute must be different between the two vhosts but the
'name' is also used to dictate the user and group. This change
allows the user and group to be explicitly set. The allows for
multiple wsgi vhosts for user X with different WSGIDaemonProcess
names.