### PR TITLE
Consistently render haproxy.conf (#237)

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -642,7 +642,7 @@ class HAProxyContext(OSContextGenerator):
             return {}
 
         l_unit = local_unit().replace('/', '-')
-        cluster_hosts = {}
+        cluster_hosts = collections.OrderedDict()
 
         # NOTE(jamespage): build out map of configured network endpoints
         # and associated backends


### PR DESCRIPTION
Change the primitive python dict to an OrderedDict to ensure
consistent rendering of the haproxy.conf file. The frontends
variable referenced in the haproxy.conf template uses simple
dict traversal which is not guaranteed to provide consistent
ordreing across hook invocations.

Fixes #237