### PR TITLE
Use "rabbit_use_ssl" instead of "ssl" for ocata config

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-oslo-messaging-rabbit-ocata
+++ b/charmhelpers/contrib/openstack/templates/section-oslo-messaging-rabbit-ocata
@@ -1,0 +1,10 @@
+[oslo_messaging_rabbit]
+{% if rabbitmq_ha_queues -%}
+rabbit_ha_queues = True
+{% endif -%}
+{% if rabbit_ssl_port -%}
+rabbit_use_ssl = True
+{% endif -%}
+{% if rabbit_ssl_ca -%}
+ssl_ca_file = {{ rabbit_ssl_ca }}
+{% endif -%}


### PR DESCRIPTION
Ensure "rabbit_use_ssl" is specified in the [oslo_messaging_rabbit]
config section instead of "ssl" for Ocata, since "ssl" was not yet
introduced.

Related-Bug: #1838696