### PR TITLE
Add section-oslo-messaging-rabbit for Ocata+

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-oslo-messaging-rabbit
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-messaging-rabbit
@@ -1,0 +1,10 @@
+[oslo_messaging_rabbit]
+{% if rabbitmq_ha_queues -%}
+rabbit_ha_queues = True
+{% endif -%}
+{% if rabbit_ssl_port -%}
+ssl = True
+{% endif -%}
+{% if rabbit_ssl_ca -%}
+ssl_ca_file = {{ rabbit_ssl_ca }}
+{% endif -%}


### PR DESCRIPTION
The stein version of python-oslo.messaging (9.0.0+) has removed
the following config options from the [oslo_messaging_rabbit]
section:

rabbit_host, rabbit_port, rabbit_hosts, rabbit_userid,
rabbit_password, rabbit_virtual_host rabbit_max_retries, and
rabbit_durable_queues.

These have been deprecated since Ocata, therefore this section
can be used in pre-Stein templates back to Ocata in order to drop
deprecation warnings.

See release notes at:
https://docs.openstack.org/releasenotes/oslo.messaging/index.html

See related bug:
https://bugs.launchpad.net/bugs/1817672