### PR TITLE
Catch NoNetworkBinding in addition to NotImplementedError

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -29,6 +29,7 @@ from charmhelpers.fetch import (
     filter_installed_packages,
 )
 from charmhelpers.core.hookenv import (
+    NoNetworkBinding,
     config,
     is_relation_made,
     local_unit,
@@ -868,7 +869,7 @@ class ApacheSSLContext(OSContextGenerator):
                     addr = network_get_primary_address(
                         ADDRESS_MAP[net_type]['binding']
                     )
-                except NotImplementedError:
+                except (NotImplementedError, NoNetworkBinding):
                     addr = fallback
 
             endpoint = resolve_address(net_type)

--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from charmhelpers.core.hookenv import (
+    NoNetworkBinding,
     config,
     unit_get,
     service_name,
@@ -175,7 +176,7 @@ def resolve_address(endpoint_type=PUBLIC, override=True):
             #       configuration is not in use
             try:
                 resolved_address = network_get_primary_address(binding)
-            except NotImplementedError:
+            except (NotImplementedError, NoNetworkBinding):
                 resolved_address = fallback_addr
 
     if resolved_address is None:

--- a/tests/contrib/openstack/test_ip.py
+++ b/tests/contrib/openstack/test_ip.py
@@ -1,6 +1,7 @@
 from testtools import TestCase
 from mock import patch, call, MagicMock
 
+import charmhelpers.core as ch_core
 import charmhelpers.contrib.openstack.ip as ip
 
 TO_PATCH = [
@@ -34,7 +35,10 @@ class IPTestCase(TestCase):
             setattr(self, m, self._patch(m))
         self.test_config = TestConfig()
         self.config.side_effect = self.test_config.get
-        self.network_get_primary_address.side_effect = NotImplementedError
+        self.network_get_primary_address.side_effect = [
+            NotImplementedError,
+            ch_core.hookenv.NoNetworkBinding,
+        ]
 
     def _patch(self, method):
         _m = patch('charmhelpers.contrib.openstack.ip.' + method)


### PR DESCRIPTION
Not all charms have all the bindings plumbed.