### PR TITLE
Update copy_nrpe_checks() for optional c-h directory (#247)

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -416,15 +416,20 @@ def copy_nrpe_checks(nrpe_files_dir=None):
 
     """
     NAGIOS_PLUGINS = '/usr/local/lib/nagios/plugins'
-    default_nrpe_files_dir = os.path.join(
-        os.getenv('CHARM_DIR'),
-        'hooks',
-        'charmhelpers',
-        'contrib',
-        'openstack',
-        'files')
-    if not nrpe_files_dir:
-        nrpe_files_dir = default_nrpe_files_dir
+    if nrpe_files_dir is None:
+        # determine if "charmhelpers" is in CHARMDIR or CHARMDIR/hooks
+        for segment in ['.', 'hooks']:
+            nrpe_files_dir = os.path.abspath(os.path.join(
+                os.getenv('CHARM_DIR'),
+                segment,
+                'charmhelpers',
+                'contrib',
+                'openstack',
+                'files'))
+            if os.path.isdir(nrpe_files_dir):
+                break
+        else:
+            raise RuntimeError("Couldn't find charmhelpers directory")
     if not os.path.exists(NAGIOS_PLUGINS):
         os.makedirs(NAGIOS_PLUGINS)
     for fname in glob.glob(os.path.join(nrpe_files_dir, "check_*")):

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -25,6 +25,7 @@ class NRPEBaseTestCase(TestCase):
         'remove': {'object': os},
         'open': {'object': nrpe, 'create': True},
         'isfile': {'object': os.path},
+        'isdir': {'object': os.path},
         'call': {'object': subprocess},
         'relation_ids': {'object': nrpe},
         'relation_set': {'object': nrpe},
@@ -370,10 +371,27 @@ class NRPEMiscTestCase(NRPEBaseTestCase):
             'fileb': False}
         self.patched['exists'].return_value = True
         self.patched['glob'].return_value = ['filea', 'fileb']
+        self.patched['isdir'].side_effect = [False, True]
         self.patched['isfile'].side_effect = lambda x: file_presence[x]
         nrpe.copy_nrpe_checks()
         self.patched['glob'].assert_called_once_with(
             ('/usr/lib/test_charm_dir/hooks/charmhelpers/contrib/openstack/'
+             'files/check_*'))
+        self.patched['copy2'].assert_called_once_with(
+            'filea',
+            '/usr/local/lib/nagios/plugins/filea')
+
+    def test_copy_nrpe_checks_other_root(self):
+        file_presence = {
+            'filea': True,
+            'fileb': False}
+        self.patched['exists'].return_value = True
+        self.patched['glob'].return_value = ['filea', 'fileb']
+        self.patched['isdir'].side_effect = [True, False]
+        self.patched['isfile'].side_effect = lambda x: file_presence[x]
+        nrpe.copy_nrpe_checks()
+        self.patched['glob'].assert_called_once_with(
+            ('/usr/lib/test_charm_dir/charmhelpers/contrib/openstack/'
              'files/check_*'))
         self.patched['copy2'].assert_called_once_with(
             'filea',


### PR DESCRIPTION
The function assumed that the charmhelpers directory would always be in
the hooks directory.  However, with PY3 it can be very tricky to try to
keep a symlink in the hooks directory.  Therefore, for some PY3
non-reactive charms, charmhelpers was moved to the CHARMDIR.  However,
this caused this function to fail.

The change here is to search for the charmhelpers directory in both
CHARMDIR and CHARMDIR/hooks and then use that.

Cherry-picked from master

Related-Bug: #246
LP-Bug: #1796830