### PR TITLE
Add helpers for common series upgrade tasks

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1733,3 +1733,19 @@ def is_unit_upgrading_set():
             return not(not(kv.get('unit-upgrading')))
     except Exception:
         return False
+
+
+def series_upgrade_prepare(pause_unit_helper=None, configs=None):
+    """ Run common series upgrade prepare tasks."""
+    set_unit_upgrading()
+    if pause_unit_helper and configs:
+        if not is_unit_paused_set():
+            pause_unit_helper(configs)
+
+
+def series_upgrade_complete(resume_unit_helper=None, configs=None):
+    """ Run common series upgrade complete tasks."""
+    clear_unit_paused()
+    clear_unit_upgrading()
+    if resume_unit_helper and configs:
+        resume_unit_helper(configs)

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1718,6 +1718,39 @@ class OpenStackHelpersTestCase(TestCase):
         mock_snap_install.assert_called_with(
             'os_project', '--channel=pike', '--jailmode')
 
+    @patch.object(openstack, 'set_unit_upgrading')
+    @patch.object(openstack, 'is_unit_paused_set')
+    def test_series_upgrade_prepare(
+            self, is_unit_paused_set, set_unit_upgrading):
+        is_unit_paused_set.return_value = False
+        fake_pause_helper = MagicMock()
+        fake_configs = MagicMock()
+        openstack.series_upgrade_prepare(fake_pause_helper, fake_configs)
+        set_unit_upgrading.assert_called_once()
+        fake_pause_helper.assert_called_once_with(fake_configs)
+
+    @patch.object(openstack, 'set_unit_upgrading')
+    @patch.object(openstack, 'is_unit_paused_set')
+    def test_series_upgrade_prepare_no_pause(
+            self, is_unit_paused_set, set_unit_upgrading):
+        is_unit_paused_set.return_value = True
+        fake_pause_helper = MagicMock()
+        fake_configs = MagicMock()
+        openstack.series_upgrade_prepare(fake_pause_helper, fake_configs)
+        set_unit_upgrading.assert_called_once()
+        fake_pause_helper.assert_not_called()
+
+    @patch.object(openstack, 'clear_unit_upgrading')
+    @patch.object(openstack, 'clear_unit_paused')
+    def test_series_upgrade_complete(
+            self, clear_unit_paused, clear_unit_upgrading):
+        fake_resume_helper = MagicMock()
+        fake_configs = MagicMock()
+        openstack.series_upgrade_complete(fake_resume_helper, fake_configs)
+        clear_unit_upgrading.assert_called_once()
+        clear_unit_paused.assert_called_once()
+        fake_resume_helper.assert_called_once_with(fake_configs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For many of the OpenStack API charms the tasks for series upgrade
prepare and complete are the same between charms. These helpers run
those common tasks.