### PR TITLE
Allow cirros image virt type to be set

### DIFF
--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -682,7 +682,7 @@ class OpenStackAmuletUtils(AmuletUtils):
 
     def glance_create_image(self, glance, image_name, image_url,
                             download_dir='tests',
-                            hypervisor_type='qemu',
+                            hypervisor_type=None,
                             disk_format='qcow2',
                             architecture='x86_64',
                             container_format='bare'):
@@ -703,6 +703,7 @@ class OpenStackAmuletUtils(AmuletUtils):
         self.log.debug('Creating glance image ({}) from '
                        '{}...'.format(image_name, image_url))
 
+        hypervisor_type = hypervisor_type or 'qemu'
         # Download image
         http_proxy = os.getenv('AMULET_HTTP_PROXY')
         self.log.debug('AMULET_HTTP_PROXY: {}'.format(http_proxy))
@@ -776,12 +777,13 @@ class OpenStackAmuletUtils(AmuletUtils):
 
         return image
 
-    def create_cirros_image(self, glance, image_name):
+    def create_cirros_image(self, glance, image_name, hypervisor_type=None):
         """Download the latest cirros image and upload it to glance,
         validate and return a resource pointer.
 
         :param glance: pointer to authenticated glance connection
         :param image_name: display name for new image
+        :param hypervisor_type: glance image hypervisor property
         :returns: glance image pointer
         """
         # /!\ DEPRECATION WARNING
@@ -808,7 +810,11 @@ class OpenStackAmuletUtils(AmuletUtils):
                                               version, cirros_img)
         f.close()
 
-        return self.glance_create_image(glance, image_name, cirros_url)
+        return self.glance_create_image(
+            glance,
+            image_name,
+            cirros_url,
+            hypervisor_type=hypervisor_type)
 
     def delete_image(self, glance, image):
         """Delete the specified image."""


### PR DESCRIPTION
Allow the virt type property of the image to the cirros image to be
explicitly set.