### PR TITLE
Add relation support for firewall group logging

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1710,6 +1710,10 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-nsg-logging',
                 'default': False,
             },
+            'enable_nfg_logging': {
+                'rel_key': 'enable-nfg-logging',
+                'default': False,
+            },
             'global_physnet_mtu': {
                 'rel_key': 'global-physnet-mtu',
                 'default': 1500,

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3547,6 +3547,22 @@ class ContextTests(unittest.TestCase):
         api_ctxt = context.NeutronAPIContext()()
         self.assertEquals(api_ctxt['extension_drivers'], 'qos,log')
 
+    def test_neutronapicontext_firewall_group_logging_on(self):
+        self.setup_neutron_api_context_relation({
+            'enable-nfg-logging': 'True',
+            'l2-population': 'True'
+        })
+        api_ctxt = context.NeutronAPIContext()()
+        self.assertEquals(api_ctxt['enable_nfg_logging'], True)
+
+    def test_neutronapicontext_firewall_group_logging_off(self):
+        self.setup_neutron_api_context_relation({
+            'enable-nfg-logging': 'False',
+            'l2-population': 'True'
+        })
+        api_ctxt = context.NeutronAPIContext()()
+        self.assertEquals(api_ctxt['enable_nfg_logging'], False)
+
     def test_neutronapicontext_string_converted(self):
         self.setup_neutron_api_context_relation({
             'l2-population': 'True'})


### PR DESCRIPTION
Add relation keys to support configuration of Neutron Firewall
Group logging in the neutron-gateway charm.