### PR TITLE
Handle migrated / moved packages in charm_helpers_sync

### DIFF
--- a/charmhelpers/contrib/python.py
+++ b/charmhelpers/contrib/python.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from importlib import import_module
+
+_globals = globals()
 
 # deprecated aliases for backwards compatibility
-from charmhelpers.fetch.python import debug  # noqa
-from charmhelpers.fetch.python import packages  # noqa
-from charmhelpers.fetch.python import rpdb  # noqa
-from charmhelpers.fetch.python import version  # noqa
+for subpackage in ('debug', 'packages', 'rpdb', 'version'):
+    try:
+        full_name = 'charmhelpers.fetch.python.{}'.format(subpackage)
+        _globals[subpackage] = import_module(full_name)
+    except ImportError:
+        # not all subpackages may be present if charm-helpers-sync is used
+        pass


### PR DESCRIPTION
Some legacy charms use `charm_helpers_sync.py` to vendor in portions of the charmhelpers library, rather than installing the full package. The recent move of `charmshelpers.contrib.python` to `charmhelpers.fetch.python` was broken with sync, despite the import aliases put into place to maintain backward compatibility. This should resolve that by handling migrations automatically when syncing.

Fixes #272