### PR TITLE
Set unit_name when requesting certificates.

### DIFF
--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -106,9 +106,11 @@ class CertRequest(object):
             sans = sorted(list(set(entry['addresses'])))
             request[entry['cn']] = {'sans': sans}
         if self.json_encode:
-            return {'cert_requests': json.dumps(request, sort_keys=True)}
+            req = {'cert_requests': json.dumps(request, sort_keys=True)}
         else:
-            return {'cert_requests': request}
+            req = {'cert_requests': request}
+        req['unit_name'] = local_unit().replace('/', '_')
+        return req
 
 
 def get_certificate_request(json_encode=True):

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -12,21 +12,24 @@ class CertUtilsTests(unittest.TestCase):
         self.assertEqual(cr.entries, [])
         self.assertIsNone(cr.hostname_entry)
 
-    def test_CertRequest_add_entry(self):
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
+    def test_CertRequest_add_entry(self, local_unit):
         cr = cert_utils.CertRequest()
         cr.add_entry('admin', 'admin.openstack.local', ['10.10.10.10'])
         self.assertEqual(
             cr.get_request(),
             {'cert_requests':
-                '{"admin.openstack.local": {"sans": ["10.10.10.10"]}}'})
+                '{"admin.openstack.local": {"sans": ["10.10.10.10"]}}',
+             'unit_name': 'unit_2'})
 
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
     @mock.patch.object(cert_utils, 'get_hostname')
     @mock.patch.object(cert_utils, 'unit_get')
     def test_CertRequest_add_hostname_cn(self, unit_get, get_hostname,
                                          get_vip_in_network,
-                                         resolve_network_cidr):
+                                         resolve_network_cidr, local_unit):
         resolve_network_cidr.side_effect = lambda x: x
         get_vip_in_network.return_value = '10.1.2.100'
         unit_get.return_value = '10.1.2.3'
@@ -36,15 +39,17 @@ class CertUtilsTests(unittest.TestCase):
         self.assertEqual(
             cr.get_request(),
             {'cert_requests':
-                '{"juju-unit-2": {"sans": ["10.1.2.100", "10.1.2.3"]}}'})
+                '{"juju-unit-2": {"sans": ["10.1.2.100", "10.1.2.3"]}}',
+             'unit_name': 'unit_2'})
 
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
     @mock.patch.object(cert_utils, 'get_hostname')
     @mock.patch.object(cert_utils, 'unit_get')
     def test_CertRequest_add_hostname_cn_ip(self, unit_get, get_hostname,
                                             get_vip_in_network,
-                                            resolve_network_cidr):
+                                            resolve_network_cidr, local_unit):
         resolve_network_cidr.side_effect = lambda x: x
         get_vip_in_network.return_value = '10.1.2.100'
         unit_get.return_value = '10.1.2.3'
@@ -56,8 +61,10 @@ class CertUtilsTests(unittest.TestCase):
             cr.get_request(),
             {'cert_requests':
                 ('{"juju-unit-2": {"sans": ["10.1.2.100", "10.1.2.3", '
-                 '"10.1.2.4"]}}')})
+                 '"10.1.2.4"]}}'),
+             'unit_name': 'unit_2'})
 
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
     @mock.patch.object(cert_utils, 'network_get_primary_address')
@@ -68,7 +75,8 @@ class CertUtilsTests(unittest.TestCase):
     def test_get_certificate_request(self, unit_get, get_hostname,
                                      config, resolve_address,
                                      network_get_primary_address,
-                                     get_vip_in_network, resolve_network_cidr):
+                                     get_vip_in_network, resolve_network_cidr,
+                                     local_unit):
         unit_get.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {


### PR DESCRIPTION
A fix has landed in the tls-certificates interface to support
relating to vaults certificates relation over a cross-model
relation *1. The old style charms do not use this interface
so the fixes need to be ported to charm helpers. The fix works by
having the client explicitly publish a unit name in the
relation data. That unit name is then used by the client
when looking up its certificates in the returned dict.

*1 https://github.com/juju-solutions/interface-tls-certificates/commit/231c86ce4086fa4d3d78414594336089b519f704