### PR TITLE
Stop duplicate ops being added to CephBrokerRq

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1185,6 +1185,17 @@ class CephBrokerRq(object):
             self.request_id = str(uuid.uuid1())
         self.ops = []
 
+    def add_op(self, op):
+        """Add an op if it not already in the list.
+
+        :param name: operation to add.
+        :type name: dict
+        """
+        for existing_op in self.ops:
+            if op == existing_op:
+                return
+        self.ops.append(op)
+
     def add_op_request_access_to_group(self, name, namespace=None,
                                        permission=None, key_name=None,
                                        object_prefix_permissions=None):
@@ -1198,7 +1209,7 @@ class CephBrokerRq(object):
                 'rwx': ['prefix1', 'prefix2'],
                 'class-read': ['prefix3']}
         """
-        self.ops.append({
+        self.add_op({
             'op': 'add-permissions-to-key', 'group': name,
             'namespace': namespace,
             'name': key_name or service_name(),
@@ -1251,11 +1262,11 @@ class CephBrokerRq(object):
         if pg_num and weight:
             raise ValueError('pg_num and weight are mutually exclusive')
 
-        self.ops.append({'op': 'create-pool', 'name': name,
-                         'replicas': replica_count, 'pg_num': pg_num,
-                         'weight': weight, 'group': group,
-                         'group-namespace': namespace, 'app-name': app_name,
-                         'max-bytes': max_bytes, 'max-objects': max_objects})
+        self.add_op({'op': 'create-pool', 'name': name,
+                     'replicas': replica_count, 'pg_num': pg_num,
+                     'weight': weight, 'group': group,
+                     'group-namespace': namespace, 'app-name': app_name,
+                     'max-bytes': max_bytes, 'max-objects': max_objects})
 
     def add_op_create_erasure_pool(self, name, erasure_profile=None,
                                    weight=None, group=None, app_name=None,
@@ -1283,12 +1294,12 @@ class CephBrokerRq(object):
         :param max_objects: Maximum objects quota to apply
         :type max_objects: int
         """
-        self.ops.append({'op': 'create-pool', 'name': name,
-                         'pool-type': 'erasure',
-                         'erasure-profile': erasure_profile,
-                         'weight': weight,
-                         'group': group, 'app-name': app_name,
-                         'max-bytes': max_bytes, 'max-objects': max_objects})
+        self.add_op({'op': 'create-pool', 'name': name,
+                     'pool-type': 'erasure',
+                     'erasure-profile': erasure_profile,
+                     'weight': weight,
+                     'group': group, 'app-name': app_name,
+                     'max-bytes': max_bytes, 'max-objects': max_objects})
 
     def set_ops(self, ops):
         """Set request ops to provided value.

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1191,10 +1191,8 @@ class CephBrokerRq(object):
         :param op: Operation to add.
         :type op: dict
         """
-        for existing_op in self.ops:
-            if op == existing_op:
-                return
-        self.ops.append(op)
+        if op not in self.ops:
+            self.ops.append(op)
 
     def add_op_request_access_to_group(self, name, namespace=None,
                                        permission=None, key_name=None,

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1186,10 +1186,10 @@ class CephBrokerRq(object):
         self.ops = []
 
     def add_op(self, op):
-        """Add an op if it not already in the list.
+        """Add an op if it is not already in the list.
 
-        :param name: operation to add.
-        :type name: dict
+        :param op: Operation to add.
+        :type op: dict
         """
         for existing_op in self.ops:
             if op == existing_op:

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1254,8 +1254,11 @@ class CephUtilsTests(TestCase):
         uuid.uuid1.return_value = 'uuid'
         rq = ceph_utils.CephBrokerRq()
         rq.add_op_create_pool('pool1', replica_count=1)
+        rq.add_op_create_pool('pool1', replica_count=1)
+        rq.add_op_create_pool('pool2')
         rq.add_op_create_pool('pool2')
         rq.add_op_create_pool('pool3', group='test')
+        rq.add_op_request_access_to_group(name='test')
         rq.add_op_request_access_to_group(name='test')
         rq.add_op_request_access_to_group(name='objects',
                                           key_name='test')


### PR DESCRIPTION
If an op already exists in a CephBrokerRq then there is no
reason to add it again.