### PR TITLE
Make ConfigParser not strict

### DIFF
--- a/charmhelpers/contrib/openstack/audits/openstack_security_guide.py
+++ b/charmhelpers/contrib/openstack/audits/openstack_security_guide.py
@@ -126,7 +126,11 @@ def _config_ini(path):
     :returns: Configuration contained in path
     :rtype: Dict
     """
-    conf = configparser.ConfigParser()
+    # When strict is enabled, duplicate options are not allowed in the
+    # parsed INI; however, Oslo allows duplicate values. This change
+    # causes us to ignore the duplicate values which is acceptable as
+    # long as we don't validate any multi-value options
+    conf = configparser.ConfigParser(strict=False)
     conf.read(path)
     return dict(conf)
 

--- a/tests/contrib/openstack/test_audits.py
+++ b/tests/contrib/openstack/test_audits.py
@@ -1,5 +1,5 @@
 from testtools import TestCase, skipIf
-from mock import patch
+from mock import patch, MagicMock
 import six
 
 import charmhelpers.contrib.openstack.audits as audits
@@ -191,6 +191,14 @@ class AuditsTestCase(TestCase):
 
 @skipIf(six.PY2, 'Audits only support Python3')
 class OpenstackSecurityGuideTestCase(TestCase):
+
+    @patch('configparser.ConfigParser')
+    def test_internal_config_parser_is_not_strict(self, _config_parser):
+        parser = MagicMock()
+        _config_parser.return_value = parser
+        guide._config_ini('test')
+        _config_parser.assert_called_with(strict=False)
+        parser.read.assert_called_with('test')
 
     @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._stat')
     def test_internal_validate_file_ownership(self, _stat):


### PR DESCRIPTION
When strict is enabled, duplicate options are not allowed in the
parsed INI; however, Oslo allows duplicate values. This change
causes us to ignore the duplicate values which is acceptable as
long as we don't validate any multi-value options