### PR TITLE
Add policyd override helpers

### DIFF
--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -228,7 +228,7 @@ else:
 
 
 def is_policyd_override_valid_on_this_release(openstack_release):
-    """Check that the charm is running on at least Ubuntu bionic, and at
+    """Check that the charm is running on at least Ubuntu Xenial, and at
     least the queens release.
 
     :param openstack_release: the release codename that is installed.
@@ -244,7 +244,7 @@ def is_policyd_override_valid_on_this_release(openstack_release):
     # other of the CompareOpenStackReleases or status message generation code
     # into a 3rd module.
     import charmhelpers.contrib.openstack.utils as ch_utils
-    return (ch_host.CompareHostReleases(ubuntu_release) >= 'bionic' and
+    return (ch_host.CompareHostReleases(ubuntu_release) >= 'xenial' and
             ch_utils.CompareOpenStackReleases(openstack_release) >= 'queens')
 
 
@@ -259,7 +259,7 @@ def maybe_do_policyd_overrides(openstack_release,
 
     The param `openstack_release` is required as the policyd overrides feature
     is only supported on openstack_release "queens" or later, and on ubuntu
-    "bionic" or later.  Prior to these versions, this feature is a NOP.
+    "xenial" or later.  Prior to these versions, this feature is a NOP.
 
     The optional template_function is a function that accepts a string and has
     an opportunity to modify the loaded file prior to it being read by

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -406,7 +406,7 @@ def clean_policyd_dir_for(service, keep_paths=None):
     """
     keep_paths = keep_paths or []
     path = policyd_dir_for(service)
-    if not os.path.exist(path):
+    if not os.path.exists(path):
         ch_host.mkdir(path, owner=service, group=service, perms=0o775)
     for direntry in os.scandir(policyd_dir_for(service)):
         # see if the path should be kept.

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -257,7 +257,7 @@ def maybe_do_policyd_overrides_on_config_changed(openstack_release,
     if not is_policyd_override_valid_on_this_release(openstack_release):
         return
     # if the policyd overrides have been performed just return
-    if os.isfile(_policy_success_file()):
+    if os.path.isfile(_policy_success_file()):
         return
     maybe_do_policyd_overrides(
         service, blacklist_paths, blacklist_keys, modify_function,

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -405,6 +405,9 @@ def clean_policyd_dir_for(service, keep_paths=None):
     :type keep_paths: Union[None, List[str]]
     """
     keep_paths = keep_paths or []
+    path = policyd_dir_for(service)
+    if not os.path.exist(path):
+        ch_host.mkdir(path, owner=service, group=service, perms=0o775)
     for direntry in os.scandir(policyd_dir_for(service)):
         # see if the path should be kept.
         if direntry.path in keep_paths:

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -254,14 +254,12 @@ def maybe_do_policyd_overrides_on_config_changed(openstack_release,
             return
     except Exception:
         return
-    if not is_policyd_override_valid_on_this_release(openstack_release):
-        return
     # if the policyd overrides have been performed just return
     if os.path.isfile(_policy_success_file()):
         return
     maybe_do_policyd_overrides(
-        service, blacklist_paths, blacklist_keys, modify_function,
-        restart_handler)
+        openstack_release, service, blacklist_paths, blacklist_keys,
+        modify_function, restart_handler)
 
 
 def get_policy_resource_filename():

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -1,0 +1,544 @@
+# Copyright 2019 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import contextlib
+import os
+import six
+import shutil
+import yaml
+import zipfile
+
+import charmhelpers.core.hookenv as hookenv
+import charmhelpers.core.host as ch_host
+import charmhelpers.contrib.openstack.utils as ch_utils
+
+# Policy.d helper functions.
+#
+# The /etc/<service-name>/policy.d/ directory, for OpenStack services can
+# contain YAML or JSON files to override the default policies configured in a
+# service.  These helpers are used to load, validate, and write YAML files to
+# the policy.d directory
+
+# The config.yaml for the charm should contain the following for the config
+# option:
+
+"""
+  use-policyd-override:
+    type: boolean
+    default: False
+    description: |
+      If True then use the resource file named 'policyd-override' to install
+      override yaml files in the service's policy.d directory.  The resource
+      file should be a zip file containing at least one yaml file with a .yaml
+      or .yml extension.  If False then remove the overrides.
+"""
+
+# The metadata.yaml for the charm should contain the following:
+"""
+resources:
+  policyd-override:
+    type: file
+    filename: policyd-override.zip
+    description: The policy.d overrides file
+"""
+
+# The README for the charm should contain the following:
+"""
+Policy Overrides
+----------------
+
+This service allows for policy overrides using the `policy.d` directory.  This
+is an **advanced** feature and the policies that the service supports should be
+clearly and unambiguously understood before trying to override, or add to, the
+default policies that the service uses.
+
+The charm also has some policy defaults.  They should also be understood before
+being overridden.  It is possible to break the system (for tenants and other
+services) if policies are incorrectly applied to the service.
+
+Policy overrides are YAML files that contain rules that will add to, or
+override, existing policy rules in the service.  The `policy.d` directory is
+a place to put the YAML override files.  This charm owns the
+`/etc/keystone/policy.d` directory, and as such, any manual changes to it will
+be overwritten on charm upgrades.
+
+Policy overrides are provided to the charm using a resource file called
+`policyd-override`.  This is attached to the charm using (for example):
+
+    juju attach-resource <charm-name> policyd-override=<some-file>
+
+The `<charm-name>` is the name that this charm is deployed as, with
+`<some-file>` being the resource file containing the policy overrides.
+
+The format of the resource file is a ZIP file (.zip extension) containing at
+least one YAML file with an extension of `.yaml` or `.yml`.  Note that any
+directories in the ZIP file are ignored; all of the files are flattened into
+a single directory.  There must not be any duplicated filenames; this will
+cause an error and nothing in the resource file will be applied.
+
+To enable the policy overrides the config option `use-policyd-override` must be
+set to `True`.
+
+When `use-policyd-override` is `True` the status line of the charm will be
+prefixed with `PO:` indicating that policies have been overridden.  If the
+installation of the policy override YAML files failed for any reason then the
+status line will be prefixed with `PO (broken):`.  The log file for the charm
+will indicate the reason.  No policy override files are installed if the `PO
+(broken):` is shown.  The status line indicates that the overrides are broken,
+not that the policy for the service has failed - they will be the defaults for
+the charm and service.
+
+If the policy overrides did not install then *either* attach a new, corrected,
+resource file *or* disable the policy overrides by setting
+`use-policyd-override` to False.
+
+Policy overrides on one service may affect the functionality of another
+service. Therefore, it may be necessary to provide policy overrides for
+multiple service charms to achieve a consistent set of policies across the
+OpenStack system.  The charms for the other services that may need overrides
+should be checked to ensure that they support overrides before proceeding.
+"""
+
+YAML_EXTS = ['.yaml', '.yml']
+POLICYD_RESOURCE_NAME = "policyd-override"
+POLICYD_CONFIG_NAME = "use-policyd-override"
+POLICYD_SUCCESS_FILENAME = "policyd-override-success"
+POLICYD_LOG_LEVEL_DEFAULT = hookenv.INFO
+
+
+class BadPolicyZipFile(Exception):
+
+    def __init__(self, log_message):
+        self.log_message = log_message
+
+
+class BadPolicyYamlFile(Exception):
+
+    def __init__(self, log_message):
+        self.log_message = log_message
+
+
+def is_policyd_override_valid_on_this_release(openstack_release):
+    """Check that the charm is running on at least Ubuntu bionic, and at
+    least the queens release.
+
+    :param openstack_release: the release codename that is installed.
+    :type openstack_release: str
+    :returns: True if okay
+    :rtype: bool
+    """
+    ubuntu_release = ch_host.lsb_release()['DISTRIB_CODENAME'].lower()
+    return (ch_host.CompareHostReleases(ubuntu_release) >= 'bionic' and
+            ch_utils.CompareOpenStackReleases(openstack_release) >= 'queens')
+
+
+def maybe_do_policyd_overrides(openstack_release,
+                               service,
+                               blacklist_paths=None,
+                               blacklist_keys=None,
+                               modify_function=None,
+                               restart_handler=None):
+    """If the config option is set, get the resource file and process it to
+    enable the policy.d overrides for the service passed.
+
+    The param `openstack_release` is required as the policyd overrides feature
+    is only supported on openstack_release "queens" or later, and on ubuntu
+    "bionic" or later.  Prior to these versions, this feature is a NOP.
+
+    The optional modify_function is a function that accepts a python dictionary
+    and has an opportunity to modify the yaml (as a python object) prior to it
+    being written to the disk.
+
+    The param blacklist_paths are paths (that are in the service's policy.d
+    directory that should not be touched).
+
+    The param blacklist_keys are keys that must not appear in the yaml file.
+    If they do, then the whole policy.d file fails.
+
+    The yaml file extracted from the resource_file (which is a zipped file) has
+    its file path reconstructed.  This, also, must not match any path in the
+    black list.
+
+    The param restart_handler is an optional Callable that is called to perform
+    the service restart if the policy.d file is changed.  This should normally
+    be None as oslo.policy automatically picks up changes in the policy.d
+    directory.  However, for any services where this is buggy then a
+    restart_handler can be used to force the policy.d files to be read.
+
+    :param openstack_release: The openstack release that is installed.
+    :type openstack_release: str
+    :param service: the service name to construct the policy.d directory for.
+    :type service: str
+    :param blacklist_paths: optional list of paths to leave alone
+    :type blacklist_paths: Union[None, List[str]]
+    :param blacklist_keys: optional list of keys that mustn't appear in the
+                           yaml file's
+    :type blacklist_keys: Union[None, List[str]]
+    :param modify_function: Optional function that can modify the yaml
+                            document.
+    :type modify_function: Union[None,
+                                 Callable[[Dict[str, str]], Dict[str,str]]]
+    :param restart_handler: The function to call if the service should be
+                            restarted.
+    :type restart_handler: Union[None, Callable[]]
+    """
+    config = hookenv.config()
+    try:
+        if not config.get(POLICYD_CONFIG_NAME, False):
+            return
+    except Exception:
+        return
+    if not is_policyd_override_valid_on_this_release(openstack_release):
+        return
+    # from now on it should succeed; if it doesn't then status line will show
+    # broken.
+    resource_filename = get_policy_resource_filename()
+    restart = process_policy_resource_file(
+        resource_filename, service, blacklist_paths, blacklist_keys,
+        modify_function)
+    if restart and restart_handler is not None and callable(restart_handler):
+        restart_handler()
+
+
+def maybe_do_policyd_overrides_on_config_changed(openstack_release,
+                                                 service,
+                                                 blacklist_paths=None,
+                                                 blacklist_keys=None,
+                                                 modify_function=None,
+                                                 restart_handler=None):
+    """This function is designed to be called from the config changed hook
+    handler.  It will only perform the policyd overrides if the config is True
+    and the success file doesn't exist.  Otherwise, it does nothing as the
+    resource file has already been processed.
+
+    See maybe_do_policyd_overrides() for more details on the params.
+
+    :param openstack_release: The openstack release that is installed.
+    :type openstack_release: str
+    :param service: the service name to construct the policy.d directory for.
+    :type service: str
+    :param blacklist_paths: optional list of paths to leave alone
+    :type blacklist_paths: Union[None, List[str]]
+    :param blacklist_keys: optional list of keys that mustn't appear in the
+                           yaml file's
+    :type blacklist_keys: Union[None, List[str]]
+    :param modify_function: Optional function that can modify the yaml
+                            document.
+    :type modify_function: Union[None,
+                                 Callable[[Dict[str, str]], Dict[str,str]]]
+    :param restart_handler: The function to call if the service should be
+                            restarted.
+    :type restart_handler: Union[None, Callable[]]
+    """
+    config = hookenv.config()
+    try:
+        if not config.get(POLICYD_CONFIG_NAME, False):
+            return
+    except Exception:
+        return
+    if not is_policyd_override_valid_on_this_release(openstack_release):
+        return
+    # if the policyd overrides have been performed just return
+    if os.isfile(_policy_success_file()):
+        return
+    maybe_do_policyd_overrides(
+        service, blacklist_paths, blacklist_keys, modify_function,
+        restart_handler)
+
+
+def get_policy_resource_filename():
+    """Function to extract the policy resource filename
+
+    :returns: The filename of the resource, if set, otherwise, if an error
+               occurs, then None is returned.
+    :rtype: Union[str, None]
+    """
+    try:
+        return hookenv.resource_get(POLICYD_RESOURCE_NAME)
+    except Exception:
+        return None
+
+
+@contextlib.contextmanager
+def open_and_filter_yaml_files(filepath):
+    """Validate that the filepath provided is a zip file and contains at least
+    one (.yaml|.yml) file, and that the files are not duplicated when the zip
+    file is flattened.  Note that the yaml files are not checked.  This is the
+    first stage in validating the policy zipfile; individual yaml files are not
+    checked for validity or black listed keys.
+
+    An example of use is:
+
+        with open_and_filter_yaml_files(some_path) as zfp, g:
+            for zipinfo in g:
+                # do something with zipinfo ...
+
+    :param filepath: a filepath object that can be opened by zipfile
+    :type filepath: Union[AnyStr, os.PathLike[AntStr]]
+    :returns: (zfp handle,
+               a generator of the (name, filename, ZipInfo object) tuples) as a
+               tuple.
+    :rtype: ContextManager[(zipfile.ZipFile,
+                            Generator[(name, str, str, zipfile.ZipInfo)])]
+    :raises: zipfile.BadZipFile
+    :raises: BadPolicyZipFile if duplicated yaml or missing
+    :raises: IOError if the filepath is not found
+    """
+    with zipfile.ZipFile(filepath, 'r') as zfp:
+        # first pass through; check for duplicates and at least one yaml file.
+        names = collections.defaultdict(int)
+        for name, _, _ in _yield_yamlfiles(zfp):
+            names[name] += 1
+        # There must be at least 1 yaml file.
+        if not names:
+            raise BadPolicyZipFile("contains no yaml files with {} extensions."
+                                   .format(", ".join(YAML_EXTS)))
+        # There must be no duplicates
+        duplicates = [n for n, c in names if c > 1]
+        if duplicates:
+            raise BadPolicyZipFile("{} have duplicates in the zip file."
+                                   .format(", ".join(duplicates)))
+        # Finally, let's yield the generator
+        yield (zfp, _yield_yamlfiles(zfp))
+
+
+def _yield_yamlfiles(zipfile):
+    """Helper to get a yaml file (according to YAML_EXTS extensions) and the
+    infolist item from a zipfile.
+
+    :param zipfile: the zipfile to read zipinfo items from
+    :type zipfile: zipfile.ZipFile
+    :returns: generator of (name, filename, info item) for each self-identified
+              yaml file.
+    :rtype: Generator[(str, str, zipfile.ZipInfo)]
+    """
+    for infolist_item in zipfile.infolist():
+        if infolist_item.is_dir():
+            continue
+        _, name_ext = os.path.split(zipfile.filename)
+        name, ext = os.path.splitext(name_ext)
+        ext = ext.lower()
+        if ext and ext in YAML_EXTS:
+            yield name, name_ext, infolist_item
+
+
+def read_and_validate_yaml(stream, blacklist_keys=None):
+    """Read, validate and return the (first) yaml document from the stream.
+
+    The stream is read, and checked for a yaml file.  The the top-level keys
+    are checked against the blacklist_keys provided.  If there are problems
+    then an Exception is raised.  Otherwise the yaml document is returned as a
+    Python object that can be dumped back as a yaml file on the system.
+
+    The yaml file must only consist of a str:str mapping, and if not then the
+    yaml file is rejected.
+
+    :param stream: the file object to read the yaml from
+    :type stream: Union[AnyStr, IO[AnyStr]]
+    :param blacklist_keys: Any keys, which if in the yaml file, should cause
+        and error.
+    :type blacklisted_keys: Union[None, List[str]]
+    :returns: the yaml file as a python document
+    :rtype: Dict[str, str]
+    :raises: yaml.YAMLError if there is a problem with the document
+    :raises: BadPolicyYamlFile if file doesn't look right or there are
+             blacklisted keys in the file.
+    """
+    blacklist_keys = blacklist_keys or []
+    doc = yaml.safe_load(stream)
+    if not isinstance(doc, dict):
+        raise BadPolicyYamlFile("doesn't look like a policy file?")
+    keys = set(doc.keys())
+    blacklisted_keys_present = keys.union(blacklist_keys)
+    if blacklisted_keys_present:
+        raise BadPolicyYamlFile("blacklisted keys {} present."
+                                .format(", ".join(blacklisted_keys_present)))
+    if not all(isinstance(k, six.string_types) for k in keys):
+        raise BadPolicyYamlFile("keys in yaml aren't all strings?")
+    # check that the dictionary looks like a mapping of str to str
+    if not all(isinstance(v, six.string_types) for v in doc.values()):
+        raise BadPolicyYamlFile("values in yaml aren't all strings?")
+    return doc
+
+
+def policyd_dir_for(service):
+    """Return the policy directory for the named service.
+
+    This assumes the default name of "policy.d" which is kept across all
+    charms.
+
+    :param service: str
+    :returns: the policy.d override directory.
+    :rtype: os.PathLike[str]
+    """
+    return os.path.join("etc", service, "policy.d")
+
+
+def clean_policyd_dir_for(service, keep_paths=None):
+    """Clean out the policyd directory except for items that should be kept.
+
+    The keep_paths, if used, should be set to the full path of the files that
+    should be kept in the policyd directory for the service.  Note that the
+    service name is passed in, and then the policyd_dir_for() function is used.
+    This is so that a coding error doesn't result in a sudden deletion of the
+    charm (say).
+
+    :param service: the service name to use to construct the policy.d dir.
+    :type service: str
+    :param keep_paths: optional list of paths to not delete.
+    :type keep_paths: Union[None, List[str]]
+    """
+    keep_paths = keep_paths or []
+    for direntry in os.scandir(policyd_dir_for(service)):
+        # see if the path should be kept.
+        if direntry.path in keep_paths:
+            continue
+        # we remove any directories; it's ours and there shouldn't be any
+        if direntry.is_dir():
+            shutil.rmtree(direntry.path)
+        else:
+            os.remove(direntry.path)
+
+
+def path_for_policy_file(service, name):
+    """Return the full path for a policy.d file that will be written to the
+    service's policy.d directory.
+
+    It is constructed using policyd_dir_for(), the name and the ".yaml"
+    extension.
+
+    :param service: the service name
+    :type service: str
+    :param name: the name for the policy override
+    :type name: str
+    :returns: the full path name for the file
+    :rtype: os.PathLike[str]
+    """
+    return os.path.join(policyd_dir_for(service), name + ".yaml")
+
+
+def _policy_success_file():
+    """Return the file name for a successful drop of policy.d overrides
+
+    :returns: the path name for the file.
+    :rtype: str
+    """
+    return os.path.join(hookenv.charm_dir(), POLICYD_SUCCESS_FILENAME)
+
+
+def remove_policy_success_file():
+    """Remove the file that indicates successful policyd override."""
+    try:
+        os.remove(_policy_success_file())
+    except Exception:
+        pass
+
+
+def policyd_status_message_prefix():
+    """Return the prefix str for the status line.
+
+    "PO:" indicating that the policy overrides are in place, or "PO (broken):"
+    if the policy is supposed to be working but there is no success file.
+
+    :returns: the prefix
+    :rtype: str
+    """
+    if os.path.isfile(_policy_success_file()):
+        return "PO:"
+    return "PO (broken):"
+
+
+def process_policy_resource_file(resource_file,
+                                 service,
+                                 blacklist_paths=None,
+                                 blacklist_keys=None,
+                                 modify_function=None):
+    """Process the resource file (which should contain at least one yaml file)
+    and write those files to the service's policy.d directory.
+
+    The optional modify_function is a function that accepts a python dictionary
+    and has an opportunity to modify the yaml (as a python object) prior to it
+    being written to the disk.
+
+    The param blacklist_paths are paths (that are in the service's policy.d
+    directory that should not be touched).
+
+    The param blacklist_keys are keys that must not appear in the yaml file.
+    If they do, then the whole policy.d file fails.
+
+    The yaml file extracted from the resource_file (which is a zipped file) has
+    its file path reconstructed.  This, also, must not match any path in the
+    black list.
+
+    If any error occurs, then the policy.d directory is cleared, the error is
+    written to the log, and the status line will eventually show as failed.
+
+    :param resource_file: The zipped file to open and extract yaml files form.
+    :type resource_file: Union[AnyStr, os.PathLike[AnyStr]]
+    :param service: the service name to construct the policy.d directory for.
+    :type service: str
+    :param blacklist_paths: optional list of paths to leave alone
+    :type blacklist_paths: Union[None, List[str]]
+    :param blacklist_keys: optional list of keys that mustn't appear in the
+                           yaml file's
+    :type blacklist_keys: Union[None, List[str]]
+    :param modify_function: Optional function that can modify the yaml
+                            document.
+    :type modify_function: Union[None,
+                                 Callable[[Dict[str, str]], Dict[str,str]]]
+    :returns: True if the processing was successful, False if not.
+    :rtype: boolean
+    """
+    completed = False
+    try:
+        with open_and_filter_yaml_files(resource_file) as (zfp, gen):
+            # first clear out the policy.d directory and clear success
+            remove_policy_success_file()
+            clean_policyd_dir_for(service, blacklist_paths)
+            for name, filename, zipinfo in gen:
+                # construct a name for the output file.
+                yaml_filename = path_for_policy_file(service, name)
+                if yaml_filename in blacklist_paths:
+                    raise BadPolicyZipFile("policy.d name {} is blacklisted"
+                                           .format(yaml_filename))
+                with zfp.open(gen) as fp:
+                    yaml_doc = read_and_validate_yaml(fp, blacklist_keys)
+                if modify_function is not None and callable(modify_function):
+                    yaml_doc = modify_function(yaml_doc)
+                with open(yaml_filename, "wt") as f:
+                    yaml.dump(yaml_doc, f)
+        # Every thing worked, so we mark up a success.
+        completed = True
+    except (zipfile.BadZipFile, BadPolicyZipFile, BadPolicyYamlFile) as e:
+        hookenv.log("Processing {} failed: {}".format(resource_file, str(e)),
+                    level=POLICYD_LOG_LEVEL_DEFAULT)
+    except IOError as e:
+        # technically this shouldn't happen; it would be a programming error as
+        # the filename comes from Juju and thus, should exist.
+        hookenv.log(
+            "File {} failed with IOError.  This really shouldn't happen"
+            " -- error: {}".format(str(e)),
+            level=POLICYD_LOG_LEVEL_DEFAULT)
+    finally:
+        if not completed:
+            hookenv.log("Processing {} failed: cleaning policy.d directory",
+                        level=POLICYD_LOG_LEVEL_DEFAULT)
+            clean_policyd_dir_for(service, blacklist_paths)
+        else:
+            # touch the success filename
+            hookenv.log("policy.d overrides installed.",
+                        level=POLICYD_LOG_LEVEL_DEFAULT)
+            open(_policy_success_file(), "w").close()
+        return completed

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -115,6 +115,7 @@ POLICYD_RESOURCE_NAME = "policyd-override"
 POLICYD_CONFIG_NAME = "use-policyd-override"
 POLICYD_SUCCESS_FILENAME = "policyd-override-success"
 POLICYD_LOG_LEVEL_DEFAULT = hookenv.INFO
+POLICYD_ALWAYS_BLACKLISTED_KEYS = ("admin_required", "cloud_admin")
 
 
 class BadPolicyZipFile(Exception):
@@ -375,6 +376,7 @@ def read_and_validate_yaml(stream, blacklist_keys=None):
              blacklisted keys in the file.
     """
     blacklist_keys = blacklist_keys or []
+    blacklist_keys.append(POLICYD_ALWAYS_BLACKLISTED_KEYS)
     doc = yaml.safe_load(stream)
     if not isinstance(doc, dict):
         raise BadPolicyYamlFile("doesn't look like a policy file?")

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -194,8 +194,8 @@ OpenStack system.  The charms for the other services that may need overrides
 should be checked to ensure that they support overrides before proceeding.
 """
 
-POLICYD_VALID_EXTS = ['.yaml', '.yml', '.j2']
-POLICYD_TEMPLATE_EXTS = ['.j2']
+POLICYD_VALID_EXTS = ['.yaml', '.yml', '.j2', '.tmpl', '.tpl']
+POLICYD_TEMPLATE_EXTS = ['.j2', '.tmpl', '.tpl']
 POLICYD_RESOURCE_NAME = "policyd-override"
 POLICYD_CONFIG_NAME = "use-policyd-override"
 POLICYD_SUCCESS_FILENAME = "policyd-override-success"
@@ -237,7 +237,7 @@ def is_policyd_override_valid_on_this_release(openstack_release):
     :rtype: bool
     """
     ubuntu_release = ch_host.lsb_release()['DISTRIB_CODENAME'].lower()
-    # TODO(ajkavanagh) circular import!  This is because the status message
+    # NOTE(ajkavanagh) circular import!  This is because the status message
     # generation code in utils has to call into this module, but this function
     # needs the CompareOpenStackReleases() function.  The only way to solve
     # this is either to put ALL of this module into utils, or refactor one or
@@ -401,7 +401,7 @@ def open_and_filter_yaml_files(filepath):
         # first pass through; check for duplicates and at least one yaml file.
         names = collections.defaultdict(int)
         yamlfiles = _yamlfiles(zfp)
-        for name, _, _ in yamlfiles:
+        for name, _, _, _ in yamlfiles:
             names[name] += 1
         # There must be at least 1 yaml file.
         if len(names.keys()) == 0:

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -135,6 +135,7 @@ class BadPolicyYamlFile(Exception):
     def __str__(self):
         return self.log_message
 
+
 if six.PY2:
     BadZipFile = zipfile.BadZipfile
 else:
@@ -434,6 +435,7 @@ def clean_policyd_dir_for(service, keep_paths=None):
             shutil.rmtree(direntry.path)
         else:
             os.remove(direntry.path)
+
 
 @contextlib.contextmanager
 def _py2_scandir(path):

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -301,6 +301,8 @@ def maybe_do_policyd_overrides(openstack_release,
     config = hookenv.config()
     try:
         if not config.get(POLICYD_CONFIG_NAME, False):
+            remove_policy_success_file()
+            clean_policyd_dir_for(service, blacklist_paths)
             return
     except Exception:
         return
@@ -348,6 +350,8 @@ def maybe_do_policyd_overrides_on_config_changed(openstack_release,
     config = hookenv.config()
     try:
         if not config.get(POLICYD_CONFIG_NAME, False):
+            remove_policy_success_file()
+            clean_policyd_dir_for(service, blacklist_paths)
             return
     except Exception:
         return

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -236,7 +236,6 @@ def is_policyd_override_valid_on_this_release(openstack_release):
     :returns: True if okay
     :rtype: bool
     """
-    ubuntu_release = ch_host.lsb_release()['DISTRIB_CODENAME'].lower()
     # NOTE(ajkavanagh) circular import!  This is because the status message
     # generation code in utils has to call into this module, but this function
     # needs the CompareOpenStackReleases() function.  The only way to solve
@@ -244,8 +243,7 @@ def is_policyd_override_valid_on_this_release(openstack_release):
     # other of the CompareOpenStackReleases or status message generation code
     # into a 3rd module.
     import charmhelpers.contrib.openstack.utils as ch_utils
-    return (ch_host.CompareHostReleases(ubuntu_release) >= 'xenial' and
-            ch_utils.CompareOpenStackReleases(openstack_release) >= 'queens')
+    return ch_utils.CompareOpenStackReleases(openstack_release) >= 'queens'
 
 
 def maybe_do_policyd_overrides(openstack_release,

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -22,7 +22,6 @@ import zipfile
 
 import charmhelpers.core.hookenv as hookenv
 import charmhelpers.core.host as ch_host
-import charmhelpers.contrib.openstack.utils as ch_utils
 
 # Policy.d helper functions.
 #
@@ -140,6 +139,13 @@ def is_policyd_override_valid_on_this_release(openstack_release):
     :rtype: bool
     """
     ubuntu_release = ch_host.lsb_release()['DISTRIB_CODENAME'].lower()
+    # TODO(ajkavanagh) circular import!  This is because the status message
+    # generation code in utils has to call into this module, but this function
+    # needs the CompareOpenStackReleases() function.  The only way to solve
+    # this is either to put ALL of this module into utils, or refactor one or
+    # other of the CompareOpenStackReleases or status message generation code
+    # into a 3rd module.
+    import charmhelpers.contrib.openstack.utils as ch_utils
     return (ch_host.CompareHostReleases(ubuntu_release) >= 'bionic' and
             ch_utils.CompareOpenStackReleases(openstack_release) >= 'queens')
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -97,6 +97,10 @@ from charmhelpers.fetch.snap import (
 from charmhelpers.contrib.storage.linux.utils import is_block_device, zap_disk
 from charmhelpers.contrib.storage.linux.loopback import ensure_loopback_device
 from charmhelpers.contrib.openstack.exceptions import OSContextError
+from charmhelpers.contrib.openstack.policyd import (
+    policyd_status_message_prefix,
+    POLICYD_CONFIG_NAME,
+)
 
 CLOUD_ARCHIVE_URL = "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 CLOUD_ARCHIVE_KEY_ID = '5EDB1B62EC4926EA'
@@ -861,6 +865,12 @@ def _determine_os_workload_status(
         state = 'active'
         message = "Unit is ready"
         juju_log(message, 'INFO')
+
+    try:
+        if config(POLICYD_CONFIG_NAME):
+            message = "{} {}".format(policyd_status_message_prefix(), message)
+    except Exception:
+        pass
 
     return state, message
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1596,6 +1596,10 @@ class OpenStackHelpersTestCase(TestCase):
         r = f()
         self.assertEquals(r, 'damaged')
 
+    # TODO(ajkavanagh) -- there should be a test for
+    # _determine_os_workload_status() as the policyd override code has changed
+    # it, but there wasn't a test previously.
+
     @patch.object(openstack, 'restart_on_change_helper')
     @patch.object(openstack, 'is_unit_paused_set')
     def test_pausable_restart_on_change(

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -18,40 +18,10 @@ class PolicydTests(unittest.TestCase):
     def setUp(self):
         super(PolicydTests, self).setUp()
 
-    @mock.patch('charmhelpers.core.host.lsb_release')
-    def test_is_policyd_override_valid_on_this_release(self, mock_lsb_release):
-        mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "xenial",
-        }
+    def test_is_policyd_override_valid_on_this_release(self):
         self.assertTrue(
             policyd.is_policyd_override_valid_on_this_release("queens"))
         self.assertTrue(
-            policyd.is_policyd_override_valid_on_this_release("rocky"))
-        self.assertFalse(
-            policyd.is_policyd_override_valid_on_this_release("pike"))
-        # and shift to cosmic
-        mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "cosmic",
-        }
-        self.assertTrue(
-            policyd.is_policyd_override_valid_on_this_release("queens"))
-        # and should fail on trusty and vivid, etc.
-        mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "wily",
-        }
-        self.assertFalse(
-            policyd.is_policyd_override_valid_on_this_release("queens"))
-        self.assertFalse(
-            policyd.is_policyd_override_valid_on_this_release("rocky"))
-        self.assertFalse(
-            policyd.is_policyd_override_valid_on_this_release("pike"))
-        # and trusty, just to make sure
-        mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "trusty",
-        }
-        self.assertFalse(
-            policyd.is_policyd_override_valid_on_this_release("queens"))
-        self.assertFalse(
             policyd.is_policyd_override_valid_on_this_release("rocky"))
         self.assertFalse(
             policyd.is_policyd_override_valid_on_this_release("pike"))

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -153,16 +153,16 @@ class PolicydTests(unittest.TestCase):
     @mock.patch.object(policyd.zipfile, "ZipFile")
     def test_open_and_filter_yaml_files(self, mock_ZipFile, mock__yamlfiles):
         mock__yamlfiles.return_value = [
-            ("file1", "file1.yaml", None),
-            ("file2", "file2.YML", None)]
+            ("file1", ".yaml", "file1.yaml", None),
+            ("file2", ".yml", "file2.YML", None)]
         mock_ZipFile.return_value.__enter__.return_value = "zfp"
         # test a valid zip file
         with policyd.open_and_filter_yaml_files("some-file") as (zfp, files):
             self.assertEqual(zfp, "zfp")
             mock_ZipFile.assert_called_once_with("some-file", "r")
             self.assertEqual(files, [
-                ("file1", "file1.yaml", None),
-                ("file2", "file2.YML", None)])
+                ("file1", ".yaml", "file1.yaml", None),
+                ("file2", ".yml", "file2.YML", None)])
         # ensure that there must be at least one file.
         mock__yamlfiles.return_value = []
         with self.assertRaises(policyd.BadPolicyZipFile):
@@ -170,9 +170,9 @@ class PolicydTests(unittest.TestCase):
                 pass
         # ensure that it picks up duplicates
         mock__yamlfiles.return_value = [
-            ("file1", "file1.yaml", None),
-            ("file2", "file2.yml", None),
-            ("file1", "file1.yml", None)]
+            ("file1", ".yaml", "file1.yaml", None),
+            ("file2", ".yml", "file2.yml", None),
+            ("file1", ".yml", "file1.yml", None)]
         with self.assertRaises(policyd.BadPolicyZipFile):
             with policyd.open_and_filter_yaml_files("some-file"):
                 pass

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -141,6 +141,7 @@ class PolicydTests(unittest.TestCase):
                          "test-file")
         mock_resource_get.assert_called_once_with(
             policyd.POLICYD_RESOURCE_NAME)
+
         # check that if an error is raised, that None is returned.
         def go_bang(*args):
             raise Exception("bang")
@@ -338,6 +339,7 @@ class PolicydTests(unittest.TestCase):
         mock_file.return_value = "the-path"
         policyd.remove_policy_success_file()
         mock_os_remove.assert_called_once_with("the-path")
+
         # now test that failure doesn't fail the function
         def go_bang(*args):
             raise Exception("bang")
@@ -456,5 +458,3 @@ class PolicydTests(unittest.TestCase):
         mock_log.assert_any_call(
             "General Exception(bang2) during policyd processing",
             level=policyd.POLICYD_LOG_LEVEL_DEFAULT)
-
-

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -21,7 +21,7 @@ class PolicydTests(unittest.TestCase):
     @mock.patch('charmhelpers.core.host.lsb_release')
     def test_is_policyd_override_valid_on_this_release(self, mock_lsb_release):
         mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "bionic",
+            'DISTRIB_CODENAME': "xenial",
         }
         self.assertTrue(
             policyd.is_policyd_override_valid_on_this_release("queens"))
@@ -31,13 +31,13 @@ class PolicydTests(unittest.TestCase):
             policyd.is_policyd_override_valid_on_this_release("pike"))
         # and shift to cosmic
         mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "bionic",
+            'DISTRIB_CODENAME': "cosmic",
         }
         self.assertTrue(
             policyd.is_policyd_override_valid_on_this_release("queens"))
-        # and should fail on artful and xenial, etc.
+        # and should fail on trusty and vivid, etc.
         mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "artful",
+            'DISTRIB_CODENAME': "wily",
         }
         self.assertFalse(
             policyd.is_policyd_override_valid_on_this_release("queens"))
@@ -45,9 +45,9 @@ class PolicydTests(unittest.TestCase):
             policyd.is_policyd_override_valid_on_this_release("rocky"))
         self.assertFalse(
             policyd.is_policyd_override_valid_on_this_release("pike"))
-        # and xenial, just to make sure
+        # and trusty, just to make sure
         mock_lsb_release.return_value = {
-            'DISTRIB_CODENAME': "xenial",
+            'DISTRIB_CODENAME': "trusty",
         }
         self.assertFalse(
             policyd.is_policyd_override_valid_on_this_release("queens"))

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -1,0 +1,460 @@
+import contextlib
+import copy
+import io
+import mock
+import six
+import unittest
+
+from charmhelpers.contrib.openstack import policyd
+
+
+if not six.PY3:
+    builtin_open = '__builtin__.open'
+else:
+    builtin_open = 'builtins.open'
+
+
+class PolicydTests(unittest.TestCase):
+    def setUp(self):
+        super(PolicydTests, self).setUp()
+
+    @mock.patch('charmhelpers.core.host.lsb_release')
+    def test_is_policyd_override_valid_on_this_release(self, mock_lsb_release):
+        mock_lsb_release.return_value = {
+            'DISTRIB_CODENAME': "bionic",
+        }
+        self.assertTrue(
+            policyd.is_policyd_override_valid_on_this_release("queens"))
+        self.assertTrue(
+            policyd.is_policyd_override_valid_on_this_release("rocky"))
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("pike"))
+        # and shift to cosmic
+        mock_lsb_release.return_value = {
+            'DISTRIB_CODENAME': "bionic",
+        }
+        self.assertTrue(
+            policyd.is_policyd_override_valid_on_this_release("queens"))
+        # and should fail on artful and xenial, etc.
+        mock_lsb_release.return_value = {
+            'DISTRIB_CODENAME': "artful",
+        }
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("queens"))
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("rocky"))
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("pike"))
+        # and xenial, just to make sure
+        mock_lsb_release.return_value = {
+            'DISTRIB_CODENAME': "xenial",
+        }
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("queens"))
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("rocky"))
+        self.assertFalse(
+            policyd.is_policyd_override_valid_on_this_release("pike"))
+
+    @mock.patch.object(policyd, "process_policy_resource_file")
+    @mock.patch.object(policyd, "get_policy_resource_filename")
+    @mock.patch.object(policyd, "is_policyd_override_valid_on_this_release")
+    @mock.patch.object(policyd.hookenv, "config")
+    def test_maybe_do_policyd_overrides(
+        self,
+        mock_config,
+        mock_is_policyd_override_valid_on_this_release,
+        mock_get_policy_resource_filename,
+        mock_process_policy_resource_file
+    ):
+        # test success condition
+        mock_config.return_value = {policyd.POLICYD_CONFIG_NAME: True}
+        mock_is_policyd_override_valid_on_this_release.return_value = True
+        mock_get_policy_resource_filename.return_value = "resource.zip"
+        mock_process_policy_resource_file.return_value = True
+        mod_fn = mock.Mock()
+        restart_handler = mock.Mock()
+        policyd.maybe_do_policyd_overrides(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_is_policyd_override_valid_on_this_release.assert_called_once_with(
+            "arelease")
+        mock_get_policy_resource_filename.assert_called_once_with()
+        mock_process_policy_resource_file.assert_called_once_with(
+            "resource.zip", "aservice", ["a"], ["b"], mod_fn)
+        restart_handler.assert_called_once_with()
+        # test process_policy_resource_file is not called if not valid on the
+        # release.
+        mock_process_policy_resource_file.reset_mock()
+        restart_handler.reset_mock()
+        mock_is_policyd_override_valid_on_this_release.return_value = False
+        policyd.maybe_do_policyd_overrides(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_process_policy_resource_file.assert_not_called()
+        restart_handler.assert_not_called()
+        # test restart_handler is not called if not needed.
+        mock_is_policyd_override_valid_on_this_release.return_value = True
+        mock_process_policy_resource_file.return_value = False
+        policyd.maybe_do_policyd_overrides(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_process_policy_resource_file.assert_called_once_with(
+            "resource.zip", "aservice", ["a"], ["b"], mod_fn)
+        restart_handler.assert_not_called()
+
+    @mock.patch.object(policyd, "maybe_do_policyd_overrides")
+    @mock.patch.object(policyd, "_policy_success_file")
+    @mock.patch("os.path.isfile")
+    @mock.patch.object(policyd.hookenv, "config")
+    def test_maybe_do_policyd_overrides_on_config_changed(
+            self, mock_config, mock_isfile, mock__policy_success_file,
+            mock_maybe_do_policyd_overrides
+    ):
+        # test success condition
+        mock_config.return_value = {policyd.POLICYD_CONFIG_NAME: True}
+        mock__policy_success_file.return_value = "s-return"
+        mock_isfile.return_value = False
+        mod_fn = mock.Mock()
+        restart_handler = mock.Mock()
+        policyd.maybe_do_policyd_overrides_on_config_changed(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_maybe_do_policyd_overrides.assert_called_once_with(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_config.assert_called_once_with()
+        mock_isfile.assert_called_once_with("s-return")
+        # test no config value for POLICYD_SUCCESS_FILENAME
+        mock_maybe_do_policyd_overrides.reset_mock()
+        mock_config.return_value = {}
+        policyd.maybe_do_policyd_overrides_on_config_changed(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_maybe_do_policyd_overrides.assert_not_called()
+        # test that policy success file is already set (i.e. policy override
+        # already done)
+        mock_config.return_value = {policyd.POLICYD_CONFIG_NAME: True}
+        mock_isfile.return_value = False
+        policyd.maybe_do_policyd_overrides_on_config_changed(
+            "arelease", "aservice", ["a"], ["b"], mod_fn, restart_handler)
+        mock_maybe_do_policyd_overrides.assert_not_called()
+
+    @mock.patch("charmhelpers.core.hookenv.resource_get")
+    def test_get_policy_resource_filename(self, mock_resource_get):
+        mock_resource_get.return_value = "test-file"
+        self.assertEqual(policyd.get_policy_resource_filename(),
+                         "test-file")
+        mock_resource_get.assert_called_once_with(
+            policyd.POLICYD_RESOURCE_NAME)
+        # check that if an error is raised, that None is returned.
+        def go_bang(*args):
+            raise Exception("bang")
+
+        mock_resource_get.side_effect = go_bang
+        self.assertEqual(policyd.get_policy_resource_filename(), None)
+
+    @mock.patch.object(policyd, "_yamlfiles")
+    @mock.patch.object(policyd.zipfile, "ZipFile")
+    def test_open_and_filter_yaml_files(self, mock_ZipFile, mock__yamlfiles):
+        mock__yamlfiles.return_value = [
+            ("file1", "file1.yaml", None),
+            ("file2", "file2.YML", None)]
+        mock_ZipFile.return_value.__enter__.return_value = "zfp"
+        # test a valid zip file
+        with policyd.open_and_filter_yaml_files("some-file") as (zfp, files):
+            self.assertEqual(zfp, "zfp")
+            mock_ZipFile.assert_called_once_with("some-file", "r")
+            self.assertEqual(files, [
+                ("file1", "file1.yaml", None),
+                ("file2", "file2.YML", None)])
+        # ensure that there must be at least one file.
+        mock__yamlfiles.return_value = []
+        with self.assertRaises(policyd.BadPolicyZipFile):
+            with policyd.open_and_filter_yaml_files("some-file"):
+                pass
+        # ensure that it picks up duplicates
+        mock__yamlfiles.return_value = [
+            ("file1", "file1.yaml", None),
+            ("file2", "file2.yml", None),
+            ("file1", "file1.yml", None)]
+        with self.assertRaises(policyd.BadPolicyZipFile):
+            with policyd.open_and_filter_yaml_files("some-file"):
+                pass
+
+    def test__yamlfiles(self):
+        class MockZipFile(object):
+            def __init__(self, infolist):
+                self._infolist = infolist
+
+            def infolist(self):
+                return self._infolist
+
+        class MockInfoListItem(object):
+            def __init__(self, is_dir, filename):
+                self.filename = filename
+                self._is_dir = is_dir
+
+            def is_dir(self):
+                return self._is_dir
+
+            def __repr__(self):
+                return "MockInfoListItem({}, {})".format(self._is_dir,
+                                                         self.filename)
+
+        zipfile = MockZipFile([
+            MockInfoListItem(False, "file1.yaml"),
+            MockInfoListItem(False, "file2.md"),
+            MockInfoListItem(False, "file3.YML"),
+            MockInfoListItem(False, "file4.Yaml"),
+            MockInfoListItem(True, "file5"),
+            MockInfoListItem(True, "file6.yaml"),
+            MockInfoListItem(False, "file7")])
+
+        self.assertEqual(list(policyd._yamlfiles(zipfile)),
+                         [("file1", "file1.yaml", mock.ANY),
+                          ("file3", "file3.YML", mock.ANY),
+                          ("file4", "file4.Yaml", mock.ANY)])
+
+    @mock.patch.object(policyd.yaml, "safe_load")
+    def test_read_and_validate_yaml(self, mock_safe_load):
+        # test a valid document
+        good_doc = {
+            "key1": "rule1",
+            "key2": "rule2",
+        }
+        mock_safe_load.return_value = copy.deepcopy(good_doc)
+        doc = policyd.read_and_validate_yaml("test-stream")
+        self.assertEqual(doc, good_doc)
+        mock_safe_load.assert_called_once_with("test-stream")
+        # test an invalid document - return a string
+        mock_safe_load.return_value = "wrong"
+        with self.assertRaises(policyd.BadPolicyYamlFile):
+            policyd.read_and_validate_yaml("test-stream")
+        # test for black-listed keys
+        with self.assertRaises(policyd.BadPolicyYamlFile):
+            mock_safe_load.return_value = copy.deepcopy(good_doc)
+            policyd.read_and_validate_yaml("test-stream", ["key1"])
+        # test for non string keys
+        bad_key_doc = {
+            (1,): "rule1",
+            "key2": "rule2",
+        }
+        with self.assertRaises(policyd.BadPolicyYamlFile):
+            mock_safe_load.return_value = copy.deepcopy(bad_key_doc)
+            policyd.read_and_validate_yaml("test-stream", ["key1"])
+        # test for non string values (i.e. no nested keys)
+        bad_key_doc2 = {
+            "key1": "rule1",
+            "key2": {"sub_key": "rule2"},
+        }
+        with self.assertRaises(policyd.BadPolicyYamlFile):
+            mock_safe_load.return_value = copy.deepcopy(bad_key_doc2)
+            policyd.read_and_validate_yaml("test-stream", ["key1"])
+
+    def test_policyd_dir_for(self):
+        self.assertEqual(policyd.policyd_dir_for('thing'),
+                         "/etc/thing/policy.d")
+
+    @mock.patch("os.remove")
+    @mock.patch("shutil.rmtree")
+    @mock.patch("charmhelpers.core.host.mkdir")
+    @mock.patch("os.path.exists")
+    @mock.patch.object(policyd, "policyd_dir_for")
+    def test_clean_policyd_dir_for(self,
+                                   mock_policyd_dir_for,
+                                   mock_os_path_exists,
+                                   mock_mkdir,
+                                   mock_shutil_rmtree,
+                                   mock_os_remove):
+        if six.PY3:
+            mock_scan_dir_parts = (mock.patch, ["os.scandir"])
+        else:
+            mock_scan_dir_parts = (mock.patch.object,
+                                   [policyd, "_py2_scandir"])
+
+        class MockDirEntry(object):
+            def __init__(self, path, is_dir):
+                self.path = path
+                self._is_dir = is_dir
+
+            def is_dir(self):
+                return self._is_dir
+
+        # list of scanned objects
+        directory_contents = [
+            MockDirEntry("one", False),
+            MockDirEntry("two", False),
+            MockDirEntry("three", True),
+            MockDirEntry("four", False)]
+
+        mock_policyd_dir_for.return_value = "the-path"
+
+        # Initial conditions
+        mock_os_path_exists.return_value = False
+
+        # call the function
+        with mock_scan_dir_parts[0](*mock_scan_dir_parts[1]) as \
+                mock_os_scandir:
+            mock_os_scandir.return_value = directory_contents
+            policyd.clean_policyd_dir_for("aservice")
+
+        # check it did the right thing
+        mock_policyd_dir_for.assert_called_once_with("aservice")
+        mock_os_path_exists.assert_called_once_with("the-path")
+        mock_mkdir.assert_called_once_with("the-path",
+                                           owner="aservice",
+                                           group="aservice",
+                                           perms=0o775)
+        mock_shutil_rmtree.assert_called_once_with("three")
+        mock_os_remove.assert_has_calls([
+            mock.call("one"), mock.call("two"), mock.call("four")])
+
+        # check also that we can omit paths ... reset everything
+        mock_os_remove.reset_mock()
+        mock_shutil_rmtree.reset_mock()
+        mock_os_path_exists.reset_mock()
+        mock_os_path_exists.return_value = True
+        mock_mkdir.reset_mock()
+
+        with mock_scan_dir_parts[0](*mock_scan_dir_parts[1]) as \
+                mock_os_scandir:
+            mock_os_scandir.return_value = directory_contents
+            policyd.clean_policyd_dir_for("aservice",
+                                          keep_paths=["one", "three"])
+
+        # verify all worked as we expected
+        mock_mkdir.assert_not_called()
+        mock_shutil_rmtree.assert_not_called()
+        mock_os_remove.assert_has_calls([mock.call("two"), mock.call("four")])
+
+    def test_path_for_policy_file(self):
+        self.assertEqual(policyd.path_for_policy_file('this', 'that'),
+                         "/etc/this/policy.d/that.yaml")
+
+    @mock.patch("charmhelpers.core.hookenv.charm_dir")
+    def test__policy_success_file(self, mock_charm_dir):
+        mock_charm_dir.return_value = "/this"
+        self.assertEqual(policyd._policy_success_file(),
+                         "/this/{}".format(policyd.POLICYD_SUCCESS_FILENAME))
+
+    @mock.patch("os.remove")
+    @mock.patch.object(policyd, "_policy_success_file")
+    def test_remove_policy_success_file(self, mock_file, mock_os_remove):
+        mock_file.return_value = "the-path"
+        policyd.remove_policy_success_file()
+        mock_os_remove.assert_called_once_with("the-path")
+        # now test that failure doesn't fail the function
+        def go_bang(*args):
+            raise Exception("bang")
+
+        mock_os_remove.side_effect = go_bang
+        policyd.remove_policy_success_file()
+
+    @mock.patch("os.path.isfile")
+    @mock.patch.object(policyd, "_policy_success_file")
+    def test_policyd_status_message_prefix(self, mock_file, mock_is_file):
+        mock_file.return_value = "the-path"
+        mock_is_file.return_value = True
+        self.assertEqual(policyd.policyd_status_message_prefix(), "PO:")
+        mock_is_file.return_value = False
+        self.assertEqual(
+            policyd.policyd_status_message_prefix(), "PO (broken):")
+
+    @mock.patch("yaml.dump")
+    @mock.patch.object(policyd, "_policy_success_file")
+    @mock.patch.object(policyd.hookenv, "log")
+    @mock.patch.object(policyd, "read_and_validate_yaml")
+    @mock.patch.object(policyd, "path_for_policy_file")
+    @mock.patch.object(policyd, "clean_policyd_dir_for")
+    @mock.patch.object(policyd, "remove_policy_success_file")
+    @mock.patch.object(policyd, "open_and_filter_yaml_files")
+    def test_process_policy_resource_file(
+        self,
+        mock_open_and_filter_yaml_files,
+        mock_remove_policy_success_file,
+        mock_clean_policyd_dir_for,
+        mock_path_for_policy_file,
+        mock_read_and_validate_yaml,
+        mock_log,
+        mock__policy_success_file,
+        mock_yaml_dump,
+    ):
+        mock_zfp = mock.MagicMock()
+        mod_fn = mock.Mock()
+        mock_path_for_policy_file.side_effect = lambda s, n: s + "/" + n
+        gen = [
+            ("file1", "file1.yaml", "file1-zipinfo"),
+            ("file2", "file2.yml", "file2-zipinfo")]
+        mock_open_and_filter_yaml_files.return_value.__enter__.return_value = \
+            (mock_zfp, gen)
+        # first verify that we can blacklist a file
+        res = policyd.process_policy_resource_file(
+            "resource.zip", "aservice", ["aservice/file1"], [], mod_fn)
+        self.assertFalse(res)
+        mock_remove_policy_success_file.assert_called_once_with()
+        mock_clean_policyd_dir_for.assert_has_calls([
+            mock.call("aservice", ["aservice/file1"]),
+            mock.call("aservice", ["aservice/file1"])])
+        mock_zfp.open.assert_not_called()
+        mod_fn.assert_not_called()
+        mock_log.assert_any_call("Processing resource.zip failed: policy.d"
+                                 " name aservice/file1 is blacklisted",
+                                 level=policyd.POLICYD_LOG_LEVEL_DEFAULT)
+
+        # now test for success
+        @contextlib.contextmanager
+        def _patch_open():
+            '''Patch open() to allow mocking both open() itself and the file that is
+            yielded.
+
+            Yields the mock for "open" and "file", respectively.'''
+            mock_open = mock.MagicMock(spec=open)
+            mock_file = mock.MagicMock(spec=io.FileIO)
+
+            with mock.patch(builtin_open, mock_open):
+                yield mock_open, mock_file
+
+        mock_clean_policyd_dir_for.reset_mock()
+        mock_zfp.reset_mock()
+        mock_zfp.open.return_value.__enter__.return_value = "fp"
+        gen = [("file1", "file1.yaml", "file1-zipinfo")]
+        mock_open_and_filter_yaml_files.return_value.__enter__.return_value = \
+            (mock_zfp, gen)
+        mock_read_and_validate_yaml.return_value = "read_yaml_return"
+        mod_fn.return_value = "modded_yaml"
+        mock__policy_success_file.return_value = "policy-success-file"
+        with _patch_open() as (mock_open, mock_file):
+            res = policyd.process_policy_resource_file(
+                "resource.zip", "aservice", [], ["key"], mod_fn)
+            self.assertTrue(res)
+            mock_open.assert_any_call("aservice/file1", "wt")
+            mock_open.assert_any_call("policy-success-file", "w")
+            mock_yaml_dump.assert_called_once_with("modded_yaml", mock.ANY)
+        mock_zfp.open.assert_called_once_with("file1-zipinfo")
+        mock_read_and_validate_yaml.assert_called_once_with("fp", ["key"])
+        mod_fn.assert_called_once_with("read_yaml_return")
+
+        # raise the IOError to validate that code path
+        def raise_ioerror(*args):
+            raise IOError("bang")
+
+        mock_open_and_filter_yaml_files.side_effect = raise_ioerror
+        mock_log.reset_mock()
+        res = policyd.process_policy_resource_file(
+            "resource.zip", "aservice", [], ["key"], mod_fn)
+        self.assertFalse(res, False)
+        mock_log.assert_any_call(
+            "File resource.zip failed with IOError.  "
+            "This really shouldn't happen -- error: bang",
+            level=policyd.POLICYD_LOG_LEVEL_DEFAULT)
+        # raise a general exception, so that is caught and logged too.
+
+        def raise_exception(*args):
+            raise Exception("bang2")
+
+        mock_open_and_filter_yaml_files.reset_mock()
+        mock_open_and_filter_yaml_files.side_effect = raise_exception
+        mock_log.reset_mock()
+        res = policyd.process_policy_resource_file(
+            "resource.zip", "aservice", [], ["key"], mod_fn)
+        self.assertFalse(res, False)
+        mock_log.assert_any_call(
+            "General Exception(bang2) during policyd processing",
+            level=policyd.POLICYD_LOG_LEVEL_DEFAULT)
+
+


### PR DESCRIPTION
These helpers implement the policy.d override functionality for
OpenStack charms.

This is part of the work of policy overrides: Spec at: https://review.opendev.org/#/c/679421/