### PR TITLE
Conditionally add port_forwarding to l3_extension_plugins

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1717,6 +1717,10 @@ class NeutronAPIContext(OSContextGenerator):
                 'rel_key': 'enable-nfg-logging',
                 'default': False,
             },
+            'enable_port_forwarding': {
+                'rel_key': 'enable-port-forwarding',
+                'default': False,
+            },
             'global_physnet_mtu': {
                 'rel_key': 'global-physnet-mtu',
                 'default': 1500,
@@ -1745,6 +1749,13 @@ class NeutronAPIContext(OSContextGenerator):
             extension_drivers.append('log')
 
         ctxt['extension_drivers'] = ','.join(extension_drivers)
+
+        l3_extension_plugins = []
+
+        if ctxt['enable_port_forwarding']:
+            l3_extension_plugins.append('port_forwarding')
+
+        ctxt['l3_extension_plugins'] = l3_extension_plugins
 
         return ctxt
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3567,6 +3567,22 @@ class ContextTests(unittest.TestCase):
         api_ctxt = context.NeutronAPIContext()()
         self.assertEquals(api_ctxt['enable_nfg_logging'], False)
 
+    def test_neutronapicontext_port_forwarding_on(self):
+        self.setup_neutron_api_context_relation({
+            'enable-port-forwarding': 'True',
+            'l2-population': 'True'
+        })
+        api_ctxt = context.NeutronAPIContext()()
+        self.assertEquals(api_ctxt['enable_port_forwarding'], True)
+
+    def test_neutronapicontext_port_forwarding_off(self):
+        self.setup_neutron_api_context_relation({
+            'enable-port-forwarding': 'False',
+            'l2-population': 'True'
+        })
+        api_ctxt = context.NeutronAPIContext()()
+        self.assertEquals(api_ctxt['enable_port_forwarding'], False)
+
     def test_neutronapicontext_string_converted(self):
         self.setup_neutron_api_context_relation({
             'l2-population': 'True'})


### PR DESCRIPTION
Adds port_forwarding which is an extension to an l3 agent to support the
port forwarding feature.

See LP: #1842353

Partial-Bug: #1842353