### PR TITLE
Add OpenStack version filter to audits

### DIFF
--- a/charmhelpers/contrib/openstack/audits/__init__.py
+++ b/charmhelpers/contrib/openstack/audits/__init__.py
@@ -19,7 +19,7 @@ from enum import Enum
 import traceback
 
 from charmhelpers.core.host import cmp_pkgrevno
-
+import charmhelpers.contrib.openstack.utils as openstack_utils
 import charmhelpers.core.hookenv as hookenv
 
 
@@ -76,6 +76,17 @@ def before_package(pkg, pkg_version):
     """This audit should be run before the specified package version (excl)."""
     return lambda audit_options=None: not since_package(pkg, pkg_version)()
 
+
+def since_openstack_release(pkg, release):
+    """This audit should be run after the specified OpenStack version (incl)."""
+    def _since_openstack_release(audit_options=None):
+        _release = openstack_utils.get_os_codename_package(pkg)
+        return openstack_utils.CompareOpenStackReleases(_release) >= release
+    return _since_openstack_release
+
+def before_openstack_release(pkg, version):
+    """This audit should be run before the specified OpenStack version (excl)."""
+    return lambda audit_options=None: not since_openstack_release(pkg, version)(audit_options)
 
 def it_has_config(config_key):
     """This audit should be run based on specified config keys."""

--- a/charmhelpers/contrib/openstack/audits/__init__.py
+++ b/charmhelpers/contrib/openstack/audits/__init__.py
@@ -39,7 +39,7 @@ def audit(*args):
     deployed system that matches the given configuration
 
     :param args: List of functions to filter tests against
-    :type args: List[Callable(dict)]
+    :type args: List[Callable[Dict]]
     """
     def wrapper(f):
         test_name = f.__name__
@@ -62,7 +62,7 @@ def is_audit_type(*args):
 
     :param *args: List of AuditTypes to include this audit in
     :type args: List[AuditType]
-    :rtype: Callable[dict]
+    :rtype: Callable[Dict]
     """
     def _is_audit_type(audit_options):
         if audit_options.get('audit_type') in args:
@@ -79,7 +79,8 @@ def since_package(pkg, pkg_version):
     :type pkg: str
     :param release: The package version
     :type release: str
-    :rtype: Callable[dict]"""
+    :rtype: Callable[Dict]
+    """
     def _since_package(audit_options=None):
         return cmp_pkgrevno(pkg, pkg_version) >= 0
 
@@ -93,7 +94,8 @@ def before_package(pkg, pkg_version):
     :type pkg: str
     :param release: The package version
     :type release: str
-    :rtype: Callable[dict]"""
+    :rtype: Callable[Dict]
+    """
     def _before_package(audit_options=None):
         return not since_package(pkg, pkg_version)()
 
@@ -107,7 +109,7 @@ def since_openstack_release(pkg, release):
     :type pkg: str
     :param release: The OpenStack release codename
     :type release: str
-    :rtype: Callable[dict]
+    :rtype: Callable[Dict]
     """
     def _since_openstack_release(audit_options=None):
         _release = openstack_utils.get_os_codename_package(pkg)
@@ -123,7 +125,7 @@ def before_openstack_release(pkg, release):
     :type pkg: str
     :param release: The OpenStack release codename
     :type release: str
-    :rtype: Callable[dict]
+    :rtype: Callable[Dict]
     """
     def _before_openstack_release(audit_options=None):
         return not since_openstack_release(pkg, release)()
@@ -136,7 +138,8 @@ def it_has_config(config_key):
 
     :param config_key: Config key to look for
     :type config_key: str
-    :rtype: Callable[dict]"""
+    :rtype: Callable[Dict]
+    """
     def _it_has_config(audit_options):
         return audit_options.get(config_key) is not None
 
@@ -192,9 +195,10 @@ def run(audit_options):
 def action_parse_results(result):
     """Parse the result of `run` in the context of an action.
 
-    :param result:
-    :type result:
-    :rtype: integer
+    :param result: The result of running the security-checklist
+        action on a unit
+    :type result: Dict[str, Dict[str, str]]
+    :rtype: int
     """
     passed = True
     for test, result in result.items():

--- a/charmhelpers/contrib/openstack/audits/__init__.py
+++ b/charmhelpers/contrib/openstack/audits/__init__.py
@@ -78,15 +78,18 @@ def before_package(pkg, pkg_version):
 
 
 def since_openstack_release(pkg, release):
-    """This audit should be run after the specified OpenStack version (incl)."""
+    """This audit should run after the specified OpenStack version (incl)."""
     def _since_openstack_release(audit_options=None):
         _release = openstack_utils.get_os_codename_package(pkg)
         return openstack_utils.CompareOpenStackReleases(_release) >= release
     return _since_openstack_release
 
+
 def before_openstack_release(pkg, version):
-    """This audit should be run before the specified OpenStack version (excl)."""
-    return lambda audit_options=None: not since_openstack_release(pkg, version)(audit_options)
+    """This audit should run before the specified OpenStack version (excl)."""
+    return lambda audit_options=None: \
+        not since_openstack_release(pkg, version)(audit_options)
+
 
 def it_has_config(config_key):
     """This audit should be run based on specified config keys."""

--- a/charmhelpers/contrib/openstack/audits/__init__.py
+++ b/charmhelpers/contrib/openstack/audits/__init__.py
@@ -39,7 +39,7 @@ def audit(*args):
     deployed system that matches the given configuration
 
     :param args: List of functions to filter tests against
