### PR TITLE
Fix policyd helper where when the config value is set to false

### DIFF
--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -299,10 +299,17 @@ def maybe_do_policyd_overrides(openstack_release,
     config = hookenv.config()
     try:
         if not config.get(POLICYD_CONFIG_NAME, False):
-            remove_policy_success_file()
             clean_policyd_dir_for(service, blacklist_paths)
+            if (os.path.isfile(_policy_success_file()) and
+                    restart_handler is not None and
+                    callable(restart_handler)):
+                restart_handler()
+            remove_policy_success_file()
             return
-    except Exception:
+    except Exception as e:
+        print("Exception is: ", str(e))
+        import traceback
+        traceback.print_exc()
         return
     if not is_policyd_override_valid_on_this_release(openstack_release):
         return
@@ -348,8 +355,12 @@ def maybe_do_policyd_overrides_on_config_changed(openstack_release,
     config = hookenv.config()
     try:
         if not config.get(POLICYD_CONFIG_NAME, False):
-            remove_policy_success_file()
             clean_policyd_dir_for(service, blacklist_paths)
+            if (os.path.isfile(_policy_success_file()) and
+                    restart_handler is not None and
+                    callable(restart_handler)):
+                restart_handler()
+            remove_policy_success_file()
             return
     except Exception:
         return

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -31,16 +31,22 @@ class PolicydTests(unittest.TestCase):
     @mock.patch.object(policyd, "process_policy_resource_file")
     @mock.patch.object(policyd, "get_policy_resource_filename")
     @mock.patch.object(policyd, "is_policyd_override_valid_on_this_release")
+    @mock.patch.object(policyd, "_policy_success_file")
+    @mock.patch("os.path.isfile")
     @mock.patch.object(policyd.hookenv, "config")
     def test_maybe_do_policyd_overrides(
         self,
         mock_config,
+        mock_isfile,
+        mock__policy_success_file,
         mock_is_policyd_override_valid_on_this_release,
         mock_get_policy_resource_filename,
         mock_process_policy_resource_file,
         mock_remove_policy_success_file,
         mock_clean_policyd_dir_for,
     ):
+        mock_isfile.return_value = False
+        mock__policy_success_file.return_value = "s-return"
         # test success condition
         mock_config.return_value = {policyd.POLICYD_CONFIG_NAME: True}
         mock_is_policyd_override_valid_on_this_release.return_value = True


### PR DESCRIPTION
The issue was that the restart helper wasn't called when config was set
to false and previously there had been a working policy override.  If
the underlying service needs a restart (e.g. neutron-server) then the
policy override change isn't seen, and so the policy stays in force.
This change ensures the restart handler is called under all
circumstances.