### PR TITLE
Make NRPE.add_check(shortname=...) optional again

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -266,11 +266,14 @@ class NRPE(object):
         self.remove_check_queue = set()
 
     def add_check(self, *args, **kwargs):
+        shortname = None
         if kwargs.get('shortname') is None:
-            raise ValueError('shortname of check must be specified')
+            if len(args) > 0:
+                shortname = args[0]
+        else:
+            shortname = kwargs['shortname']
 
         self.checks.append(Check(*args, **kwargs))
-        shortname = kwargs['shortname']
         try:
             self.remove_check_queue.remove(shortname)
         except KeyError:


### PR DESCRIPTION
Commit 859a149 enforced the use of "shortname" in add_check when *args
can carry the same value as first element. This change makes "shortname"
key optional again, as documented at the beginning of the module.