-    :type args: List[Callable(Config)]
+    :type args: List[Callable(dict)]
     """
     def wrapper(f):
         test_name = f.__name__
@@ -58,42 +58,89 @@ def audit(*args):
 
 
 def is_audit_type(*args):
-    """This audit is included in the specified kinds of audits."""
-    def should_run(audit_options):
+    """This audit is included in the specified kinds of audits.
+
+    :param *args: List of AuditTypes to include this audit in
+    :type args: List[AuditType]
+    :rtype: Callable[dict]
+    """
+    def _is_audit_type(audit_options):
         if audit_options.get('audit_type') in args:
             return True
         else:
             return False
-    return should_run
+    return _is_audit_type
 
 
 def since_package(pkg, pkg_version):
-    """This audit should be run after the specified package version (incl)."""
-    return lambda audit_options=None: cmp_pkgrevno(pkg, pkg_version) >= 0
+    """This audit should be run after the specified package version (incl).
+
+    :param pkg: Package name to compare
+    :type pkg: str
+    :param release: The package version
+    :type release: str
+    :rtype: Callable[dict]"""
+    def _since_package(audit_options=None):
+        return cmp_pkgrevno(pkg, pkg_version) >= 0
+
+    return _since_package
 
 
 def before_package(pkg, pkg_version):
-    """This audit should be run before the specified package version (excl)."""
-    return lambda audit_options=None: not since_package(pkg, pkg_version)()
+    """This audit should be run before the specified package version (excl).
+
+    :param pkg: Package name to compare
+    :type pkg: str
+    :param release: The package version
+    :type release: str
+    :rtype: Callable[dict]"""
+    def _before_package(audit_options=None):
+        return not since_package(pkg, pkg_version)()
+
+    return _before_package
 
 
 def since_openstack_release(pkg, release):
-    """This audit should run after the specified OpenStack version (incl)."""
+    """This audit should run after the specified OpenStack version (incl).
+
+    :param pkg: Package name to compare
+    :type pkg: str
+    :param release: The OpenStack release codename
+    :type release: str
+    :rtype: Callable[dict]
+    """
     def _since_openstack_release(audit_options=None):
         _release = openstack_utils.get_os_codename_package(pkg)
         return openstack_utils.CompareOpenStackReleases(_release) >= release
+
     return _since_openstack_release
 
 
-def before_openstack_release(pkg, version):
-    """This audit should run before the specified OpenStack version (excl)."""
-    return lambda audit_options=None: \
-        not since_openstack_release(pkg, version)(audit_options)
+def before_openstack_release(pkg, release):
+    """This audit should run before the specified OpenStack version (excl).
+
+    :param pkg: Package name to compare
+    :type pkg: str
+    :param release: The OpenStack release codename
+    :type release: str
+    :rtype: Callable[dict]
+    """
+    def _before_openstack_release(audit_options=None):
+        return not since_openstack_release(pkg, release)()
+
+    return _before_openstack_release
 
 
 def it_has_config(config_key):
-    """This audit should be run based on specified config keys."""
-    return lambda audit_options: audit_options.get(config_key) is not None
+    """This audit should be run based on specified config keys.
+
+    :param config_key: Config key to look for
+    :type config_key: str
+    :rtype: Callable[dict]"""
+    def _it_has_config(audit_options):
+        return audit_options.get(config_key) is not None
+
+    return _it_has_config
 
 
 def run(audit_options):
@@ -101,6 +148,8 @@ def run(audit_options):
 
     :param audit_options: Configuration for the audit
     :type audit_options: Config
+
+    :rtype: Dict[str, str]
     """
     errors = {}
     results = {}
@@ -141,7 +190,12 @@ def run(audit_options):
 
 
 def action_parse_results(result):
-    """Parse the result of `run` in the context of an action."""
+    """Parse the result of `run` in the context of an action.
+
+    :param result:
+    :type result:
+    :rtype: integer
+    """
     passed = True
     for test, result in result.items():
         if result['success']:

--- a/tests/contrib/openstack/test_audits.py
+++ b/tests/contrib/openstack/test_audits.py
@@ -117,6 +117,48 @@ class AuditsTestCase(TestCase):
         verifier = audits.since_package('test', '13.0.0')
         self.assertEqual(verifier(), True)
 
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_since_openstack_less(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "icehouse"
+
+        verifier = audits.since_openstack_release('test', 'mitaka')
+        self.assertEqual(verifier(), False)
+
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_since_openstack_greater(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "rocky"
+
+        verifier = audits.since_openstack_release('test', 'queens')
+        self.assertEqual(verifier(), True)
+
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_since_openstack_equal(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "mitaka"
+
+        verifier = audits.since_openstack_release('test', 'mitaka')
+        self.assertEqual(verifier(), True)
+
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_before_openstack_less(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "icehouse"
+
+        verifier = audits.before_openstack_release('test', 'mitaka')
+        self.assertEqual(verifier(), True)
+
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_before_openstack_greater(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "rocky"
+
+        verifier = audits.before_openstack_release('test', 'queens')
+        self.assertEqual(verifier(), False)
+
+    @patch('charmhelpers.contrib.openstack.utils.get_os_codename_package')
+    def test_before_openstack_equal(self, _get_os_codename_package):
+        _get_os_codename_package.return_value = "mitaka"
+
+        verifier = audits.before_openstack_release('test', 'mitaka')
+        self.assertEqual(verifier(), False)
+
     @patch('charmhelpers.contrib.openstack.audits.cmp_pkgrevno')
     def test_before_package_less(self, _cmp_pkgrevno):
         _cmp_pkgrevno.return_value = 1


### PR DESCRIPTION
OpenStack packages should be compared via release codenames, rather than directly via package versions. This change adds an audit filter to restrict based on OpenStack release for packages.