### PR TITLE
Ensure CephContext will correctly be incomplete

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -781,6 +781,25 @@ class CephContext(OSContextGenerator):
         ensure_packages(['ceph-common'])
         return ctxt
 
+    def context_complete(self, ctxt):
+        """Overridden here to ensure the context is actually complete.
+
+        We set `key` and `auth` to None here, by default, to ensure
+        that the context will always evaluate to incomplete until the
+        Ceph relation has actually sent these details; otherwise,
+        there is a potential race condition between the relation
+        appearing and the first unit actually setting this data on the
+        relation.
+
+        :param ctxt: The current context members
+        :type ctxt: Dict[str, ANY]
+        :returns: True if the context is complete
+        :rtype: bool
+        """
+        if 'auth' not in ctxt or 'key' not in ctxt:
+            return False
+        return super(CephContext, self).context_complete(ctxt)
+
 
 class HAProxyContext(OSContextGenerator):
     """Provides half a context for the haproxy template, which describes

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1510,6 +1510,15 @@ class ContextTests(unittest.TestCase):
         result = ceph()
         self.assertEquals(result, {})
 
+    def test_ceph_rel_with_no_units(self):
+        '''Test ceph context with missing related units'''
+        relation = FakeRelation(relation_data={})
+        self.relation_ids.side_effect = relation.relation_ids
+        self.related_units.side_effect = []
+        ceph = context.CephContext()
+        result = ceph()
+        self.assertEquals(result, {})
+
     @patch.object(context, 'config')
     @patch('os.path.isdir')
     @patch('os.mkdir')
@@ -1538,7 +1547,6 @@ class ContextTests(unittest.TestCase):
         }
         self.assertEquals(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
-        mkdir.assert_called_with('/etc/ceph')
 
     @patch('os.mkdir')
     @patch.object(context, 'ensure_packages')


### PR DESCRIPTION
If the relation appears before a unit appears on the
relation, it is possible to end up with a context that
is considered complete even though it is missing all of
the required relation data. This change ensures that we
cannot complete until the relation is complete