### PR TITLE
Allow disabling load balancing

### DIFF
--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1908,7 +1908,8 @@ class ContextTests(unittest.TestCase):
         self.relation_get.side_effect = relation.get
         self.related_units.side_effect = relation.relation_units
         self.get_netmask_for_address.return_value = '255.255.0.0'
-        self.config.return_value = False
+        self.config.side_effect = [
+            True, True, False, False, False, False, False, False, False, False]
         self.maxDiff = None
         self.is_ipv6_disabled.return_value = True
         haproxy = context.HAProxyContext()
@@ -2038,7 +2039,8 @@ class ContextTests(unittest.TestCase):
                                             'cluster-peer0.public',
                                             'cluster-peer0.localnet']
         self.get_netmask_for_address.return_value = '255.255.0.0'
-        self.config.return_value = False
+        self.config.side_effect = [
+            True, True, False, False, False, False, False, False, False, False]
         self.maxDiff = None
         self.is_ipv6_disabled.return_value = True
         haproxy = context.HAProxyContext()
@@ -2263,7 +2265,8 @@ class ContextTests(unittest.TestCase):
         self.relation_ids.side_effect = relation.relation_ids
         self.relation_get.side_effect = relation.get
         self.related_units.side_effect = relation.relation_units
-        self.config.return_value = False
+        self.config.side_effect = [
+            True, True, False, False, False, False, False, False, False, False]
         haproxy = context.HAProxyContext()
         self.assertEquals({}, haproxy())
         self.get_relation_ip.assert_has_calls([call('admin', False),
@@ -2356,6 +2359,54 @@ class ContextTests(unittest.TestCase):
                                                call('internal', False),
                                                call('public', False),
                                                call('cluster')])
+
+    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_unit')
+    def test_haproxy_context_no_lb(self, local_unit, unit_get):
+        '''Test haproxy context with all relation data'''
+        cluster_relation = {
+            'cluster:0': {
+                'peer/1': {
+                    'private-address': 'cluster-peer1.localnet',
+                },
+                'peer/2': {
+                    'private-address': 'cluster-peer2.localnet',
+                },
+            },
+        }
+        local_unit.return_value = 'peer/0'
+        # We are only using get_relation_ip.
+        # Setup the values it returns on each subsequent call.
+        self.get_relation_ip.side_effect = [None, None, None,
+                                            'cluster-peer0.localnet']
+        relation = FakeRelation(cluster_relation)
+        self.relation_ids.side_effect = relation.relation_ids
+        self.relation_get.side_effect = relation.get
+        self.get_netmask_for_address.return_value = '255.255.0.0'
+        self.config.return_value = False
+        self.maxDiff = None
+        self.is_ipv6_disabled.return_value = True
+        haproxy = context.HAProxyContext()
+        with patch_open() as (_open, _file):
+            result = haproxy()
+        ex = {
+            'frontends': {
+                'cluster-peer0.localnet': {
+                    'network': 'cluster-peer0.localnet/255.255.0.0',
+                    'backends': collections.OrderedDict([
+                        ('peer-0', 'cluster-peer0.localnet'),
+                    ]),
+                },
+            },
+            'default_backend': 'cluster-peer0.localnet',
+            'local_host': '127.0.0.1',
+            'haproxy_host': '0.0.0.0',
+            'ipv6_enabled': False,
+            'stat_password': 'testpassword',
+            'stat_port': '8888',
+        }
+        # the context gets generated.
+        self.assertEquals(ex, result)
 
     def test_https_context_with_no_https(self):
         '''Test apache2 https when no https data available'''


### PR DESCRIPTION
This patchset implements a logic to control whether HAProxy load
balancing should be enabled or not based on the 'ha' relation data.

Partial-Bug: 1827356