### PR TITLE
storage: inode size configurable when constructing XFS filesystem

### DIFF
--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -110,17 +110,20 @@ def is_device_mounted(device):
     return bool(re.search(r'MOUNTPOINT=".+"', out))
 
 
-def mkfs_xfs(device, force=False):
+def mkfs_xfs(device, force=False, inode_size=1024):
     """Format device with XFS filesystem.
 
     By default this should fail if the device already has a filesystem on it.
     :param device: Full path to device to format
     :ptype device: tr
     :param force: Force operation
-    :ptype: force: boolean"""
+    :ptype: force: boolean
+    :param inode_size: The inode size in bytes, min 256, max 2048.
+    :ptype: inode_size: integer
+    """
     cmd = ['mkfs.xfs']
     if force:
         cmd.append("-f")
 
-    cmd += ['-i', 'size=1024', device]
+    cmd += ['-i', 'size=%d' % inode_size, device]
     check_call(cmd)

--- a/tests/contrib/storage/test_linux_storage_utils.py
+++ b/tests/contrib/storage/test_linux_storage_utils.py
@@ -126,6 +126,13 @@ class MiscStorageUtilsTests(unittest.TestCase):
             ['mkfs.xfs', '-f', '-i', 'size=1024', '/dev/sdb']
         )
 
+    @patch(STORAGE_LINUX_UTILS + '.check_call')
+    def test_mkfs_xfs_inode_size(self, check_call):
+        storage_utils.mkfs_xfs('/dev/sdb', inode_size=2048)
+        check_call.assert_called_with(
+            ['mkfs.xfs', '-i', 'size=2048', '/dev/sdb']
+        )
+
 
 class CephLUKSDeviceTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Related to:
  https://bugs.launchpad.net/charm-swift-storage/+bug/1826552

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>