### PR TITLE
Remove unnecessary charm relation option

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1523,10 +1523,6 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-nsg-logging',
                 'default': False,
             },
-            'nsg_log_output_base': {
-                'rel_key': 'nsg-log-output-base',
-                'default': None,
-            },
         }
         ctxt = self.get_neutron_options({})
         for rid in relation_ids('neutron-plugin-api'):


### PR DESCRIPTION
In scope of https://review.openstack.org/#/c/602780/6/hooks/neutron_ovs_context.py review I'd like to remove unnecessary context variable and make that option configurable via charm config itself.