### PR TITLE
Added context generator for logrotate

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1935,3 +1935,30 @@ class VersionsContext(OSContextGenerator):
         return {
             'openstack_release': ostack,
             'operating_system_release': osystem}
+
+
+class LogrotateContext(OSContextGenerator):
+    """Common context generator for logrotate."""
+
+    def __init__(self, location, interval, count):
+        """
+        :param location: Absolute path for the logrotate config file
+        :type location: str
+        :param interval: The interval for the rotations. Valid values are
+                         'daily', 'weekly', 'monthly', 'yearly'
+        :type interval: str
+        :param count: The logrotate count option configures the 'count' times
+                      the log files are being rotated before being
+        :type count: int
+        """
+        self.location = location
+        self.interval = interval
+        self.count = 'rotate {}'.format(count)
+
+    def __call__(self):
+        ctxt = {
+            'logrotate_logs_location': self.location,
+            'logrotate_interval': self.interval,
+            'logrotate_count': self.count,
+        }
+        return ctxt

--- a/charmhelpers/contrib/openstack/templates/logrotate
+++ b/charmhelpers/contrib/openstack/templates/logrotate
@@ -1,0 +1,9 @@
+/var/log/{{ logrotate_logs_location }}/*.log {
+    {{ logrotate_interval }}
+    {{ logrotate_count }}
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3678,3 +3678,15 @@ class ContextTests(unittest.TestCase):
                 'operating_system_release': 'xenial'})
         os_release.assert_called_once_with('python-keystone', base='icehouse')
         self.lsb_release.assert_called_once_with()
+
+    def test_logrotate_context_unset(self):
+        logrotate = context.LogrotateContext(location='nova',
+                                             interval='weekly',
+                                             count=4)
+        ctxt = logrotate()
+        expected_ctxt = {
+            'logrotate_logs_location': 'nova',
+            'logrotate_interval': 'weekly',
+            'logrotate_count': 'rotate 4',
+        }
+        self.assertEquals(ctxt, expected_ctxt)


### PR DESCRIPTION
New simple context generator for logrotate + template.

The logrotate context generator has 3 arguments:
 * interval
 * rotate count
 * location of log files in /var/log/

Added coresponding template.

Related-Bug: #1692118