### PR TITLE
Allow None state from charm_func_with_configs

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -982,7 +982,9 @@ def _ows_check_charm_func(state, message, charm_func_with_configs):
     """
     if charm_func_with_configs:
         charm_state, charm_message = charm_func_with_configs()
-        if charm_state != 'active' and charm_state != 'unknown':
+        if (charm_state != 'active'
+                and charm_state != 'unknown'
+                and charm_state is not None):
             state = workload_state_compare(state, charm_state)
             if message:
                 charm_message = charm_message.replace("Incomplete relations: ",

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -982,9 +982,9 @@ def _ows_check_charm_func(state, message, charm_func_with_configs):
     """
     if charm_func_with_configs:
         charm_state, charm_message = charm_func_with_configs()
-        if (charm_state != 'active'
-                and charm_state != 'unknown'
-                and charm_state is not None):
+        if (charm_state != 'active' and
+                charm_state != 'unknown' and
+                charm_state is not None):
             state = workload_state_compare(state, charm_state)
             if message:
                 charm_message = charm_message.replace("Incomplete relations: ",


### PR DESCRIPTION
The charm_func_with_configs function is passed to
_ows_check_charm_func in order to allow unique status checks per
charm. It works when the charm sets a state like blocked or
maintenance. However, when you want the custom
charm_func_with_configs to do nothing and allow the rest of the
assess status code to run unimpeded there is no state setting to do
this. If set to None the code currently Tracebacks. "active" will
work but the charm_func_with_configs may not have the full
perspective to confirm this is the case.

Allow the charm_func_with_configs to return None, None when no action
is required.

Example:

```python
def charm_func_with_configs():
 """Unique status check"""
   if key != value:
       """Unique status result"""
       return "blocked", "This charm requires key to equal value"
   """The key does equal value so let the rest of asses status code
   determine the state as normal."""
   return None, None
```