### PR TITLE
Add Contexts for Nova Vendor Metadata

### DIFF
--- a/charmhelpers/contrib/openstack/templates/vendor_data.json
+++ b/charmhelpers/contrib/openstack/templates/vendor_data.json
@@ -1,0 +1,1 @@
+{{ vendor_data_json }}


### PR DESCRIPTION
Added two new generic contexts to avoid more duplication
of code on several projects when dealing with nova
vendor metadata.

NovaVendorMetadataContext is responsible for reading
"vendor-data" and "vendor-data-url" config options and
returning the proper context for setting the values to
nova.conf file. If a particular charm needs to complement
the logic, such as disregarding a certain value for a
given OpenStack release or propagating the values to a
relation, it is recommended that the context is inherited
and specialized for that particular charm.

NovaVendorMetadataJSONContext is responsible for reading
only the vendor-data config option, validating it and
returning the context to write the value to vendor_data.json
file. Since this context is simple enough, it is included a
min_release and max_release validation in order to not need
to be inherited and specialized for that purpose.

Related-Bug: #1777714