### PR TITLE
Update openstack amulet helper to permit proposed uca pocket

### DIFF
--- a/charmhelpers/contrib/openstack/amulet/deployment.py
+++ b/charmhelpers/contrib/openstack/amulet/deployment.py
@@ -294,7 +294,8 @@ class OpenStackAmuletDeployment(AmuletDeployment):
             ('bionic', 'cloud:bionic-rocky'): self.bionic_rocky,
             ('cosmic', None): self.cosmic_rocky,
         }
-        return releases[(self.series, self.openstack)]
+        # Strip cloud archive pockets from origin, ie. /proposed /staging
+        return releases[(self.series, self.openstack.split('/')[0])]
 
     def _get_openstack_release_string(self):
         """Get openstack release string.


### PR DESCRIPTION
This will allow flipping a test suite to the "proposed" Ubuntu Cloud Archive pocket (or staging, etc).

ex.

https://review.openstack.org/#/c/614797/2/src/tests/gate-basic-bionic-rocky