### PR TITLE
get_system_env: Search should be case sensitive

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -1098,7 +1098,7 @@ def get_system_env(key, default=None):
         universal_newlines=True)
     for k, v in (line.split('=', 1)
                  for line in output.splitlines() if '=' in line):
-        if k.upper() == key.upper():
+        if k == key:
             return v
     else:
         return default

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1995,9 +1995,9 @@ class HelpersTest(TestCase):
         check_output.return_value = 'aKey=aValue\n'
         self.assertEquals(
             host.get_system_env('aKey', 'aDefault'), 'aValue')
-        check_output.return_value = 'avalue=shell=wicked\n'
+        check_output.return_value = 'otherKey=shell=wicked\n'
         self.assertEquals(
-            host.get_system_env('AVALUE', 'aDefault'), 'shell=wicked')
+            host.get_system_env('otherKey', 'aDefault'), 'shell=wicked')
 
 
 class TestHostCompator(TestCase):


### PR DESCRIPTION
The original version of the helper used a case insensitive search,
shell variables are indeed case sensitive so fix the search.