### PR TITLE
Fix wrong usage of relation_get in *_broker_action_done

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1488,7 +1488,7 @@ def is_broker_action_done(action, rid=None, unit=None):
     @param action: name of action to be performed
     @returns True if action complete otherwise False
     """
-    rdata = relation_get(rid, unit) or {}
+    rdata = relation_get(rid=rid, unit=unit) or {}
     broker_rsp = rdata.get(get_broker_rsp_key())
     if not broker_rsp:
         return False
@@ -1510,7 +1510,7 @@ def mark_broker_action_done(action, rid=None, unit=None):
     @param action: name of action to be performed
     @returns None
     """
-    rdata = relation_get(rid, unit) or {}
+    rdata = relation_get(rid=rid, unit=unit) or {}
     broker_rsp = rdata.get(get_broker_rsp_key())
     if not broker_rsp:
         return

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1540,7 +1540,7 @@ class CephUtilsTests(TestCase):
                 action = 'restart_nova_compute'
                 ret = ceph_utils.is_broker_action_done(action, rid="ceph:1",
                                                        unit="ceph/0")
-                self.relation_get.assert_has_calls([call('ceph:1', 'ceph/0')])
+                self.relation_get.assert_has_calls([call(rid='ceph:1', unit='ceph/0')])
                 self.assertFalse(ret)
 
                 ceph_utils.mark_broker_action_done(action)
@@ -1567,7 +1567,7 @@ class CephUtilsTests(TestCase):
                 ceph_utils.mark_broker_action_done(action, rid="ceph:1",
                                                    unit="ceph/0")
                 key = 'unit_0_ceph_broker_action.{}'.format(action)
-                self.relation_get.assert_has_calls([call('ceph:1', 'ceph/0')])
+                self.relation_get.assert_has_calls([call(rid='ceph:1', unit='ceph/0')])
                 kvstore = Storage(db_path)
                 self.assertEqual(kvstore.get(key=key), rq_id)
         finally:


### PR DESCRIPTION
Because of wrong usage, it doesn't behaviour as expected.
e.g when config-changed hook, it runs multiple times 
when there are multiple ceph-mons
Making it use right signature and reduce 2 lines to 1 line.