### PR TITLE
Write all configs on series upgrade complete

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1736,7 +1736,12 @@ def is_unit_upgrading_set():
 
 
 def series_upgrade_prepare(pause_unit_helper=None, configs=None):
-    """ Run common series upgrade prepare tasks."""
+    """ Run common series upgrade prepare tasks.
+
+    :param pause_unit_helper: function: Function to pause unit
+    :param configs: OSConfigRenderer object: Configurations
+    :returns None:
+    """
     set_unit_upgrading()
     if pause_unit_helper and configs:
         if not is_unit_paused_set():
@@ -1744,8 +1749,15 @@ def series_upgrade_prepare(pause_unit_helper=None, configs=None):
 
 
 def series_upgrade_complete(resume_unit_helper=None, configs=None):
-    """ Run common series upgrade complete tasks."""
+    """ Run common series upgrade complete tasks.
+
+    :param resume_unit_helper: function: Function to resume unit
+    :param configs: OSConfigRenderer object: Configurations
+    :returns None:
+    """
     clear_unit_paused()
     clear_unit_upgrading()
-    if resume_unit_helper and configs:
-        resume_unit_helper(configs)
+    if configs:
+        configs.write_all()
+        if resume_unit_helper:
+            resume_unit_helper(configs)

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1749,6 +1749,7 @@ class OpenStackHelpersTestCase(TestCase):
         openstack.series_upgrade_complete(fake_resume_helper, fake_configs)
         clear_unit_upgrading.assert_called_once()
         clear_unit_paused.assert_called_once()
+        fake_configs.write_all.assert_called_once()
         fake_resume_helper.assert_called_once_with(fake_configs)
 
 


### PR DESCRIPTION
It is necessary to write out configs prior to attempting to resume a
unit after a series upgrade as configurations may be missing.
Add the OSConfigRenderer.write_all() to the series_upgrade_complete
function.