### PR TITLE
Add support for ``app_name`` in ``add_op_create_pool``

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1152,7 +1152,8 @@ class CephBrokerRq(object):
             'object-prefix-permissions': object_prefix_permissions})
 
     def add_op_create_pool(self, name, replica_count=3, pg_num=None,
-                           weight=None, group=None, namespace=None):
+                           weight=None, group=None, namespace=None,
+                           app_name=None):
         """Adds an operation to create a pool.
 
         @param pg_num setting:  optional setting. If not provided, this value
@@ -1160,6 +1161,11 @@ class CephBrokerRq(object):
         cluster at the time of creation. Note that, if provided, this value
         will be capped at the current available maximum.
         @param weight: the percentage of data the pool makes up
+        :param app_name: (Optional) Tag pool with application name.  Note that
+                         there is certain protocols emerging upstream with
+                         regard to meaningful application names to use.
+                         Examples are ``rbd`` and ``rgw``.
+        :type app_name: str
         """
         if pg_num and weight:
             raise ValueError('pg_num and weight are mutually exclusive')
@@ -1167,7 +1173,7 @@ class CephBrokerRq(object):
         self.ops.append({'op': 'create-pool', 'name': name,
                          'replicas': replica_count, 'pg_num': pg_num,
                          'weight': weight, 'group': group,
-                         'group-namespace': namespace})
+                         'group-namespace': namespace, 'app-name': app_name})
 
     def set_ops(self, ops):
         """Set request ops to provided value.

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1559,3 +1559,46 @@ class CephUtilsTests(TestCase):
         finally:
             if os.path.exists(tmpdir):
                 shutil.rmtree(tmpdir)
+
+    def test_add_op_create_pool(self):
+        base_op = {'app-name': None,
+                   'group': None,
+                   'group-namespace': None,
+                   'name': 'apool',
+                   'op': 'create-pool',
+                   'pg_num': None,
+                   'replicas': 3,
+                   'weight': None}
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool')
+        self.assertEqual(rq.ops, [base_op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', replica_count=42)
+        op = base_op.copy()
+        op['replicas'] = 42
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', pg_num=42)
+        op = base_op.copy()
+        op['pg_num'] = 42
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', weight=42)
+        op = base_op.copy()
+        op['weight'] = 42
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', group=51)
+        op = base_op.copy()
+        op['group'] = 51
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', namespace='sol-iii')
+        op = base_op.copy()
+        op['group-namespace'] = 'sol-iii'
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_pool('apool', app_name='earth')
+        op = base_op.copy()
+        op['app-name'] = 'earth'
+        self.assertEqual(rq.ops, [op])


### PR DESCRIPTION
Some time ago upstream Ceph releases gained support for tagging
pools with which applications they are destined for.

Use cases are emerging for this and the first real user of it will
be the ``rbd-mirror`` feature enablement work that is ongoing in
the OpenStack Ceph charms.

By adding the ``rbd`` tag to the pools you use with Ceph RBD you
will get a "it just works" experience when adding your second
remote Ceph cluster and relating them using the ``ceph-rbd-mirror``
charm.