### PR TITLE
Add getter helpers to contrib ovs module

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -52,7 +52,8 @@ def get_bridges():
     """
     cmd = ["ovs-vsctl", "list-br"]
     lines = subprocess.check_output(cmd).decode('utf-8').split("\n")
-    return [l.strip() for l in lines]
+    maybe_bridges = [l.strip() for l in lines]
+    return [b for b in maybe_bridges if b]
 
 
 def get_bridge_ports(name):
@@ -67,7 +68,8 @@ def get_bridge_ports(name):
     """
     cmd = ["ovs-vsctl", "--", "list-ports", name]
     lines = subprocess.check_output(cmd).decode('utf-8').split("\n")
-    return [l.strip() for l in lines]
+    maybe_ports = [l.strip() for l in lines]
+    return [p for p in maybe_ports if p]
 
 
 def get_bridges_and_ports_map():

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -43,6 +43,44 @@ iface {linuxbridge_port} inet manual
 MAX_KERNEL_INTERFACE_NAME_LEN = 15
 
 
+def get_bridges():
+    """Return list of the bridges on the default openvswitch
+
+    :returns: List of bridge names
+    :rtype: List[str]
+    :raises: subprocess.CalledProcessError if ovs-vsctl fails
+    """
+    cmd = ["ovs-vsctl", "list-br"]
+    lines = subprocess.check_output(cmd).decode('utf-8').split("\n")
+    return [l.strip() for l in lines]
+
+
+def get_bridge_ports(name):
+    """Return a list the ports on a named bridge
+
+    :param name: the name of the bridge to list
+    :type name: str
+    :returns: List of ports on the named bridge
+    :rtype: List[str]
+    :raises: subprocess.CalledProcessError if the ovs-vsctl command fails. If
+        the named bridge doesn't exist, then the exception will be raised.
+    """
+    cmd = ["ovs-vsctl", "--", "list-ports", name]
+    lines = subprocess.check_output(cmd).decode('utf-8').split("\n")
+    return [l.strip() for l in lines]
+
+
+def get_bridges_and_ports_map():
+    """Return dictionary of bridge to ports for the default openvswitch
+
+    :returns: a mapping of bridge name to a list of ports.
+    :rtype: Dict[str, List[str]]
+    :raises: subprocess.CalledProcessError if any of the underlying ovs-vsctl
+        command fail.
+    """
+    return {b: get_bridge_ports(b) for b in get_bridges()}
+
+
 def add_bridge(name, datapath_type=None):
     ''' Add the named bridge to openvswitch '''
     log('Creating bridge {}'.format(name))

--- a/tests/contrib/network/test_ovs.py
+++ b/tests/contrib/network/test_ovs.py
@@ -146,11 +146,10 @@ class OVSHelpersTest(unittest.TestCase):
         get_bridge_ports.side_effect = [
             ['p1', 'p2'],
             ['p3']]
-        self.assertEqual(ovs.get_bridges_and_ports_map(),
-                         {
-                             'br1': ['p1', 'p2'],
-                             'br2': ['p3'],
-                         })
+        self.assertEqual(ovs.get_bridges_and_ports_map(), {
+            'br1': ['p1', 'p2'],
+            'br2': ['p3'],
+        })
 
     @patch('subprocess.check_call')
     def test_add_bridge(self, check_call):


### PR DESCRIPTION
This patch adds in some getters for listing bridges and ports on bridges
on the openvswitch.  This complements the add and delete methods and is
(primarily) to allow the neutron-gateway charm to remove bridges/ports
that are no longer in the config for that application.

Related-Bug: lp#1809190