### PR TITLE
stein: Add swift 2.21.0

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -194,7 +194,7 @@ SWIFT_CODENAMES = OrderedDict([
     ('rocky',
         ['2.18.0', '2.19.0']),
     ('stein',
-        ['2.20.0']),
+        ['2.20.0', '2.21.0']),
 ])
 
 # >= Liberty version->codename mapping


### PR DESCRIPTION
Add latest swift release for stein to the list of stein
versions.