### PR TITLE
openstack: add global-physnet-mtu to NeutronAPIContext 

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1611,6 +1611,10 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'global-physnet-mtu',
                 'default': 1500,
             },
+            'physical-network-mtus': {
+                'rel_key': 'physical-network-mtus',
+                'default': None,
+            },
         }
         ctxt = self.get_neutron_options({})
         for rid in relation_ids('neutron-plugin-api'):

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1607,6 +1607,10 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-nsg-logging',
                 'default': False,
             },
+            'global-physnet-mtu': {
+                'rel_key': 'global-physnet-mtu',
+                'default': 1500,
+            },
         }
         ctxt = self.get_neutron_options({})
         for rid in relation_ids('neutron-plugin-api'):

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3450,7 +3450,7 @@ class ContextTests(unittest.TestCase):
         expected_keys = [
             'l2_population', 'enable_dvr', 'enable_l3ha',
             'overlay_network_type', 'network_device_mtu',
-            'enable_qos', 'enable_nsg_logging'
+            'enable_qos', 'enable_nsg_logging', 'global-physnet-mtu'
         ]
         api_ctxt = context.NeutronAPIContext()()
         for key in expected_keys:
@@ -3459,6 +3459,7 @@ class ContextTests(unittest.TestCase):
         self.assertEquals(api_ctxt['rpc_response_timeout'], 60)
         self.assertEquals(api_ctxt['report_interval'], 30)
         self.assertEquals(api_ctxt['enable_nsg_logging'], False)
+        self.assertEquals(api_ctxt['global-physnet-mtu'], 1500)
 
     def setup_neutron_api_context_relation(self, cfg):
         self.relation_ids.return_value = ['neutron-plugin-api:1']

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3450,7 +3450,8 @@ class ContextTests(unittest.TestCase):
         expected_keys = [
             'l2_population', 'enable_dvr', 'enable_l3ha',
             'overlay_network_type', 'network_device_mtu',
-            'enable_qos', 'enable_nsg_logging', 'global-physnet-mtu'
+            'enable_qos', 'enable_nsg_logging', 'global-physnet-mtu',
+            'physical-network-mtus'
         ]
         api_ctxt = context.NeutronAPIContext()()
         for key in expected_keys:
@@ -3460,6 +3461,7 @@ class ContextTests(unittest.TestCase):
         self.assertEquals(api_ctxt['report_interval'], 30)
         self.assertEquals(api_ctxt['enable_nsg_logging'], False)
         self.assertEquals(api_ctxt['global-physnet-mtu'], 1500)
+        self.assertIsNone(api_ctxt['physical-network-mtus'])
 
     def setup_neutron_api_context_relation(self, cfg):
         self.relation_ids.return_value = ['neutron-plugin-api:1']


### PR DESCRIPTION
This will be used to instruct MTU for DPDK interfaces.

There two commits, one to add global-physnet-mtu which will be used as the default or fallback value and physical-network-mtus which will be used to defined MTU based on networking cards.

Related-To:
  https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1827256

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>