### PR TITLE
Openstack port resolver should filter out non-existent ports

### DIFF
--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3286,13 +3286,24 @@ class ContextTests(unittest.TestCase):
         mock_config.side_effect = config
         self.assertEquals(context.ExternalPortContext()(), {})
 
+    @patch('charmhelpers.contrib.openstack.context.list_nics')
     @patch('charmhelpers.contrib.openstack.context.config')
-    def test_ext_port_eth(self, mock_config):
+    def test_ext_port_eth(self, mock_config, mock_list_nics):
         config = fake_config({'ext-port': 'eth1010'})
         self.config.side_effect = config
         mock_config.side_effect = config
+        mock_list_nics.return_value = ['eth1010']
         self.assertEquals(context.ExternalPortContext()(),
                           {'ext_port': 'eth1010'})
+
+    @patch('charmhelpers.contrib.openstack.context.list_nics')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_ext_port_eth_non_existent(self, mock_config, mock_list_nics):
+        config = fake_config({'ext-port': 'eth1010'})
+        self.config.side_effect = config
+        mock_config.side_effect = config
+        mock_list_nics.return_value = []
+        self.assertEquals(context.ExternalPortContext()(), {})
 
     @patch('charmhelpers.contrib.openstack.context.is_phy_iface',
            lambda arg: True)


### PR DESCRIPTION
When configuring data-port the DataPortContext will filter out
mac addresses that don't correspond to interfaces that exist
on the local host. We now do the same for interface names since
not all hosts will have the same interface names.

Partial-Bug: #1822558