### PR TITLE
openstack: add send_notifications_to_logs option

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -647,6 +647,10 @@ class AMQPContext(OSContextGenerator):
         if notification_format:
             ctxt['notification_format'] = notification_format
 
+        send_notifications_to_logs = conf.get('send-notifications-to-logs', None)
+        if send_notifications_to_logs:
+            ctxt['send_notifications_to_logs'] = send_notifications_to_logs
+
         if not self.complete:
             return {}
 

--- a/charmhelpers/contrib/openstack/templates/section-oslo-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-notifications
@@ -2,6 +2,9 @@
 [oslo_messaging_notifications]
 driver = {{ oslo_messaging_driver }}
 transport_url = {{ transport_url }}
+{% if send_notifications_to_logs %}
+driver = log
+{% endif %}
 {% if notification_topics -%}
 topics = {{ notification_topics }}
 {% endif -%}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -275,6 +275,10 @@ AMQP_NOTIFICATION_FORMAT = {
     'notification-format': 'both'
 }
 
+AMQP_NOTIFICATIONS_LOGS = {
+    'send-notifications-to-logs': True
+}
+
 AMQP_NOVA_CONFIG = {
     'nova-rabbit-user': 'adam',
     'nova-rabbit-vhost': 'foo',
@@ -1461,6 +1465,26 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_virtual_host': 'foo',
             'notification_format': 'both',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
+        }
+
+        self.assertEquals(result, expected)
+
+    def test_amqp_context_with_notifications_to_logs(self):
+        """Test amqp context with send_notifications_to_logs"""
+        relation = FakeRelation(relation_data=AMQP_RELATION)
+        self.relation_get.side_effect = relation.get
+        AMQP_NOTIFICATIONS_LOGS.update(AMQP_CONFIG)
+        self.config.return_value = AMQP_NOTIFICATIONS_LOGS
+        amqp = context.AMQPContext()
+        result = amqp()
+        expected = {
+            'oslo_messaging_driver': 'messagingv2',
+            'rabbitmq_host': 'rabbithost',
+            'rabbitmq_password': 'foobar',
+            'rabbitmq_user': 'adam',
+            'rabbitmq_virtual_host': 'foo',
+            'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo',
+            'send_notifications_to_logs': True,
         }
 
         self.assertEquals(result, expected)


### PR DESCRIPTION
 openstack: add send_notifications_to_logs option

This new option introduced will give to the charms ability to set
additional 'log' driver so the oslo messaging notifications will also
be sent to the system logs

Related-to:
  https://bugs.launchpad.net/charm-nova-compute/+bug/1825016