### PR TITLE
Enable the apache audit checks to also be PY3 compatible

### DIFF
--- a/charmhelpers/contrib/hardening/apache/checks/config.py
+++ b/charmhelpers/contrib/hardening/apache/checks/config.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import six
 import subprocess
 
 
@@ -95,6 +96,8 @@ class ApacheConfContext(object):
         ctxt = settings['hardening']
 
         out = subprocess.check_output(['apache2', '-v'])
+        if six.PY3:
+            out = out.decode('utf-8')
         ctxt['apache_version'] = re.search(r'.+version: Apache/(.+?)\s.+',
                                            out).group(1)
         ctxt['apache_icondir'] = '/usr/share/apache2/icons/'

--- a/charmhelpers/contrib/hardening/audits/apache.py
+++ b/charmhelpers/contrib/hardening/audits/apache.py
@@ -15,7 +15,7 @@
 import re
 import subprocess
 
-from six import string_types
+import six
 
 from charmhelpers.core.hookenv import (
     log,
@@ -35,7 +35,7 @@ class DisabledModuleAudit(BaseAudit):
     def __init__(self, modules):
         if modules is None:
             self.modules = []
-        elif isinstance(modules, string_types):
+        elif isinstance(modules, six.string_types):
             self.modules = [modules]
         else:
             self.modules = modules
@@ -69,6 +69,8 @@ class DisabledModuleAudit(BaseAudit):
     def _get_loaded_modules():
         """Returns the modules which are enabled in Apache."""
         output = subprocess.check_output(['apache2ctl', '-M'])
+        if six.PY3:
+            output = output.decode('utf-8')
         modules = []
         for line in output.splitlines():
             # Each line of the enabled module output looks like:

--- a/tests/contrib/hardening/apache/checks/test_config.py
+++ b/tests/contrib/hardening/apache/checks/test_config.py
@@ -22,7 +22,7 @@ from mock import patch
 from charmhelpers.contrib.hardening.apache.checks import config
 
 TEST_TMPDIR = None
-APACHE_VERSION_STR = """Server version: Apache/2.4.7 (Ubuntu)
+APACHE_VERSION_STR = b"""Server version: Apache/2.4.7 (Ubuntu)
 Server built:   Jan 14 2016 17:45:23
 """
 

--- a/tests/contrib/hardening/audits/test_apache_audits.py
+++ b/tests/contrib/hardening/audits/test_apache_audits.py
@@ -78,9 +78,9 @@ class DisabledModuleAuditsTest(TestCase):
 
     @patch('subprocess.check_output')
     def test_get_loaded_modules(self, mock_check_output):
-        mock_check_output.return_value = ('Loaded Modules:\n'
-                                          ' foo_module (static)\n'
-                                          ' bar_module (shared)\n')
+        mock_check_output.return_value = (b'Loaded Modules:\n'
+                                          b' foo_module (static)\n'
+                                          b' bar_module (shared)\n')
         audit = apache.DisabledModuleAudit('bar')
         result = audit._get_loaded_modules()
         self.assertEqual(['foo', 'bar'], result)

--- a/tests/contrib/hardening/test_templating.py
+++ b/tests/contrib/hardening/test_templating.py
@@ -238,7 +238,7 @@ class TemplatingTestCase(TestCase):
     def test_apache_conf_and_check(self, mock_write, mock_ensure_permissions,
                                    mock_subprocess):
         mock_subprocess.call.return_value = 0
-        apache_version = """Server version: Apache/2.4.7 (Ubuntu)
+        apache_version = b"""Server version: Apache/2.4.7 (Ubuntu)
         Server built:   Jan 14 2016 17:45:23
         """
         mock_subprocess.check_output.return_value = apache_version


### PR DESCRIPTION
This is needed for the openstack-dashboard charm's migration to PY3.