### PR TITLE
Preserve old keymap entries on NRPE.write

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -268,8 +268,8 @@ class NRPE(object):
     def add_check(self, *args, **kwargs):
         self.checks.append(Check(*args, **kwargs))
         shortname = kwargs['shortname']
-        if shortname in self.remove_check_queue.copy():
-            del self.remove_check_queue[shortname]
+        if shortname in self.remove_check_queue:
+            self.remove_check_queue.remove(shortname)
 
     def remove_check(self, *args, **kwargs):
         if kwargs.get('shortname') is None:

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -330,11 +330,12 @@ class NRPE(object):
                 old_nrpe_monitors = {k: v for k, v in old_nrpe_monitors.items() if k not in self.remove_check_queue}
                 # update/add nrpe_monitors
                 old_nrpe_monitors.update(nrpe_monitors)
+                old_monitors['monitors']['remote']['nrpe'] = old_nrpe_monitors
                 # write back to the relation
                 relation_set(relation_id=rid, monitors=yaml.dump(old_monitors))
             else:
                 # write a brand new set of monitors, as no existing ones.
-                relation_set(relation_id=rid, monitor=yaml.dump(monitors))
+                relation_set(relation_id=rid, monitors=yaml.dump(monitors))
 
         self.remove_check_queue.clear()
 

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -268,7 +268,7 @@ class NRPE(object):
     def add_check(self, *args, **kwargs):
         self.checks.append(Check(*args, **kwargs))
         shortname = kwargs['shortname']
-        if shortname in self.remove_check_queue:
+        if shortname in self.remove_check_queue.copy():
             del self.remove_check_queue[shortname]
 
     def remove_check(self, *args, **kwargs):

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -266,6 +266,9 @@ class NRPE(object):
         self.remove_check_queue = set()
 
     def add_check(self, *args, **kwargs):
+        if kwargs.get('shortname') is None:
+            raise ValueError('shortname of check must be specified')
+
         self.checks.append(Check(*args, **kwargs))
         shortname = kwargs['shortname']
         try:

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -330,7 +330,8 @@ class NRPE(object):
                 old_monitors = yaml.safe_load(reldata['monitors'])
                 old_nrpe_monitors = old_monitors['monitors']['remote']['nrpe']
                 # remove keys that are in the remove_check_queue
-                old_nrpe_monitors = {k: v for k, v in old_nrpe_monitors.items() if k not in self.remove_check_queue}
+                old_nrpe_monitors = {k: v for k, v in old_nrpe_monitors.items()
+                                     if k not in self.remove_check_queue}
                 # update/add nrpe_monitors
                 old_nrpe_monitors.update(nrpe_monitors)
                 old_monitors['monitors']['remote']['nrpe'] = old_nrpe_monitors

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -268,8 +268,10 @@ class NRPE(object):
     def add_check(self, *args, **kwargs):
         self.checks.append(Check(*args, **kwargs))
         shortname = kwargs['shortname']
-        if shortname in self.remove_check_queue:
+        try:
             self.remove_check_queue.remove(shortname)
+        except KeyError:
+            pass
 
     def remove_check(self, *args, **kwargs):
         if kwargs.get('shortname') is None:

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -27,6 +27,7 @@ class NRPEBaseTestCase(TestCase):
         'isfile': {'object': os.path},
         'isdir': {'object': os.path},
         'call': {'object': subprocess},
+        'relation_get': {'object': nrpe},
         'relation_ids': {'object': nrpe},
         'relation_set': {'object': nrpe},
         'relations_of_type': {'object': nrpe},
@@ -123,6 +124,11 @@ class NRPETestCase(NRPEBaseTestCase):
         self.patched['config'].return_value = {'nagios_context': 'a',
                                                'nagios_servicegroups': ''}
         self.patched['exists'].return_value = True
+        self.patched['relation_get'].return_value = {
+            'egress-subnets': '10.66.111.24/32',
+            'ingress-address': '10.66.111.24',
+            'private-address': '10.66.111.24'
+        }
 
         def _rels(rname):
             relations = {

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -187,7 +187,7 @@ define service {
         ]
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
-                               exists=4, open=2, listdir=1,
+                               exists=4, open=2, listdir=1, relation_get=3,
                                relation_ids=4, relation_set=3)
 
 

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -187,7 +187,7 @@ define service {
         ]
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
-                               exists=4, open=2, listdir=1, relation_get=3,
+                               exists=4, open=2, listdir=1, relation_get=2,
                                relation_ids=3, relation_set=3)
 
 

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -188,7 +188,7 @@ define service {
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
                                exists=4, open=2, listdir=1, relation_get=3,
-                               relation_ids=4, relation_set=3)
+                               relation_ids=3, relation_set=3)
 
 
 class NRPECheckTestCase(NRPEBaseTestCase):


### PR DESCRIPTION
 * NRPE.write retrieves the [monitors] (monitors/remote/nrpe) relation
data before overriding it with relation_set
 * If NRPE.remove_check was called, old entries (removed) will be
removed, but others will be preserved