### PR TITLE
Charms can sepcify additional delete & group info

### DIFF
--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -325,5 +325,5 @@ def update_hacluster_vip(service, relation_data):
             relation_data['groups'][key] = ' '.join(vip_group)
         except KeyError:
             relation_data['groups'] = {
-                'grp_{}_vips'.format(service): ' '.join(vip_group)
+                key: ' '.join(vip_group)
             }

--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -314,9 +314,17 @@ def update_hacluster_vip(service, relation_data):
             vip_group.append(vip_key)
 
     if vips_to_delete:
-        relation_data['delete_resources'] = vips_to_delete
+        try:
+            relation_data['delete_resources'].extend(vips_to_delete)
+        except KeyError:
+            relation_data['delete_resources'] = vips_to_delete
+
 
     if len(vip_group) >= 1:
-        relation_data['groups'] = {
-            'grp_{}_vips'.format(service): ' '.join(vip_group)
-        }
+        key = 'grp_{}_vips'.format(service)
+        try:
+            relation_data['groups'][key] = ' '.join(vip_group)
+        except KeyError:
+            relation_data['groups'] = {
+                'grp_{}_vips'.format(service): ' '.join(vip_group)
+            }

--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -319,7 +319,6 @@ def update_hacluster_vip(service, relation_data):
         except KeyError:
             relation_data['delete_resources'] = vips_to_delete
 
-
     if len(vip_group) >= 1:
         key = 'grp_{}_vips'.format(service)
         try:

--- a/tests/contrib/openstack/ha/test_ha_utils.py
+++ b/tests/contrib/openstack/ha/test_ha_utils.py
@@ -263,13 +263,16 @@ class HATests(unittest.TestCase):
         extra_settings = {
             'colocations': {'vip_cauth': 'inf: res_nova_cauth grp_nova_vips'},
             'init_services': {'res_nova_cauth': 'nova-cauth'},
+            'delete_resources': ['res_ceilometer_polling'],
+            'groups': {'grp_testservice_wombles': 'res_testservice_orinoco'},
         }
         expected = {
             'colocations': {'vip_cauth': 'inf: res_nova_cauth grp_nova_vips'},
             'groups': {
                 'grp_testservice_vips': ('res_testservice_242d562_vip '
                                          'res_testservice_856d56f_vip '
-                                         'res_testservice_f563c5d_vip')
+                                         'res_testservice_f563c5d_vip'),
+                'grp_testservice_wombles': 'res_testservice_orinoco'
             },
             'resource_params': {
                 'res_testservice_242d562_vip': 'params ip="10.5.100.1"',
@@ -290,7 +293,8 @@ class HATests(unittest.TestCase):
                 'res_testservice_haproxy': 'haproxy',
                 'res_nova_cauth': 'nova-cauth'
             },
-            'delete_resources': ["res_testservice_eth1_vip",
+            'delete_resources': ["res_ceilometer_polling",
+                                 "res_testservice_eth1_vip",
                                  "res_testservice_eth1_vip_ipv6addr",
                                  "res_testservice_eth2_vip"],
         }


### PR DESCRIPTION
When a charm calls generate_ha_relation_data allow additional
resources to be deleted and groups to be specified.