### PR TITLE
Replace ``python-apt`` functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ userinstall:
 
 
 .venv:
-	dpkg-query -W -f='$${status}' gcc python-dev python-virtualenv python-apt 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python-dev python-virtualenv python-apt
+	dpkg-query -W -f='$${status}' gcc python-dev python-virtualenv 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python-dev python-virtualenv
 	virtualenv .venv --system-site-packages
 	.venv/bin/pip install -U pip
 	.venv/bin/pip install -I -r test_requirements.txt

--- a/charmhelpers/contrib/hardening/audits/apt.py
+++ b/charmhelpers/contrib/hardening/audits/apt.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import  # required for external apt import
-from apt import apt_pkg
 from six import string_types
 
 from charmhelpers.fetch import (
@@ -26,6 +25,7 @@ from charmhelpers.core.hookenv import (
     WARNING,
 )
 from charmhelpers.contrib.hardening.audits import BaseAudit
+from charmhelpers.fetch import ubuntu_apt_pkg as apt_pkg
 
 
 class AptConfig(BaseAudit):

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -84,7 +84,8 @@ from charmhelpers.fetch import (
     SourceConfigError,
     GPGKeyError,
     get_upstream_version,
-    filter_missing_packages
+    filter_missing_packages,
+    ubuntu_apt_pkg as apt,
 )
 
 from charmhelpers.fetch.snap import (
@@ -443,8 +444,6 @@ def get_os_codename_package(package, fatal=True):
                 # Second item in list is Version
                 return line.split()[1]
 
-    import apt_pkg as apt
-
     cache = apt_cache()
 
     try:
@@ -658,7 +657,6 @@ def openstack_upgrade_available(package):
                          a newer version of package.
     """
 
-    import apt_pkg as apt
     src = config('openstack-origin')
     cur_vers = get_os_version_package(package)
     if not cur_vers:

--- a/charmhelpers/core/host_factory/ubuntu.py
+++ b/charmhelpers/core/host_factory/ubuntu.py
@@ -93,7 +93,7 @@ def cmp_pkgrevno(package, revno, pkgcache=None):
     the pkgcache argument is None. Be sure to add charmhelpers.fetch if
     you call this function, or pass an apt_pkg.Cache() instance.
     """
-    import apt_pkg
+    from charmhelpers.fetch import apt_pkg
     if not pkgcache:
         from charmhelpers.fetch import apt_cache
         pkgcache = apt_cache()

--- a/charmhelpers/fetch/__init__.py
+++ b/charmhelpers/fetch/__init__.py
@@ -103,6 +103,7 @@ if __platform__ == "ubuntu":
     apt_unhold = fetch.apt_unhold
     import_key = fetch.import_key
     get_upstream_version = fetch.get_upstream_version
+    apt_pkg = fetch.ubuntu_apt_pkg
 elif __platform__ == "centos":
     yum_search = fetch.yum_search
 

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -218,11 +218,11 @@ def filter_missing_packages(packages):
     )
 
 
-def apt_cache(in_memory=True, progress=None):
+def apt_cache(*_):
     """Shim returning an object simulating the apt_pkg Cache.
 
-    :param in_memory: Kept for compability reasons, has no effect.
-    :param progress: Kept for compability reasons, has no effect.
+    :param _: Accept arguments for compability, not used.
+    :type _: any
     :returns:Object used to interrogate the system apt and dpkg databases.
     :rtype:ubuntu_apt_pkg.Cache
     """

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -218,11 +218,13 @@ def filter_missing_packages(packages):
     )
 
 
-def apt_cache(*_):
+def apt_cache(*_, **__):
     """Shim returning an object simulating the apt_pkg Cache.
 
     :param _: Accept arguments for compability, not used.
     :type _: any
+    :param __: Accept keyword arguments for compability, not used.
+    :type __: any
     :returns:Object used to interrogate the system apt and dpkg databases.
     :rtype:ubuntu_apt_pkg.Cache
     """

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -17,8 +17,8 @@ import os
 import platform
 import re
 import six
-import time
 import subprocess
+import time
 
 from charmhelpers.core.host import get_distrib_codename
 
@@ -29,6 +29,7 @@ from charmhelpers.core.hookenv import (
     env_proxy_settings,
 )
 from charmhelpers.fetch import SourceConfigError, GPGKeyError
