### PR TITLE
Allow overriding usage of cache for hookenv config

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -391,7 +391,7 @@ class Config(dict):
 _cache_config = None
 
 
-def config(scope=None):
+def config(scope=None, use_cache=True):
     """
     Get the juju charm configuration (scope==None) or individual key,
     (scope=str).  The returned value is a Python data structure loaded as
@@ -411,10 +411,11 @@ def config(scope=None):
         # JSON Decode Exception for Python2.7 through Python3.4
         exc_json = ValueError
     try:
-        if _cache_config is None:
+        if not use_cache or _cache_config is None:
             config_data = json.loads(
                 subprocess.check_output(config_cmd_line).decode('UTF-8'))
             _cache_config = Config(config_data)
+            _cache_config.implicit_save = use_cache
         if scope is not None:
             return _cache_config.get(scope)
         return _cache_config

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -488,6 +488,21 @@ class HelpersTest(TestCase):
         self.assertEqual(result, None)
         self.assertFalse(check_output.called)
 
+    @patch('charmhelpers.core.hookenv._cache_config', {'baz': 'bar'})
+    @patch('charmhelpers.core.hookenv.charm_dir')
+    @patch('subprocess.check_output')
+    def test_gets_config_no_cache_without_scope(self,
+                                                check_output,
+                                                charm_dir):
+        check_output.return_value = json.dumps(dict(baz='bar')).encode('UTF-8')
+        charm_dir.return_value = '/nonexistent'
+
+        result = hookenv.config(use_cache=False)
+
+        self.assertFalse(result.implicit_save)
+        self.assertEqual(result['baz'], 'bar')
+        self.assertTrue(check_output.called)
+
     @patch('charmhelpers.core.hookenv.os')
     def test_gets_the_local_unit(self, os_):
         os_.environ = {


### PR DESCRIPTION
In certain cases, we may not want to use the cached results from
config-get such as when hook is run as a non-root user and does not
have access to the cache file (currently charm/.juju-persistent-config).