### PR TITLE
Add service_{project,domain}_id keys to Ident ctxt

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -443,8 +443,10 @@ class IdentityServiceContext(OSContextGenerator):
                              'api_version': api_version})
 
                 if float(api_version) > 2:
-                    ctxt.update({'admin_domain_name':
-                                 rdata.get('service_domain')})
+                    ctxt.update({
+                        'admin_domain_name': rdata.get('service_domain'),
+                        'service_project_id': rdata.get('service_tenant_id'),
+                        'service_domain_id': rdata.get('service_domain_id')})
 
                 # we keep all veriables in ctxt for compatibility and
                 # add nested dictionary for keystone_authtoken generic

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1216,8 +1216,8 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'filter_installed_packages')
     @patch.object(context, 'os_release')
     def test_keystone_authtoken_www_authenticate_uri_stein_apiv3(self, mock_os_release, mock_filter_installed_packages):
-        relation = FakeRelation(
-            relation_data=IDENTITY_SERVICE_RELATION_VERSIONED)
+        relation_data = deepcopy(IDENTITY_SERVICE_RELATION_VERSIONED)
+        relation = FakeRelation(relation_data=relation_data)
         self.relation_get.side_effect = relation.get
 
         mock_filter_installed_packages.return_value = []

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -193,12 +193,15 @@ IDENTITY_SERVICE_RELATION_HTTPS = {
 
 IDENTITY_SERVICE_RELATION_VERSIONED = {
     'api_version': '3',
+    'service_tenant_id': 'svc-proj-id',
+    'service_domain_id': 'svc-dom-id',
 }
 IDENTITY_SERVICE_RELATION_VERSIONED.update(IDENTITY_SERVICE_RELATION_HTTPS)
 
 IDENTITY_CREDENTIALS_RELATION_VERSIONED = {
     'api_version': '3',
-    'service_domain_id': '567890',
+    'service_tenant_id': 'svc-proj-id',
+    'service_domain_id': 'svc-dom-id',
 }
 IDENTITY_CREDENTIALS_RELATION_VERSIONED.update(IDENTITY_CREDENTIALS_RELATION_UNSET)
 
@@ -1132,8 +1135,10 @@ class ContextTests(unittest.TestCase):
             'admin_password': 'foo',
             'admin_domain_name': 'admin_domain',
             'admin_tenant_name': 'admin',
-            'admin_tenant_id': None,
-            'admin_domain_id': None,
+            'admin_tenant_id': 'svc-proj-id',
+            'admin_domain_id': 'svc-dom-id',
+            'service_project_id': 'svc-proj-id',
+            'service_domain_id': 'svc-dom-id',
             'admin_user': 'adam',
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
@@ -1211,9 +1216,8 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'filter_installed_packages')
     @patch.object(context, 'os_release')
     def test_keystone_authtoken_www_authenticate_uri_stein_apiv3(self, mock_os_release, mock_filter_installed_packages):
-        relation_data = deepcopy(IDENTITY_SERVICE_RELATION_UNSET)
-        relation_data['api_version'] = '3'
-        relation = FakeRelation(relation_data=relation_data)
+        relation = FakeRelation(
+            relation_data=IDENTITY_SERVICE_RELATION_VERSIONED)
         self.relation_get.side_effect = relation.get
 
         mock_filter_installed_packages.return_value = []
@@ -1227,8 +1231,8 @@ class ContextTests(unittest.TestCase):
 
         expected = collections.OrderedDict((
             ('auth_type', 'password'),
-            ('www_authenticate_uri', 'http://keystonehost.local:5000/v3'),
-            ('auth_url', 'http://keystone-host.local:35357/v3'),
+            ('www_authenticate_uri', 'https://keystonehost.local:5000/v3'),
+            ('auth_url', 'https://keystone-host.local:35357/v3'),
             ('project_domain_name', 'admin_domain'),
             ('user_domain_name', 'admin_domain'),
             ('project_name', 'admin'),


### PR DESCRIPTION
Add service_{project,domain}_id keys to IdentityServiceContext. The
data is already present in the admin_domain_name and admin_tenant_id
keys but those key names are confusing.

Adding service_{project,domain}_id keys to the context is gated on
the use of keystone api version greater than 2. It is assumed that
if api 3 is being used then the service project and domain ids
are being passed down the relation which is true as of the 18.04
keystone charms (https://review.opendev.org/#/c/548264).