### PR TITLE
openstack: oslo messaging notification

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -117,6 +117,7 @@ except ImportError:
 CA_CERT_PATH = '/usr/local/share/ca-certificates/keystone_juju_ca_cert.crt'
 ADDRESS_TYPES = ['admin', 'internal', 'public']
 HAPROXY_RUN_DIR = '/var/run/haproxy/'
+DEFAULT_OSLO_MESSAGING_DRIVER = "messagingv2"
 
 
 def ensure_packages(packages):
@@ -568,6 +569,11 @@ class AMQPContext(OSContextGenerator):
         if oslo_messaging_flags:
             ctxt['oslo_messaging_flags'] = config_flags_parser(
                 oslo_messaging_flags)
+
+        oslo_messaging_driver = conf.get(
+            'oslo-messaging-driver', DEFAULT_OSLO_MESSAGING_DRIVER)
+        if oslo_messaging_driver:
+            ctxt['oslo_messaging_driver'] = oslo_messaging_driver
 
         notification_format = conf.get('notification-format', None)
         if notification_format:

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -569,6 +569,10 @@ class AMQPContext(OSContextGenerator):
             ctxt['oslo_messaging_flags'] = config_flags_parser(
                 oslo_messaging_flags)
 
+        notification_format = conf.get('notification-format', None)
+        if notification_format:
+            ctxt['notification_format'] = notification_format
+
         if not self.complete:
             return {}
 

--- a/charmhelpers/contrib/openstack/templates/section-oslo-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-notifications
@@ -1,6 +1,6 @@
 {% if transport_url -%}
 [oslo_messaging_notifications]
-driver = messagingv2
+driver = {{ oslo_messaging_driver }}
 transport_url = {{ transport_url }}
 {% if notification_topics -%}
 topics = {{ notification_topics }}

--- a/charmhelpers/contrib/openstack/templates/section-oslo-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-notifications
@@ -6,6 +6,7 @@ transport_url = {{ transport_url }}
 topics = {{ notification_topics }}
 {% endif -%}
 {% if notification_format -%}
+[notifications]
 notification_format = {{ notification_format }}
 {% endif -%}
 {% endif -%}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -270,6 +270,10 @@ AMQP_OSLO_CONFIG = {
                              ",rabbit_retry_interval=1")
 }
 
+AMQP_NOTIFICATION_FORMAT = {
+    'notification-format': 'both'
+}
+
 AMQP_NOVA_CONFIG = {
     'nova-rabbit-user': 'adam',
     'nova-rabbit-vhost': 'foo',
@@ -1372,6 +1376,25 @@ class ContextTests(unittest.TestCase):
                 'rabbit_retry_backoff': '1',
                 'rabbit_retry_interval': '1'
             },
+            'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
+        }
+
+        self.assertEquals(result, expected)
+
+    def test_amqp_context_with_notification_format(self):
+        """Test amqp context with notification_format option"""
+        relation = FakeRelation(relation_data=AMQP_RELATION)
+        self.relation_get.side_effect = relation.get
+        AMQP_NOTIFICATION_FORMAT.update(AMQP_CONFIG)
+        self.config.return_value = AMQP_NOTIFICATION_FORMAT
+        amqp = context.AMQPContext()
+        result = amqp()
+        expected = {
+            'rabbitmq_host': 'rabbithost',
+            'rabbitmq_password': 'foobar',
+            'rabbitmq_user': 'adam',
+            'rabbitmq_virtual_host': 'foo',
+            'notification_format': 'both',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -267,7 +267,8 @@ AMQP_CONFIG = {
 AMQP_OSLO_CONFIG = {
     'oslo-messaging-flags': ("rabbit_max_retries=1"
                              ",rabbit_retry_backoff=1"
-                             ",rabbit_retry_interval=1")
+                             ",rabbit_retry_interval=1"),
+    'oslo-messaging-driver': 'log'
 }
 
 AMQP_NOTIFICATION_FORMAT = {
@@ -1188,6 +1189,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1205,6 +1207,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext(relation_id='amqp-alt:0')
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbitalthost1',
             'rabbitmq_password': 'flump',
             'rabbitmq_user': 'adam',
@@ -1223,6 +1226,7 @@ class ContextTests(unittest.TestCase):
             relation_prefix='nova')
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1241,6 +1245,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext(ssl_dir=ssl_dir)
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1263,6 +1268,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1284,6 +1290,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'clustered': True,
             'rabbitmq_host': relation_data['vip'],
             'rabbitmq_password': 'foobar',
@@ -1304,6 +1311,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost1',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1348,6 +1356,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': '[2001:db8:1::1]',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',
@@ -1376,6 +1385,7 @@ class ContextTests(unittest.TestCase):
                 'rabbit_retry_backoff': '1',
                 'rabbit_retry_interval': '1'
             },
+            'oslo_messaging_driver': 'log',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 
@@ -1390,6 +1400,7 @@ class ContextTests(unittest.TestCase):
         amqp = context.AMQPContext()
         result = amqp()
         expected = {
+            'oslo_messaging_driver': 'messagingv2',
             'rabbitmq_host': 'rabbithost',
             'rabbitmq_password': 'foobar',
             'rabbitmq_user': 'adam',


### PR DESCRIPTION
To address the requested feature from lp#1825016 [0], we need to add the ability to configure the `notification_format` and the driver used.

[0] https://bugs.launchpad.net/cham-nova-compute/+bug/1825016