### PR TITLE
contrib/openstack: Return status on process certificates

### DIFF
--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -220,6 +220,8 @@ def process_certificates(service_name, relation_id, unit,
     :type user: str
     :param group: (Optional) Group of certificate files. Defaults to 'root'
     :type group: str
+    :returns: True if certificates processed for local unit or False
+    :rtype: bool
     """
     data = relation_get(rid=relation_id, unit=unit)
     ssl_dir = os.path.join('/etc/apache2/ssl/', service_name)
@@ -235,6 +237,8 @@ def process_certificates(service_name, relation_id, unit,
         create_ip_cert_links(
             ssl_dir,
             custom_hostname_link=custom_hostname_link)
+        return True
+    return False
 
 
 def get_requests_for_local_unit(relation_name=None):

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -211,7 +211,7 @@ class CertUtilsTests(unittest.TestCase):
     def test_process_certificates(self, relation_get, mkdir, install_ca_cert,
                                   install_certs, create_ip_cert_links,
                                   local_unit):
-        local_unit.return_value = 'keystone/2'
+        local_unit.return_value = 'devnull/2'
         certs = {
             'admin.openstack.local': {
                 'cert': 'ADMINCERT',
@@ -222,11 +222,17 @@ class CertUtilsTests(unittest.TestCase):
             'ca': 'ROOTCA',
         }
         relation_get.return_value = _relation_info
-        cert_utils.process_certificates(
+        self.assertFalse(cert_utils.process_certificates(
             'myservice',
             'certificates:2',
             'vault/0',
-            custom_hostname_link='funky-name')
+            custom_hostname_link='funky-name'))
+        local_unit.return_value = 'keystone/2'
+        self.assertTrue(cert_utils.process_certificates(
+            'myservice',
+            'certificates:2',
+            'vault/0',
+            custom_hostname_link='funky-name'))
         install_ca_cert.assert_called_once_with(b'ROOTCA')
         install_certs.assert_called_once_with(
             '/etc/apache2/ssl/myservice',


### PR DESCRIPTION
Returns True when certificates found and processed for local unit
in relation data, return False otherwise.