### PR TITLE
openstack: enable additional log driver for oslo notification

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-oslo-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-notifications
@@ -2,6 +2,7 @@
 [oslo_messaging_notifications]
 driver = {{ oslo_messaging_driver }}
 transport_url = {{ transport_url }}
+driver = log
 {% if notification_topics -%}
 topics = {{ notification_topics }}
 {% endif -%}


### PR DESCRIPTION
In this commit we enable an addition driver to let users of Gaylog
collect notifications from system logs.

Related-to:
  https://bugs.launchpad.net/charm-nova-compute/+bug/1825016

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>