### PR TITLE
Add "host" option to "connect" method

### DIFF
--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -78,9 +78,11 @@ class MySQLHelper(object):
         self.delete_ondisk_passwd_file = delete_ondisk_passwd_file
         self.connection = None
 
-    def connect(self, user='root', password=None):
-        log("Opening db connection for %s@%s" % (user, self.host), level=DEBUG)
-        self.connection = MySQLdb.connect(user=user, host=self.host,
+    def connect(self, user='root', password=None, host=None):
+        if host is None:
+            host = self.host
+        log("Opening db connection for %s@%s" % (user, host), level=DEBUG)
+        self.connection = MySQLdb.connect(user=user, host=host,
                                           passwd=password)
 
     def database_exists(self, db_name):

--- a/tests/contrib/database/test_mysql.py
+++ b/tests/contrib/database/test_mysql.py
@@ -11,9 +11,32 @@ sys.modules['MySQLdb'] = mock.Mock()
 from charmhelpers.contrib.database import mysql  # noqa
 
 
+try:
+    import MySQLdb
+except ImportError:
+    apt_update(fatal=True)
+    if six.PY2:
+        apt_install(filter_installed_packages(['python-mysqldb']), fatal=True)
+    else:
+        apt_install(filter_installed_packages(['python3-mysqldb']), fatal=True)
+    import MySQLdb
+
+
 class MysqlTests(unittest.TestCase):
     def setUp(self):
         super(MysqlTests, self).setUp()
+
+    @mock.patch.object(MySQLdb, 'connect')
+    def test_connect_host_defined(self, mock_connect):
+        helper = mysql.MySQLHelper('foo', 'bar', host='hostA')
+        helper.connect(user='user', password='password', host='1.1.1.1')
+        mock_connect.assert_called_with('user', '1.1.1.1', 'password')
+
+    @mock.patch.object(MySQLdb, 'connect')
+    def test_connect_host_not_defined(self, mock_connect):
+        helper = mysql.MySQLHelper('foo', 'bar', host='hostA')
+        helper.connect(user='user', password='password')
+        mock_connect.assert_called_with('user', 'localhost', 'password')
 
     @mock.patch.object(mysql.MySQLHelper, 'normalize_address')
     @mock.patch.object(mysql.MySQLHelper, 'get_mysql_password')


### PR DESCRIPTION
This patchset allows specifying the host against which the "connect"
method is executed.

Needed-By: https://review.openstack.org/#/c/576792/
Partial-Bug: 1776171