### PR TITLE
Added an "ignore" option to sysctl_create

### DIFF
--- a/charmhelpers/core/sysctl.py
+++ b/charmhelpers/core/sysctl.py
@@ -28,7 +28,7 @@ from charmhelpers.core.hookenv import (
 __author__ = 'Jorge Niedbalski R. <jorge.niedbalski@canonical.com>'
 
 
-def create(sysctl_dict, sysctl_file):
+def create(sysctl_dict, sysctl_file, ignore=False):
     """Creates a sysctl.conf file from a YAML associative array
 
     :param sysctl_dict: a dict or YAML-formatted string of sysctl
@@ -36,6 +36,8 @@ def create(sysctl_dict, sysctl_file):
     :type sysctl_dict: str
     :param sysctl_file: path to the sysctl file to be saved
     :type sysctl_file: str or unicode
+    :param ignore: If True, ignore "unknown variable" errors.
+    :type ignore: bool
     :returns: None
     """
     if type(sysctl_dict) is not dict:
@@ -52,7 +54,12 @@ def create(sysctl_dict, sysctl_file):
         for key, value in sysctl_dict_parsed.items():
             fd.write("{}={}\n".format(key, value))
 
-    log("Updating sysctl_file: %s values: %s" % (sysctl_file, sysctl_dict_parsed),
+    log("Updating sysctl_file: {} values: {}".format(sysctl_file,
+                                                     sysctl_dict_parsed),
         level=DEBUG)
 
-    check_call(["sysctl", "-p", sysctl_file])
+    call = ["sysctl", "-p", sysctl_file]
+    if ignore:
+        call.append("-e")
+
+    check_call(call)

--- a/tests/core/test_sysctl.py
+++ b/tests/core/test_sysctl.py
@@ -74,7 +74,6 @@ class SysctlTests(unittest.TestCase):
             "sysctl", "-p",
             "/etc/sysctl.d/test-sysctl.conf", "-e"])
 
-        
     @patch(builtin_open)
     def test_create_with_dict(self, mock_open):
         """Test create sysctl method"""

--- a/tests/core/test_sysctl.py
+++ b/tests/core/test_sysctl.py
@@ -54,6 +54,28 @@ class SysctlTests(unittest.TestCase):
             "/etc/sysctl.d/test-sysctl.conf"])
 
     @patch(builtin_open)
+    def test_create_with_ignore(self, mock_open):
+        """Test create sysctl method"""
+        _file = MagicMock(spec=io.FileIO)
+        mock_open.return_value = _file
+
+        create('{"kernel.max_pid": 1337}',
+               "/etc/sysctl.d/test-sysctl.conf",
+               ignore=True)
+
+        _file.__enter__().write.assert_called_with("kernel.max_pid=1337\n")
+
+        self.log.assert_called_with(
+            "Updating sysctl_file: /etc/sysctl.d/test-sysctl.conf"
+            " values: {'kernel.max_pid': 1337}",
+            level='DEBUG')
+
+        self.check_call.assert_called_with([
+            "sysctl", "-p",
+            "/etc/sysctl.d/test-sysctl.conf", "-e"])
+
+        
+    @patch(builtin_open)
     def test_create_with_dict(self, mock_open):
         """Test create sysctl method"""
         _file = MagicMock(spec=io.FileIO)


### PR DESCRIPTION
Exposes sysctl's -e flag, which allows us to ignore "unknown variable"
errors. Gives us a lightweight way of setting what sysctl we can in a
charm, without probling /proc/sys to see what modules are actually
loaded.