### PR TITLE
Adding new parameters into Neutron ctxt to make NSG logging configurable

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1519,6 +1519,14 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-qos',
                 'default': False,
             },
+            'enable_nsg_logging': {
+                'rel_key': 'enable-nsg-logging',
+                'default': False,
+            },
+            'nsg_log_output_base': {
+                'rel_key': 'nsg-log-output-base',
+                'default': None,
+            },
         }
         ctxt = self.get_neutron_options({})
         for rid in relation_ids('neutron-plugin-api'):


### PR DESCRIPTION
In scope of https://bugs.launchpad.net/charm-neutron-api/+bug/1787397 I'd like to extend Neutron context to let it pass two new parameters: 

- enable_nsg_logging: "on/off" switch for neutron-api & OVS nodes
- nsg_log_output_base: basepath for logging output; defaults to None (in this case logs will be streamed to syslog)