### PR TITLE
Add {series} support to _add_apt_repository

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -454,6 +454,9 @@ def _add_apt_repository(spec):
 
     :param spec: the parameter to pass to add_apt_repository
     """
+    if '{series}' in spec:
+        series = lsb_release()['DISTRIB_CODENAME']
+        spec = spec.replace('{series}', series)
     _run_with_retries(['add-apt-repository', '--yes', spec])
 
 


### PR DESCRIPTION
Allows sources to include a `{series}` placeholder that will be populated automatically with the correct Ubuntu series.

Closes #229