### PR TITLE
Fix openstack-upgrade-available detection

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -656,7 +656,7 @@ def openstack_upgrade_available(package):
     else:
         avail_vers = get_os_version_install_source(src)
     apt.init()
-    return apt.version_compare(avail_vers, cur_vers) == 1
+    return apt.version_compare(avail_vers, cur_vers) >= 1
 
 
 def ensure_block_device(block_device):


### PR DESCRIPTION
Fix openstack-upgrade-available detection to work with new versions of apt.version_compare() which returns +X 0 or -X instead of 1, 0, -1 on newer versions of xenial/bionic.