### PR TITLE
Extract common code to pause/resume services

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1341,8 +1341,8 @@ def manage_payload_services(action, services=None, charm_func=None):
     action = action.lower()
     if action not in actions.keys():
         raise RuntimeError(
-            "action: {} must be on of: {}".format(action,
-                                                  ', '.join(actions.keys())))
+            "action: {} must be one of: {}".format(action,
+                                                   ', '.join(actions.keys())))
     services = _extract_services_list_helper(services)
     messages = []
     success = True

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1428,6 +1428,12 @@ class OpenStackHelpersTestCase(TestCase):
             (False, ['it failed']))
         bespoke_func.assert_called_once_with()
 
+    def test_manage_payload_services_wrong_action(self):
+        self.assertRaises(
+            RuntimeError,
+            openstack.manage_payload_services,
+            'mangle')
+
     @patch('charmhelpers.contrib.openstack.utils.service_pause')
     @patch('charmhelpers.contrib.openstack.utils.set_unit_paused')
     def test_pause_unit_okay(self, set_unit_paused, service_pause):


### PR DESCRIPTION
Extract common code to pause/resume services into a new function
'manage_payload_services'. This can then be used for any action
that needs to be applied to all services (like stop and start).