### PR TITLE
ensure max lenght of message in log func

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -48,6 +48,7 @@ INFO = "INFO"
 DEBUG = "DEBUG"
 TRACE = "TRACE"
 MARKER = object()
+SH_MAX_ARG = 131071
 
 cache = {}
 
@@ -98,7 +99,7 @@ def log(message, level=None):
         command += ['-l', level]
     if not isinstance(message, six.string_types):
         message = repr(message)
-    command += [message]
+    command += [message[:SH_MAX_ARG]]
     # Missing juju-log should not cause failures in unit tests
     # Send log output to stderr
     try:


### PR DESCRIPTION
This PR limits the length of the message to be passed to `juju-log`;

preventing errors like below:
```
2018-08-31 04:25:24 DEBUG worker.uniter.jujuc server.go:181 running hook tool "juju-log"
2018-08-31 04:25:24 ERROR juju-log redis:0: Hook error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/charms/reactive/__init__.py", line 73, in main
    bus.dispatch(restricted=restricted_mode)
  File "/usr/local/lib/python3.6/dist-packages/charms/reactive/bus.py", line 382, in dispatch
    _invoke(other_handlers)
  File "/usr/local/lib/python3.6/dist-packages/charms/reactive/bus.py", line 358, in _invoke
    handler.invoke()
  File "/usr/local/lib/python3.6/dist-packages/charms/reactive/bus.py", line 180, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubeflow-seldon-cluster-manager-0/charm/reactive/kubeflow_seldon_cluster_manager.py", line 51, in start_charm
    layer.caas_base.pod_spec_set(yaml.load(rendered_podspec))
  File "lib/charms/layer/caas_base.py", line 15, in pod_spec_set
    log('set pod spec:\n{}'.format(spec), level='TRACE')
  File "/usr/local/lib/python3.6/dist-packages/charmhelpers/core/hookenv.py", line 105, in log
    subprocess.call(command)
  File "lib/charms/layer/status.py", line 165, in _patched_call
    return _orig_call(cmd, *args, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 267, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 7] Argument list too long: 'juju-log'
```
