### PR TITLE
Update ceph helpers for device class support

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -766,7 +766,8 @@ def get_osds(service, device_class=None):
     :param device_class: Class of storage device for OSD's
     :type device_class: str
     """
-    if device_class:
+    luminous_or_later = cmp_pkgrevno('ceph', '12.0.0') >= 0
+    if luminous_or_later and device_class:
         out = check_output(['ceph', '--id', service,
                             'osd', 'crush', 'class',
                             'ls-osd', device_class,

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -732,6 +732,14 @@ class CephUtilsTests(TestCase):
              'ls-osd', 'nvme', '--format=json']
         )
 
+    def test_get_osds_device_class_older(self):
+        self.check_output.return_value = json.dumps([1, 2, 3]).encode('UTF-8')
+        self.cmp_pkgrevno.return_value = -1
+        self.assertEquals(ceph_utils.get_osds('test', 'nvme'), [1, 2, 3])
+        self.check_output.assert_called_once_with(
+            ['ceph', '--id', 'test', 'osd', 'ls', '--format=json']
+        )
+
     @patch.object(ceph_utils, 'get_osds')
     @patch.object(ceph_utils, 'pool_exists')
     def test_create_pool(self, _exists, _get_osds):


### PR DESCRIPTION
Newer ceph versions automatically classify underlying block devices
by class (hdd, sdd, nvme). Provide support in ceph helpers for using
device classes when creating pools and calculating pg sizing.