### PR TITLE
Allow specifying ownership of certificate files

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -792,6 +792,7 @@ class ApacheSSLContext(OSContextGenerator):
     # and service namespace accordingly.
     external_ports = []
     service_namespace = None
+    user = group = 'root'
 
     def enable_modules(self):
         cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers']
@@ -810,9 +811,11 @@ class ApacheSSLContext(OSContextGenerator):
                 key_filename = 'key'
 
             write_file(path=os.path.join(ssl_dir, cert_filename),
-                       content=b64decode(cert), perms=0o640)
+                       content=b64decode(cert), owner=self.user,
+                       group=self.group, perms=0o640)
             write_file(path=os.path.join(ssl_dir, key_filename),
-                       content=b64decode(key), perms=0o640)
+                       content=b64decode(key), owner=self.user,
+                       group=self.group, perms=0o640)
 
     def configure_ca(self):
         ca_cert = get_ca_cert()

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -170,10 +170,12 @@ class CertUtilsTests(unittest.TestCase):
             mock.call(
                 path='/etc/ssl/cert_admin.openstack.local',
                 content='ADMINCERT\nCHAIN',
+                owner='root', group='root',
                 perms=0o640),
             mock.call(
                 path='/etc/ssl/key_admin.openstack.local',
                 content='ADMINKEY',
+                owner='root', group='root',
                 perms=0o640),
         ]
         write_file.assert_has_calls(expected)
@@ -190,10 +192,12 @@ class CertUtilsTests(unittest.TestCase):
             mock.call(
                 path='/etc/ssl/cert_admin.openstack.local',
                 content='ADMINCERT\nMYCA',
+                owner='root', group='root',
                 perms=0o640),
             mock.call(
                 path='/etc/ssl/key_admin.openstack.local',
                 content='ADMINKEY',
+                owner='root', group='root',
                 perms=0o640),
         ]
         write_file.assert_has_calls(expected)
@@ -228,7 +232,7 @@ class CertUtilsTests(unittest.TestCase):
             '/etc/apache2/ssl/myservice',
             {'admin.openstack.local': {
                 'key': 'ADMINKEY', 'cert': 'ADMINCERT'}},
-            'MYCHAIN')
+            'MYCHAIN', user='root', group='root')
         create_ip_cert_links.assert_called_once_with(
             '/etc/apache2/ssl/myservice',
             custom_hostname_link='funky-name')

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -2362,9 +2362,11 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert_test-cn',
-                      content=b'SSL_CERT', perms=0o640),
+                      content=b'SSL_CERT', owner='root', group='root',
+                      perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key_test-cn',
-                      content=b'SSL_KEY', perms=0o640)]
+                      content=b'SSL_KEY', owner='root', group='root',
+                      perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]
@@ -2381,9 +2383,11 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert',
-                      content='SSL_CERT', perms=0o640),
+                      content='SSL_CERT', owner='root', group='root',
+                      perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key',
-                      content='SSL_KEY', perms=0o640)]
+                      content='SSL_KEY', owner='root', group='root',
+                      perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]


### PR DESCRIPTION
Some services require specific ownership for access to certificate
data.