### PR TITLE
Allow OpenStack deployments from PPA packages

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1940,7 +1940,7 @@ class VolumeAPIContext(InternalEndpointContext):
         as well as the catalog_info string that would be supplied. Returns
         a dict containing the volume_api_version and the volume_catalog_info.
         """
-        rel = os_release(self.pkg, base='icehouse')
+        rel = os_release(self.pkg)
         version = '2'
         if CompareOpenStackReleases(rel) >= 'pike':
             version = '3'
@@ -2140,7 +2140,7 @@ class VersionsContext(OSContextGenerator):
         self.pkg = pkg
 
     def __call__(self):
-        ostack = os_release(self.pkg, base='icehouse')
+        ostack = os_release(self.pkg)
         osystem = lsb_release()['DISTRIB_CODENAME'].lower()
         return {
             'openstack_release': ostack,

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -531,7 +531,7 @@ def reset_os_release():
     _os_rel = None
 
 
-def os_release(package, base='essex', reset_cache=False):
+def os_release(package, base=None, reset_cache=False):
     '''
     Returns OpenStack release codename from a cached global.
 
@@ -542,6 +542,8 @@ def os_release(package, base='essex', reset_cache=False):
     the installation source, the earliest release supported by the charm should
     be returned.
     '''
+    if not base:
+        base = UBUNTU_OPENSTACK_RELEASE[lsb_release()['DISTRIB_CODENAME']]
     global _os_rel
     if reset_cache:
         reset_os_release()
@@ -670,7 +672,10 @@ def openstack_upgrade_available(package):
         codename = get_os_codename_install_source(src)
         avail_vers = get_os_version_codename_swift(codename)
     else:
-        avail_vers = get_os_version_install_source(src)
+        try:
+            avail_vers = get_os_version_install_source(src)
+        except:
+            avail_vers = cur_vers
     apt.init()
     return apt.version_compare(avail_vers, cur_vers) >= 1
 
@@ -1693,7 +1698,7 @@ def enable_memcache(source=None, release=None, package=None):
     if release:
         _release = release
     else:
-        _release = os_release(package, base='icehouse')
+        _release = os_release(package)
     if not _release:
         _release = get_os_codename_install_source(source)
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3846,7 +3846,7 @@ class ContextTests(unittest.TestCase):
             {
                 'openstack_release': 'essex',
                 'operating_system_release': 'xenial'})
-        os_release.assert_called_once_with('python-keystone', base='icehouse')
+        os_release.assert_called_once_with('python-keystone')
         self.lsb_release.assert_called_once_with()
 
     def test_logrotate_context_unset(self):


### PR DESCRIPTION
When using a PPA for an OpenStack package the current implementation
throws errors because it cannot determine the OpenStack version from
the openstack-origin. It also makes terrible assumptions about which
version of OpenStack is in use when unable to determine it from
openstack-origin.

This change does the following:
 * Gracefully handles if the openstack-origin is not a known source.
 * Uses a sane default for os_relase base, by determining the default
   OpenStack release for the currently deployed Ubuntu series.