### PR TITLE
Catch NoNetworkBinding for VIPs in resolve_address

### DIFF
--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -159,7 +159,7 @@ def resolve_address(endpoint_type=PUBLIC, override=True):
                     if is_address_in_network(bound_cidr, vip):
                         resolved_address = vip
                         break
-            except NotImplementedError:
+            except (NotImplementedError, NoNetworkBinding):
                 # If no net-splits configured and no support for extra
                 # bindings/network spaces so we expect a single vip
                 resolved_address = vips[0]


### PR DESCRIPTION
There was one network_get_primary_address call left which was not
protected by NoNetworkBinding in resolve_address when clustering is in
use and VIPs are set.

This change catches that last case. Also, confirmed there are no other
cases.