### PR TITLE
Use default sqlalchemy driver prior to stein

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -97,6 +97,7 @@ from charmhelpers.contrib.network.ip import (
 )
 from charmhelpers.contrib.openstack.utils import (
     config_flags_parser,
+    get_os_codename_install_source,
     enable_memcache,
     CompareOpenStackReleases,
     os_release,
@@ -240,6 +241,8 @@ class SharedDBContext(OSContextGenerator):
         else:
             rids = relation_ids(self.interfaces[0])
 
+        rel = (get_os_codename_install_source(config('openstack-origin')) or
+               'icehouse')
         for rid in rids:
             self.related = True
             for unit in related_units(rid):
@@ -253,6 +256,8 @@ class SharedDBContext(OSContextGenerator):
                     'database_password': rdata.get(password_setting),
                     'database_type': 'mysql+pymysql'
                 }
+                if CompareOpenStackReleases(rel) < 'stein':
+                    ctxt['database_type'] = 'mysql'
                 if self.context_complete(ctxt):
                     db_ssl(rdata, ctxt, self.ssl_dir)
                     return ctxt

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -722,8 +722,10 @@ class ContextTests(unittest.TestCase):
         base = context.OSContextGenerator()
         self.assertRaises(NotImplementedError, base)
 
-    def test_shared_db_context_with_data(self):
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_with_data(self, os_codename):
         '''Test shared-db context with all required data'''
+        os_codename.return_value = 'stein'
         relation = FakeRelation(relation_data=SHARED_DB_RELATION)
         self.relation_get.side_effect = relation.get
         self.get_address_in_network.return_value = ''
@@ -754,8 +756,11 @@ class ContextTests(unittest.TestCase):
             relation_settings={
                 'hostname': '10.5.5.1'})
 
-    def test_shared_db_context_with_data_and_access_net_match(self):
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_with_data_and_access_net_match(self,
+                                                              os_codename):
         """Correctly set hostname for access net returns complete context"""
+        os_codename.return_value = 'stein'
         relation = FakeRelation(
             relation_data=SHARED_DB_RELATION_ACCESS_NETWORK)
         self.relation_get.side_effect = relation.get
@@ -772,8 +777,10 @@ class ContextTests(unittest.TestCase):
         }
         self.assertEquals(result, expected)
 
-    def test_shared_db_context_explicit_relation_id(self):
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_explicit_relation_id(self, os_codename):
         '''Test shared-db context setting the relation_id'''
+        os_codename.return_value = 'stein'
         relation = FakeRelation(relation_data=SHARED_DB_RELATION_ALT_RID)
         self.related_units.return_value = ['mysql-alt/0']
         self.relation_get.side_effect = relation.get
@@ -820,8 +827,10 @@ class ContextTests(unittest.TestCase):
         db_ssl_ctxt = context.db_ssl(SHARED_DB_RELATION_SSL, {}, None)
         self.assertEquals(db_ssl_ctxt, {})
 
-    def test_shared_db_context_with_missing_relation(self):
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_with_missing_relation(self, os_codename):
         '''Test shared-db context missing relation data'''
+        os_codename.return_value = 'stein'
         incomplete_relation = copy(SHARED_DB_RELATION)
         incomplete_relation['password'] = None
         relation = FakeRelation(relation_data=incomplete_relation)
@@ -842,8 +851,10 @@ class ContextTests(unittest.TestCase):
         shared_db = context.SharedDBContext()
         self.assertRaises(context.OSContextError, shared_db)
 
-    def test_shared_db_context_with_params(self):
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_with_params(self, os_codename):
         '''Test shared-db context with object parameters'''
+        os_codename.return_value = 'stein'
         shared_db = context.SharedDBContext(
             database='quantum', user='quantum', relation_prefix='quantum')
         relation = FakeRelation(relation_data=SHARED_DB_RELATION_NAMESPACED)
@@ -859,11 +870,32 @@ class ContextTests(unittest.TestCase):
                      'database_host': 'bar',
                      'database_type': 'mysql+pymysql'})
 
+    @patch.object(context, 'get_os_codename_install_source')
+    def test_shared_db_context_with_params_rocky(self, os_codename):
+        '''Test shared-db context with object parameters'''
+        os_codename.return_value = 'rocky'
+        shared_db = context.SharedDBContext(
+            database='quantum', user='quantum', relation_prefix='quantum')
+        relation = FakeRelation(relation_data=SHARED_DB_RELATION_NAMESPACED)
+        self.relation_get.side_effect = relation.get
+        result = shared_db()
+        self.assertIn(
+            call(rid='foo:0', unit='foo/0'),
+            self.relation_get.call_args_list)
+        self.assertEquals(
+            result, {'database': 'quantum',
+                     'database_user': 'quantum',
+                     'database_password': 'bar2',
+                     'database_host': 'bar',
+                     'database_type': 'mysql'})
+
+    @patch.object(context, 'get_os_codename_install_source')
     @patch('charmhelpers.contrib.openstack.context.format_ipv6_addr')
-    def test_shared_db_context_with_ipv6(self, format_ipv6_addr):
+    def test_shared_db_context_with_ipv6(self, format_ipv6_addr, os_codename):
         '''Test shared-db context with ipv6'''
         shared_db = context.SharedDBContext(
             database='quantum', user='quantum', relation_prefix='quantum')
+        os_codename.return_value = 'stein'
         relation = FakeRelation(relation_data=SHARED_DB_RELATION_NAMESPACED)
         self.relation_get.side_effect = relation.get
         format_ipv6_addr.return_value = '[2001:db8:1::1]'


### PR DESCRIPTION
Use default sqlalchemy driver prior to stein

For Icehouse -> Rocky, OpenStack packages will successfully use the
default sqlalchemy driver [1] when only 'mysql' is specified in the
connection string. For Stein, the mysqldb driver must be overridden
with 'mysql+pymysql' in connection strings.

[1] Based on the OpenStack release, the sqlalchemy package defaults
to the following drivers:
  Stein+: mysqldb
  Mitaka-Rocky: pymysql
  Icehouse: mysqldb
