### PR TITLE
Add "proposed" to get_os_codename_install_source function

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -299,7 +299,7 @@ def get_os_codename_install_source(src):
     rel = ''
     if src is None:
         return rel
-    if src in ['distro', 'distro-proposed']:
+    if src in ['distro', 'distro-proposed', 'proposed']:
         try:
             rel = UBUNTU_OPENSTACK_RELEASE[ubuntu_rel]
         except KeyError:

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -189,6 +189,9 @@ class OpenStackHelpersTestCase(TestCase):
         self.assertEquals(openstack.get_os_codename_install_source(
             'distro-proposed'),
             'essex')
+        self.assertEquals(openstack.get_os_codename_install_source(
+            'proposed'),
+            'essex')
 
         # various cloud archive pockets
         src = 'cloud:precise-grizzly'


### PR DESCRIPTION
In fetch.ubuntu.add_source() the "proposed" and "distro-proposed"
strings are synonyms for each other.  However, in the
contrib.openstack.utils.get_os_codename_install_source() function the
"proposed" string is not handled.  This patch just adds "proposed" to
the get_os_codename_install_source function.

Closes-Bug: 241