+from charmhelpers.fetch import ubuntu_apt_pkg
 
 PROPOSED_POCKET = (
     "# Proposed\n"
@@ -217,13 +218,14 @@ def filter_missing_packages(packages):
 
 
 def apt_cache(in_memory=True, progress=None):
-    """Build and return an apt cache."""
-    from apt import apt_pkg
-    apt_pkg.init()
-    if in_memory:
-        apt_pkg.config.set("Dir::Cache::pkgcache", "")
-        apt_pkg.config.set("Dir::Cache::srcpkgcache", "")
-    return apt_pkg.Cache(progress)
+    """Shim returning an object simulating the apt_pkg Cache.
+
+    :param in_memory: Kept for compability reasons, has no effect.
+    :param progress: Kept for compability reasons, has no effect.
+    :returns:Object used to interrogate the system apt and dpkg databases.
+    :rtype:ubuntu_apt_pkg.Cache
+    """
+    return ubuntu_apt_pkg.Cache()
 
 
 def apt_install(packages, options=None, fatal=False):
@@ -723,7 +725,6 @@ def get_upstream_version(package):
 
     @returns None (if not installed) or the upstream version
     """
-    import apt_pkg
     cache = apt_cache()
     try:
         pkg = cache[package]
@@ -735,4 +736,4 @@ def get_upstream_version(package):
         # package is known, but no version is currently installed.
         return None
 
-    return apt_pkg.upstream_version(pkg.current_ver.ver_str)
+    return ubuntu_apt_pkg.upstream_version(pkg.current_ver.ver_str)

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -18,6 +18,7 @@ import platform
 import re
 import six
 import subprocess
+import sys
 import time
 
 from charmhelpers.core.host import get_distrib_codename
@@ -225,6 +226,17 @@ def apt_cache(in_memory=True, progress=None):
     :returns:Object used to interrogate the system apt and dpkg databases.
     :rtype:ubuntu_apt_pkg.Cache
     """
+    if 'apt_pkg' in sys.modules:
+        # NOTE(fnordahl): When our consumer use the upstream ``apt_pkg`` module
+        # in conjunction with the apt_cache helper function, they may expect us
+        # to call ``apt_pkg.init()`` for them.
+        #
+        # Detect this situation, log a warning and make the call to
+        # ``apt_pkg.init()`` to avoid the consumer Python interpreter from
+        # crashing with a segmentation fault.
+        log('Support for use of upstream ``apt_pkg`` module in conjunction'
+            'with charm-helpers is deprecated since 2019-06-25', level=WARNING)
+        sys.modules['apt_pkg'].init()
     return ubuntu_apt_pkg.Cache()
 
 

--- a/charmhelpers/fetch/ubuntu_apt_pkg.py
+++ b/charmhelpers/fetch/ubuntu_apt_pkg.py
@@ -40,17 +40,10 @@ import os
 import subprocess
 
 
-class _container(object):
+class _container(dict):
     """Simple container for attributes."""
-    def __init__(self, attr_map):
-        """Initialize package attribute container.
-
-        :param attr_map: Dictionary key value pairs to transform into
-                         attributes with a value on instance of the class.
-        :type attr_map: Dict[str, str]
-        """
-        for k, v in attr_map.items():
-            setattr(self, k, v)
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
 
 
 class Package(_container):

--- a/charmhelpers/fetch/ubuntu_apt_pkg.py
+++ b/charmhelpers/fetch/ubuntu_apt_pkg.py
@@ -1,0 +1,245 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provide a subset of the ``python-apt`` module API.
+
+Data collection is done through subprocess calls to ``apt-cache`` and
+``dpkg-query`` commands.
+
+The main purpose for this module is to avoid dependency on the
+``python-apt`` python module.
+
+The indicated python module is a wrapper around the ``apt`` C++ library
+which is tightly connected to the version of the distribution it was
+shipped on.  It is not developed in a backward/forward compatible manner.
+
+This in turn makes it incredibly hard to distribute as a wheel for a piece
+of python software that supports a span of distro releases [0][1].
+
+Upstream feedback like [2] does not give confidence in this ever changing,
+so with this we get rid of the dependency.
+
+0: https://github.com/juju-solutions/layer-basic/pull/135
+1: https://bugs.launchpad.net/charm-octavia/+bug/1824112
+2: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845330#10
+"""
+
+import locale
+import os
+import subprocess
+
+
+class _container(object):
+    """Simple container for attributes."""
+    def __init__(self, attr_map):
+        """Initialize package attribute container.
+
+        :param attr_map: Dictionary key value pairs to transform into
+                         attributes with a value on instance of the class.
+        :type attr_map: Dict[str, str]
+        """
+        for k, v in attr_map.items():
+            setattr(self, k, v)
+
+
+class Package(_container):
+    """Simple container for package attributes."""
+
+
+class Version(_container):
+    """Simple container for version attributes."""
+
+
+class Cache(object):
+    """Simulation of ``apt_pkg`` Cache object."""
+    def __init__(self, progress=None):
+        pass
+
+    def __getitem__(self, package):
+        """Get information about a package from apt and dpkg databases.
+
+        :param package: Name of package
+        :type package: str
+        :returns: Package object
+        :rtype: object
+        :raises: KeyError, subprocess.CalledProcessError
+        """
+        apt_result = self._apt_cache_show([package])[package]
+        apt_result['name'] = apt_result.pop('package')
+        pkg = Package(apt_result)
+        dpkg_result = self._dpkg_list([package]).get(package, {})
+        current_ver = None
+        installed_version = dpkg_result.get('version')
+        if installed_version:
+            current_ver = Version({'ver_str': installed_version})
+        pkg.current_ver = current_ver
+        pkg.architecture = dpkg_result.get('architecture')
+        return pkg
+
+    def _dpkg_list(self, packages):
+        """Get data from system dpkg database for package.
+
+        :param packages: Packages to get data from
+        :type packages: List[str]
+        :returns: Structured data about installed packages, keys like
+                  ``dpkg-query --list``
+        :rtype: dict
+        :raises: subprocess.CalledProcessError
+        """
+        pkgs = {}
+        cmd = ['dpkg-query', '--list']
+        cmd.extend(packages)
+        if locale.getlocale() == (None, None):
+            # subprocess calls out to locale.getpreferredencoding(False) to
+            # determine encoding.  Workaround for Trusty where the
+            # environment appears to not be set up correctly.
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+        try:
+            output = subprocess.check_output(cmd,
+                                             stderr=subprocess.STDOUT,
+                                             universal_newlines=True)
+        except subprocess.CalledProcessError as cp:
+            # ``dpkg-query`` may return error and at the same time have
+            # produced useful output, for example when asked for multiple
+            # packages where some are not installed
+            if cp.returncode != 1:
+                raise
+            output = cp.output
+        headings = []
+        for line in output.splitlines():
+            if line.startswith('||/'):
+                headings = line.split()
+                headings.pop(0)
+                continue
+            elif (line.startswith('|') or line.startswith('+') or
+                  line.startswith('dpkg-query:')):
+                continue
+            else:
+                data = line.split(None, 4)
+                status = data.pop(0)
+                if status != 'ii':
+                    continue
+                pkg = {}
+                pkg.update({k.lower(): v for k, v in zip(headings, data)})
+                if 'name' in pkg:
+                    pkgs.update({pkg['name']: pkg})
+        return pkgs
+
+    def _apt_cache_show(self, packages):
+        """Get data from system apt cache for package.
+
+        :param packages: Packages to get data from
+        :type packages: List[str]
+        :returns: Structured data about package, keys like
+                  ``apt-cache show``
+        :rtype: dict
+        :raises: subprocess.CalledProcessError
+        """
+        pkgs = {}
+        cmd = ['apt-cache', 'show', '--no-all-versions']
+        cmd.extend(packages)
+        if locale.getlocale() == (None, None):
+            # subprocess calls out to locale.getpreferredencoding(False) to
+            # determine encoding.  Workaround for Trusty where the
+            # environment appears to not be set up correctly.
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+        try:
+            output = subprocess.check_output(cmd,
+                                             stderr=subprocess.STDOUT,
+                                             universal_newlines=True)
+            previous = None
+            pkg = {}
+            for line in output.splitlines():
+                if not line:
+                    if 'package' in pkg:
+                        pkgs.update({pkg['package']: pkg})
+                        pkg = {}
+                    continue
+                if line.startswith(' '):
+                    if previous and previous in pkg:
+                        pkg[previous] += os.linesep + line.lstrip()
+                    continue
+                if ':' in line:
+                    kv = line.split(':', 1)
+                    key = kv[0].lower()
+                    if key == 'n':
+                        continue
+                    previous = key
+                    pkg.update({key: kv[1].lstrip()})
+        except subprocess.CalledProcessError as cp:
+            # ``apt-cache`` returns 100 if none of the packages asked for
+            # exist in the apt cache.
+            if cp.returncode != 100:
+                raise
+        return pkgs
+
+
+def init():
+    """Compability shim that does nothing."""
+    pass
+
+
+def upstream_version(version):
+    """Extracts upstream version from a version string.
+
+    Upstream reference: https://salsa.debian.org/apt-team/apt/blob/master/
+                                apt-pkg/deb/debversion.cc#L259
+
+    :param version: Version string
+    :type version: str
+    :returns: Upstream version
+    :rtype: str
+    """
+    if version:
+        version = version[version.find(':') + 1:]
+        if '-' in version:
+            version = version[:version.find('-')]
+    return version
+
+
+def version_compare(a, b):
+    """Compare the given versions.
+
+    Call out to ``dpkg`` to make sure the code doing the comparison is
+    compatible with what the ``apt`` library would do.  Mimic the return
+    values.
+
+    Upstream reference:
+    https://apt-team.pages.debian.net/python-apt/library/apt_pkg.html
+            ?highlight=version_compare#apt_pkg.version_compare
+
+    :param a: version string
+    :type a: str
+    :param b: version string
+    :type b: str
+    :returns: >0 if ``a`` is greater than ``b``, 0 if a equals b,
+              <0 if ``a`` is smaller than ``b``
+    :rtype: int
+    :raises: subprocess.CalledProcessError, RuntimeError
+    """
+    for op in ('gt', 1), ('eq', 0), ('lt', -1):
+        try:
+            subprocess.check_call(['dpkg', '--compare-versions',
+                                   a, op[0], b],
+                                  stderr=subprocess.STDOUT,
+                                  universal_newlines=True)
+            return op[1]
+        except subprocess.CalledProcessError as cp:
+            if cp.returncode == 1:
+                continue
+            raise
+    else:
+        raise RuntimeError('Unable to compare "{}" and "{}", according to '
+                           'our logic they are neither greater, equal nor '
+                           'less than each other.')

--- a/charmhelpers/fetch/ubuntu_apt_pkg.py
+++ b/charmhelpers/fetch/ubuntu_apt_pkg.py
@@ -202,9 +202,8 @@ def upstream_version(version):
     :rtype: str
     """
     if version:
-        version = version[version.find(':') + 1:]
-        if '-' in version:
-            version = version[:version.find('-')]
+        version = version.split(':')[-1]
+        version = version.split('-')[0]
     return version
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ SETUP = {
         'Tempita',
         'Jinja2',
         'six',
+        'psutil',
     ],
     'packages': find_packages(exclude=('tests', 'tests.*', 'tools', 'tools.*')),
     'scripts': [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 # Test-only dependencies are unpinned.
 #
 git+https://git.launchpad.net/ubuntu/+source/python-distutils-extra
-git+https://git.launchpad.net/python-apt@1.1.y-xenial
 pip
 six
 coverage>=3.6

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -300,7 +300,7 @@ class OpenStackHelpersTestCase(TestCase):
     def test_os_codename_from_package(self, mock_snap_install_requested):
         """Test deriving OpenStack codename from an installed package"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             for pkg, vers in six.iteritems(FAKE_REPO):
                 # test fake repo for all "installed" packages
@@ -317,7 +317,7 @@ class OpenStackHelpersTestCase(TestCase):
                                                   mock_snap_install_requested):
         """Test deriving OpenStack codename for a poorly versioned package"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             openstack.get_os_codename_package('bad-version')
             _e = ('Could not determine OpenStack codename for version 2200.1')
@@ -329,7 +329,7 @@ class OpenStackHelpersTestCase(TestCase):
                                           mock_snap_install_requested):
         """Test deriving OpenStack codename from an unavailable package"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_codename_package('foo')
@@ -346,7 +346,7 @@ class OpenStackHelpersTestCase(TestCase):
             self, mock_snap_install_requested):
         """Test OpenStack codename from an unavailable package is non-fatal"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             self.assertEquals(
                 None,
@@ -359,7 +359,7 @@ class OpenStackHelpersTestCase(TestCase):
                                                   mock_snap_install_requested):
         """Test OpenStack codename from an available but uninstalled pkg"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_codename_package('cinder-common', fatal=True)
@@ -374,7 +374,7 @@ class OpenStackHelpersTestCase(TestCase):
             self, mock_snap_install_requested):
         """Test OpenStack codename from avail uninstalled pkg is non fatal"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             self.assertEquals(
                 None,
