### PR TITLE
Ensure auth_uri/auth_url include v3 API version

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -1,12 +1,14 @@
 {% if auth_host -%}
 [keystone_authtoken]
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
-auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
 auth_type = password
 {% if api_version == "3" -%}
+auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v3
+auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
 project_domain_name = {{ admin_domain_name }}
 user_domain_name = {{ admin_domain_name }}
 {% else -%}
+auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
+auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
 project_domain_name = default
 user_domain_name = default
 {% endif -%}


### PR DESCRIPTION
Update the keystone authtoken template section to explicitly
specify v3 API when it is in use. This prevents errors that
result in "Could not find versioned identity endpoints when
attempting to authenticate".

Related-Bug: #1794637 on launchpad