### PR TITLE
Remove ``psutil`` from c-h setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ SETUP = {
         'Tempita',
         'Jinja2',
         'six',
-        'psutil',
     ],
     'packages': find_packages(exclude=('tests', 'tests.*', 'tools', 'tools.*')),
     'scripts': [


### PR DESCRIPTION
This module is conditionally used in some parts of the library and
we should not force it upon everyone.