@@ -387,7 +387,7 @@ class OpenStackHelpersTestCase(TestCase):
                                      mock_snap_install_requested):
         """Test deriving OpenStack version from an installed package"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             for pkg, vers in six.iteritems(FAKE_REPO):
                 if pkg.startswith('bad-'):
@@ -403,7 +403,7 @@ class OpenStackHelpersTestCase(TestCase):
                                          mock_snap_install_requested):
         """Test deriving OpenStack version from an uninstalled package"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             try:
                 openstack.get_os_version_package('foo')
@@ -420,7 +420,7 @@ class OpenStackHelpersTestCase(TestCase):
             self, mock_snap_install_requested):
         """Test OpenStack version from an uninstalled package is non-fatal"""
         mock_snap_install_requested.return_value = False
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             self.assertEquals(
                 None,
@@ -1734,7 +1734,7 @@ class OpenStackHelpersTestCase(TestCase):
     def test_os_application_version_set(self,
                                         mock_application_version_set,
                                         mock_os_release):
-        with patch('apt_pkg.Cache') as cache:
+        with patch.object(fetch, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
             mock_os_release.return_value = 'mitaka'
             openstack.os_application_version_set('neutron-common')

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -5,7 +5,6 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from textwrap import dedent
 
-import apt_pkg
 import imp
 
 from charmhelpers import osplatform
@@ -16,6 +15,7 @@ from tests.helpers import mock_open as mocked_open
 import six
 
 from charmhelpers.core import host
+from charmhelpers.fetch import ubuntu_apt_pkg
 
 
 MOUNT_LINES = ("""
@@ -1766,7 +1766,7 @@ class HelpersTest(TestCase):
         self.assertEqual(host.get_distrib_codename(), 'bionic')
 
     @patch.object(osplatform, 'get_platform')
-    @patch.object(apt_pkg, 'Cache')
+    @patch.object(ubuntu_apt_pkg, 'Cache')
     def test_cmp_pkgrevno_revnos_ubuntu(self, pkg_cache, platform):
         platform.return_value = 'ubuntu'
         imp.reload(host)

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -98,21 +98,21 @@ def getenv(update=None):
 class FetchTest(TestCase):
 
     @patch("charmhelpers.fetch.ubuntu.log")
-    @patch('apt_pkg.Cache')
+    @patch.object(fetch, 'apt_cache')
     def test_filter_packages_missing_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim', 'emacs'])
         self.assertEquals(result, ['emacs'])
 
     @patch("charmhelpers.fetch.ubuntu.log")
-    @patch('apt_pkg.Cache')
+    @patch.object(fetch, 'apt_cache')
     def test_filter_packages_none_missing_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim'])
         self.assertEquals(result, [])
 
     @patch('charmhelpers.fetch.ubuntu.log')
-    @patch('apt_pkg.Cache')
+    @patch.object(fetch, 'apt_cache')
     def test_filter_packages_not_available_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim', 'joe'])
@@ -980,7 +980,7 @@ class AptTests(TestCase):
         _run_apt_command(["some", "command"], fatal=True)
         self.assertTrue(sleep.called)
 
-    @patch('apt_pkg.Cache')
+    @patch.object(fetch, 'apt_cache')
     def test_get_upstream_version(self, cache):
         cache.side_effect = fake_apt_cache
         self.assertEqual(fetch.get_upstream_version('vim'), '7.3.547')

--- a/tests/fetch/test_fetch_ubuntu_apt_pkg.py
+++ b/tests/fetch/test_fetch_ubuntu_apt_pkg.py
@@ -1,0 +1,216 @@
+import mock
+import subprocess
+import unittest
+
+from charmhelpers.fetch import ubuntu_apt_pkg as apt_pkg
+
+
+class Test_apt_pkg_Cache(unittest.TestCase):
+    """Borrow PatchHelper methods from ``charms.openstack``."""
+    def setUp(self):
+        self._patches = {}
+        self._patches_start = {}
+
+    def tearDown(self):
+        for k, v in self._patches.items():
+            v.stop()
+            setattr(self, k, None)
+        self._patches = None
+        self._patches_start = None
+
+    def patch(self, patchee, name=None, **kwargs):
+        """Patch a patchable thing.  Uses mock.patch() to do the work.
+        Automatically unpatches at the end of the test.
+
+        The mock gets added to the test object (self) using 'name' or the last
+        part of the patchee string, after the final dot.
+
+        :param patchee: <string> representing module.object that is to be
+            patched.
+        :param name: optional <string> name to call the mock.
+        :param **kwargs: any other args to pass to mock.patch()
+        """
+        mocked = mock.patch(patchee, **kwargs)
+        if name is None:
+            name = patchee.split('.')[-1]
+        started = mocked.start()
+        self._patches[name] = mocked
+        self._patches_start[name] = started
+        setattr(self, name, started)
+
+    def patch_object(self, obj, attr, name=None, **kwargs):
+        """Patch a patchable thing.  Uses mock.patch.object() to do the work.
+        Automatically unpatches at the end of the test.
+
+        The mock gets added to the test object (self) using 'name' or the attr
+        passed in the arguments.
+
+        :param obj: an object that needs to have an attribute patched.
+        :param attr: <string> that represents the attribute being patched.
+        :param name: optional <string> name to call the mock.
+        :param **kwargs: any other args to pass to mock.patch()
+        """
+        mocked = mock.patch.object(obj, attr, **kwargs)
+        if name is None:
+            name = attr
+        started = mocked.start()
+        self._patches[name] = mocked
+        self._patches_start[name] = started
+        setattr(self, name, started)
+
+    def test_apt_cache_show(self):
+        self.patch_object(apt_pkg.subprocess, 'check_output')
+        apt_cache = apt_pkg.Cache()
+        self.check_output.return_value = (
+            'Package: dpkg\n'
+            'Version: 1.19.0.5ubuntu2.1\n'
+            'Bugs: https://bugs.launchpad.net/ubuntu/+filebug\n'
+            'Description-en: Debian package management system\n'
+            ' Multiline description\n'
+            '\n'
+            'Package: lsof\n'
+            'Architecture: amd64\n'
+            'Version: 4.91+dfsg-1ubuntu1\n'
+            '\n'
+            'N: There is 1 additional record.\n')
+        self.assertEquals(
+            apt_cache._apt_cache_show(['package']),
+            {'dpkg': {
+                'package': 'dpkg', 'version': '1.19.0.5ubuntu2.1',
+                'bugs': 'https://bugs.launchpad.net/ubuntu/+filebug',
+                'description-en': 'Debian package management system\n'
+                                  'Multiline description'},
+             'lsof': {
+                 'package': 'lsof', 'architecture': 'amd64',
+                 'version': '4.91+dfsg-1ubuntu1'},
+             })
+        self.check_output.assert_called_once_with(
+            ['apt-cache', 'show', '--no-all-versions', 'package'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+
+    def test_dpkg_list(self):
+        self.patch_object(apt_pkg.subprocess, 'check_output')
+        apt_cache = apt_pkg.Cache()
+        self.check_output.return_value = (
+            'Desired=Unknown/Install/Remove/Purge/Hold\n'
+            '| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/'
+            'trig-aWait/Trig-pend\n'
+            '|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)\n'
+            '||/ Name           Version            Architecture Description\n'
+            '+++-=============================-==================-===========-'
+            '=================================\n'
+            'ii  dpkg                          1.19.0.5ubuntu2.1  amd64       '
+            'Debian package management system\n'
+            'rc  linux-image-4.15.0-42-generic 4.15.0-42.45       amd64       '
+            'Signed kernel image generic\n'
+            'ii  lsof                          4.91+dfsg-1ubuntu1 amd64       '
+            'utility to list open files\n')
+        expect = {
+            'dpkg': {
+                'name': 'dpkg',
+                'version': '1.19.0.5ubuntu2.1',
+                'architecture': 'amd64',
+                'description': 'Debian package management system'
+            },
+            'lsof': {
+                'name': 'lsof',
+                'version': '4.91+dfsg-1ubuntu1',
+                'architecture': 'amd64',
+                'description': 'utility to list open files'
+            },
+        }
+        self.assertEquals(
+            apt_cache._dpkg_list(['package']), expect)
+        self.check_output.side_effect = subprocess.CalledProcessError(
+            1, '', output=self.check_output.return_value)
+        self.assertEquals(apt_cache._dpkg_list(['package']), expect)
+        self.check_output.side_effect = subprocess.CalledProcessError(2, '')
+        with self.assertRaises(subprocess.CalledProcessError):
+            _ = apt_cache._dpkg_list(['package'])
+
+    def test_version_compare(self):
+        self.patch_object(apt_pkg.subprocess, 'check_call')
+        self.assertEquals(apt_pkg.version_compare('2', '1'), 1)
+        self.check_call.assert_called_once_with(
+            ['dpkg', '--compare-versions', '2', 'gt', '1'],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
+        self.check_call.side_effect = [
+            subprocess.CalledProcessError(1, '', ''),
+            None,
+            None,
+        ]
+        self.assertEquals(apt_pkg.version_compare('2', '2'), 0)
+        self.check_call.side_effect = [
+            subprocess.CalledProcessError(1, '', ''),
+            subprocess.CalledProcessError(1, '', ''),
+            None,
+        ]
+        self.assertEquals(apt_pkg.version_compare('1', '2'), -1)
+        self.check_call.side_effect = subprocess.CalledProcessError(2, '', '')
+        self.assertRaises(subprocess.CalledProcessError,
+                          apt_pkg.version_compare, '2', '2')
+
+    def test_apt_cache(self):
+        self.patch_object(apt_pkg.subprocess, 'check_output')
+        apt_cache = apt_pkg.Cache()
+        self.check_output.side_effect = [
+            ('Package: dpkg\n'
+             'Version: 1.19.0.6ubuntu0\n'
+             'Bugs: https://bugs.launchpad.net/ubuntu/+filebug\n'
+             'Description-en: Debian package management system\n'
+             ' Multiline description\n'
+             '\n'
+             'Package: lsof\n'
+             'Architecture: amd64\n'
+             'Version: 4.91+dfsg-1ubuntu1\n'
+             '\n'
+             'N: There is 1 additional record.\n'),
+            ('Desired=Unknown/Install/Remove/Purge/Hold\n'
+             '| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/'
+             'trig-aWait/Trig-pend\n'
+             '|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)\n'
+             '||/ Name           Version            Architecture Description\n'
+             '+++-=============================-==================-===========-'
+             '=================================\n'
+             'ii  dpkg                          1.19.0.5ubuntu2.1  amd64       '
+             'Debian package management system\n'
+             'rc  linux-image-4.15.0-42-generic 4.15.0-42.45       amd64       '
+             'Signed kernel image generic\n'
+             'ii  lsof                          4.91+dfsg-1ubuntu1 amd64       '
+             'utility to list open files\n'),
+        ]
+        pkg = apt_cache['dpkg']
+        self.assertEquals(pkg.name, 'dpkg')
+        self.assertEquals(pkg.current_ver.ver_str, '1.19.0.5ubuntu2.1')
+        self.assertEquals(pkg.architecture, 'amd64')
+        self.check_output.side_effect = [
+            subprocess.CalledProcessError(100, ''),
+            subprocess.CalledProcessError(1, ''),
+        ]
+        with self.assertRaises(KeyError):
+            pkg = apt_cache['nonexistent']
+        self.check_output.side_effect = [
+            ('Package: dpkg\n'
+             'Version: 1.19.0.6ubuntu0\n'
+             'Bugs: https://bugs.launchpad.net/ubuntu/+filebug\n'
+             'Description-en: Debian package management system\n'
+             ' Multiline description\n'
+             '\n'
+             'Package: lsof\n'
+             'Architecture: amd64\n'
+             'Version: 4.91+dfsg-1ubuntu1\n'
+             '\n'
+             'N: There is 1 additional record.\n'),
+            subprocess.CalledProcessError(42, ''),
+        ]
+        with self.assertRaises(subprocess.CalledProcessError):
+            # System error occurs while making dpkg inquiry
+            pkg = apt_cache['dpkg']
+        self.check_output.side_effect = [
+            subprocess.CalledProcessError(42, ''),
+            subprocess.CalledProcessError(1, ''),
+        ]
+        with self.assertRaises(subprocess.CalledProcessError):
+            pkg = apt_cache['system-error-occurs-while-making-apt-inquiry']


### PR DESCRIPTION
The ``python-apt`` package is a wrapper around the ``apt`` C++
library which is tightly connected to the version of the
distribution it is shipped on.
    
This in turn makes it incredibly hard to distribute as a wheel for
a charm that supports a large span of distro versions.
    
We do not want to rely on system installed Python packages but
distribute the direct charm dependencies as part of the charms
wheelhouse.
    
As the span of distributions we need to support with reactive
charms widens we will run into compability problems with the
current model.
    
For further reference see discussion in LP: #1824112 and
juju-solutions/layer-basic#135