### PR TITLE
Add get_installed_semantic_versioned_packages

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -83,7 +83,8 @@ from charmhelpers.fetch import (
     add_source as fetch_add_source,
     SourceConfigError,
     GPGKeyError,
-    get_upstream_version
+    get_upstream_version,
+    filter_missing_packages
 )
 
 from charmhelpers.fetch.snap import (
@@ -307,6 +308,15 @@ class CompareOpenStackReleases(BasicStringComparator):
 def error_out(msg):
     juju_log("FATAL ERROR: %s" % msg, level='ERROR')
     sys.exit(1)
+
+
+def get_installed_semantic_versioned_packages():
+    '''Get a list of installed packages which have OpenStack semantic versioning
+
+    :returns List of installed packages
+    :rtype: [pkg1, pkg2, ...]
+    '''
+    return filter_missing_packages(PACKAGE_CODENAMES.keys())
 
 
 def get_os_codename_install_source(src):

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -177,6 +177,15 @@ class OpenStackHelpersTestCase(TestCase):
         cache.__getitem__.side_effect = cache_get
         return cache
 
+    @patch.object(openstack, 'filter_missing_packages')
+    def test_get_installed_semantic_versioned_packages(self, mock_filter):
+        def _filter_missing_packages(pkgs):
+            return [x for x in pkgs if x in ['cinder-common']]
+        mock_filter.side_effect = _filter_missing_packages
+        self.assertEquals(
+            openstack.get_installed_semantic_versioned_packages(),
+            ['cinder-common'])
+
     @patch('charmhelpers.contrib.openstack.utils.lsb_release')
     def test_os_codename_from_install_source(self, mocked_lsb):
         """Test mapping install source to OpenStack release name"""


### PR DESCRIPTION
Add a method that returns a list of OpenStack packages which are
installed and use semantic versioning. This is the first step
in resolving Bug #1741628. charms.openstack can then use this list
to calculate the installed OpenStack version.