### PR TITLE
openstack: rename physical-network-mtus, global-physnet-mtu for jinja

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1607,11 +1607,11 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-nsg-logging',
                 'default': False,
             },
-            'global-physnet-mtu': {
+            'global_physnet_mtu': {
                 'rel_key': 'global-physnet-mtu',
                 'default': 1500,
             },
-            'physical-network-mtus': {
+            'physical_network_mtus': {
                 'rel_key': 'physical-network-mtus',
                 'default': None,
             },

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3450,8 +3450,8 @@ class ContextTests(unittest.TestCase):
         expected_keys = [
             'l2_population', 'enable_dvr', 'enable_l3ha',
             'overlay_network_type', 'network_device_mtu',
-            'enable_qos', 'enable_nsg_logging', 'global-physnet-mtu',
-            'physical-network-mtus'
+            'enable_qos', 'enable_nsg_logging', 'global_physnet_mtu',
+            'physical_network_mtus'
         ]
         api_ctxt = context.NeutronAPIContext()()
         for key in expected_keys:
@@ -3460,8 +3460,8 @@ class ContextTests(unittest.TestCase):
         self.assertEquals(api_ctxt['rpc_response_timeout'], 60)
         self.assertEquals(api_ctxt['report_interval'], 30)
         self.assertEquals(api_ctxt['enable_nsg_logging'], False)
-        self.assertEquals(api_ctxt['global-physnet-mtu'], 1500)
-        self.assertIsNone(api_ctxt['physical-network-mtus'])
+        self.assertEquals(api_ctxt['global_physnet_mtu'], 1500)
+        self.assertIsNone(api_ctxt['physical_network_mtus'])
 
     def setup_neutron_api_context_relation(self, cfg):
         self.relation_ids.return_value = ['neutron-plugin-api:1']


### PR DESCRIPTION
To make those options Jinja compliant they need to use '_' instead of
'-'.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>