### PR TITLE
fetch: Override apt execution environment

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -1075,3 +1075,32 @@ def install_ca_cert(ca_cert, name=None):
     log("Installing new CA cert at: {}".format(cert_file), level=INFO)
     write_file(cert_file, ca_cert)
     subprocess.check_call(['update-ca-certificates', '--fresh'])
+
+
+def get_system_env(key, default=None):
+    """Get data from system environment as represented in ``/etc/environment``.
+
+    :param key: Key to look up
+    :type key: str
+    :param default: Value to return if key is not found
+    :type default: any
+    :returns: Value for key if found or contents of default parameter
+    :rtype: any
+    :raises: subprocess.CalledProcessError, KeyError
+    """
+    env_file = '/etc/environment'
+    # use the shell and env(1) to parse the global environments file.  This is
+    # done to get the correct result even if the user has shell variable
+    # substitutions or other shell logic in that file.
+    output = subprocess.check_output(
+        ['env', '-i', '/bin/bash', '-c',
+         'set -a && source {} && env'.format(env_file)],
+        universal_newlines=True)
+    for k, v in (line.split('=', 1)
+                 for line in output.splitlines() if '=' in line):
+        if k.upper() == key.upper():
+            return v
+    else:
+        if default:
+            return default
+        raise KeyError('"{}" not found in {}.'.format(key, env_file))

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -1086,7 +1086,7 @@ def get_system_env(key, default=None):
     :type default: any
     :returns: Value for key if found or contents of default parameter
     :rtype: any
-    :raises: subprocess.CalledProcessError, KeyError
+    :raises: subprocess.CalledProcessError
     """
     env_file = '/etc/environment'
     # use the shell and env(1) to parse the global environments file.  This is
@@ -1101,6 +1101,4 @@ def get_system_env(key, default=None):
         if k.upper() == key.upper():
             return v
     else:
-        if default:
-            return default
-        raise KeyError('"{}" not found in {}.'.format(key, env_file))
+        return default

--- a/charmhelpers/fetch/__init__.py
+++ b/charmhelpers/fetch/__init__.py
@@ -104,6 +104,7 @@ if __platform__ == "ubuntu":
     import_key = fetch.import_key
     get_upstream_version = fetch.get_upstream_version
     apt_pkg = fetch.ubuntu_apt_pkg
+    get_apt_dpkg_env = fetch.get_apt_dpkg_env
 elif __platform__ == "centos":
     yum_search = fetch.yum_search
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -162,7 +162,7 @@ class OpenStackHelpersTestCase(TestCase):
 
     def setUp(self):
         super(OpenStackHelpersTestCase, self).setUp()
-        self.patch(fetch, 'apt_dpkg_env', lambda: {})
+        self.patch(fetch, 'get_apt_dpkg_env', lambda: {})
 
     def _apt_cache(self):
         # mocks out the apt cache

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -160,6 +160,10 @@ class FakeDNS(object):
 
 class OpenStackHelpersTestCase(TestCase):
 
+    def setUp(self):
+        super(OpenStackHelpersTestCase, self).setUp()
+        self.patch(fetch, 'apt_dpkg_env', lambda: {})
+
     def _apt_cache(self):
         # mocks out the apt cache
         def cache_get(package):
@@ -470,7 +474,7 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.configure_installation_source(src)
             ex_cmd = [
                 'add-apt-repository', '--yes', 'ppa:gandelman-a/openstack']
-            mock.assert_called_with(ex_cmd)
+            mock.assert_called_with(ex_cmd, env={})
 
     @patch('subprocess.check_call')
     @patch.object(fetch, 'import_key')
@@ -483,7 +487,7 @@ class OpenStackHelpersTestCase(TestCase):
         _spcc.assert_called_once_with(
             ['add-apt-repository', '--yes',
              'deb http://ubuntu-cloud.archive.canonical.com/ubuntu '
-             'precise-havana main'])
+             'precise-havana main'], env={})
 
     @patch.object(fetch, 'get_distrib_codename')
     @patch(builtin_open)
@@ -504,7 +508,7 @@ class OpenStackHelpersTestCase(TestCase):
         _spcc.assert_called_once_with(
             ['add-apt-repository', '--yes',
              'deb http://archive.ubuntu.com/ubuntu/ precise-proposed '
-             'restricted main multiverse universe'])
+             'restricted main multiverse universe'], env={})
 
     @patch('charmhelpers.fetch.filter_installed_packages')
     @patch('charmhelpers.fetch.apt_install')
@@ -581,7 +585,7 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.configure_installation_source(src)
             cmd = ['add-apt-repository', '-y',
                    'ppa:ubuntu-cloud-archive/folsom-staging']
-            _subp.assert_called_with(cmd)
+            _subp.assert_called_with(cmd, env={})
 
     @patch(builtin_open)
     @patch.object(fetch, 'apt_install')

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1991,7 +1991,7 @@ class HelpersTest(TestCase):
         check_output.return_value = ''
         self.assertEquals(
             host.get_system_env('aKey', 'aDefault'), 'aDefault')
-        self.assertRaises(KeyError, host.get_system_env, 'aKey')
+        self.assertEquals(host.get_system_env('aKey'), None)
         check_output.return_value = 'aKey=aValue\n'
         self.assertEquals(
             host.get_system_env('aKey', 'aDefault'), 'aValue')

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1986,6 +1986,19 @@ class HelpersTest(TestCase):
             ['dpkg', '--print-architecture']
         )
 
+    @patch('subprocess.check_output')
+    def test_get_system_env(self, check_output):
+        check_output.return_value = ''
+        self.assertEquals(
+            host.get_system_env('aKey', 'aDefault'), 'aDefault')
+        self.assertRaises(KeyError, host.get_system_env, 'aKey')
+        check_output.return_value = 'aKey=aValue\n'
+        self.assertEquals(
+            host.get_system_env('aKey', 'aDefault'), 'aValue')
+        check_output.return_value = 'avalue=shell=wicked\n'
+        self.assertEquals(
+            host.get_system_env('AVALUE', 'aDefault'), 'shell=wicked')
+
 
 class TestHostCompator(TestCase):
 


### PR DESCRIPTION
Override the execution environment for the apt_* family of
functions with a sanitized environment.
    
The need for this rises from consumers of the library running the
code from within a virtualenv.  In such a situation a deb
post-install script interacting with Python may interact with the
virtualenv instead of the system Python environment.
    
Clean up a pre-existing left behind unit test change after update
to _run_with_retries().
    
LP: #1840257