### PR TITLE
Add source keys before the apt list entry.

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -522,14 +522,16 @@ def add_source(source, key=None, fail_invalid=False):
     for r, fn in six.iteritems(_mapping):
         m = re.match(r, source)
         if m:
-            # call the assoicated function with the captured groups
-            # raises SourceConfigError on error.
-            fn(*m.groups())
             if key:
+                # Import key before adding the source which depends on it,
+                # as refreshing packages could fail otherwise.
                 try:
                     import_key(key)
                 except GPGKeyError as e:
                     raise SourceConfigError(str(e))
+            # call the associated function with the captured groups
+            # raises SourceConfigError on error.
+            fn(*m.groups())
             break
     else:
         # nothing matched.  log an error and maybe sys.exit

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -415,11 +415,22 @@ class FetchTest(TestCase):
                                           get_distrib_codename, log,
                                           dearmor_gpg_key,
                                           w_keyfile):
+
+        def check_call_side_effect(args):
+            # Make sure the gpg key has already been added before the
+            # add-apt-repository call, as the update could fail otherwise.
+            popen.assert_called_with(
+                ['gpg', '--with-colons', '--with-fingerprint'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE)
+            return 0
+
         source = "http://archive.ubuntu.com/ubuntu raring-backports main"
         key = PGP_KEY_ASCII_ARMOR
         key_bytes = PGP_KEY_ASCII_ARMOR.encode('utf-8')
         get_distrib_codename.return_value = 'trusty'
-        check_call.return_value = 0
+        check_call.side_effect = check_call_side_effect
 
         expected_key = '35F77D63B5CEC106C577ED856E85A86E4652B4E6'
         if six.PY3:
@@ -456,11 +467,22 @@ fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
                                           get_distrib_codename, log,
                                           dearmor_gpg_key,
                                           w_keyfile):
+
+        def check_call_side_effect(args):
+            # Make sure the gpg key has already been added before the
+            # add-apt-repository call, as the update could fail otherwise.
+            popen.assert_called_with(
+                ['gpg', '--with-colons', '--with-fingerprint'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE)
+            return 0
+
         source = "http://archive.ubuntu.com/ubuntu raring-backports main"
         key = PGP_KEY_ASCII_ARMOR
         key_bytes = PGP_KEY_ASCII_ARMOR.encode('utf-8')
         get_distrib_codename.return_value = 'bionic'
-        check_call.return_value = 0
+        check_call.side_effect = check_call_side_effect
 
         expected_key = '35F77D63B5CEC106C577ED856E85A86E4652B4E6'
 


### PR DESCRIPTION
add-apt-repository now defaults to doing update after adding a source,
but providing a "deb http:..." source requires adding the repository
key for a successful refresh. This translates to failed refreshes which
differs to when "ppa:..." sources (which automatically import
keys prior to the refresh) are specified.

This change inverts adding keys and sources so that required GPG material is
present before adding the source, and before any potential apt update.