### PR TITLE
Fix loopback devices helper for PY3

### DIFF
--- a/charmhelpers/contrib/storage/linux/loopback.py
+++ b/charmhelpers/contrib/storage/linux/loopback.py
@@ -36,8 +36,10 @@ def loopback_devices():
     '''
     loopbacks = {}
     cmd = ['losetup', '-a']
-    devs = [d.strip().split(' ') for d in
-            check_output(cmd).splitlines() if d != '']
+    output = check_output(cmd)
+    if six.PY3:
+        output = output.decode('utf-8')
+    devs = [d.strip().split(' ') for d in output.splitlines() if d != '']
     for dev, _, f in devs:
         loopbacks[dev.replace(':', '')] = re.search(r'\((\S+)\)', f).groups()[0]
     return loopbacks

--- a/tests/contrib/storage/test_linux_storage_loopback.py
+++ b/tests/contrib/storage/test_linux_storage_loopback.py
@@ -4,7 +4,7 @@ from mock import patch
 
 import charmhelpers.contrib.storage.linux.loopback as loopback
 
-LOOPBACK_DEVICES = """
+LOOPBACK_DEVICES = b"""
 /dev/loop0: [0805]:2244465 (/tmp/foo.img)
 /dev/loop1: [0805]:2244466 (/tmp/bar.img)
 /dev/loop2: [0805]:2244467 (/tmp/baz.img)


### PR DESCRIPTION
This fixes the contrib.storage.linux.loopback.loopback_devices()
function so that it works in PY3.

Related-Bug: LP#1804128