### PR TITLE
Update the policyd docstrings due to charm changes

### DIFF
--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -115,8 +115,8 @@ library for further details).
     default: False
     description: |
       If True then use the resource file named 'policyd-override' to install
-      override yaml files in the service's policy.d directory.  The resource
-      file should be a zip file containing at least one yaml file with a .yaml
+      override YAML files in the service's policy.d directory.  The resource
+      file should be a ZIP file containing at least one yaml file with a .yaml
       or .yml extension.  If False then remove the overrides.
 """
 
@@ -134,14 +134,14 @@ resources:
 Policy Overrides
 ----------------
 
-This service allows for policy overrides using the `policy.d` directory.  This
-is an **advanced** feature and the policies that the service supports should be
-clearly and unambiguously understood before trying to override, or add to, the
-default policies that the service uses.
+This feature allows for policy overrides using the `policy.d` directory.  This
+is an **advanced** feature and the policies that the OpenStack service supports
+should be clearly and unambiguously understood before trying to override, or
+add to, the default policies that the service uses.  The charm also has some
+policy defaults.  They should also be understood before being overridden.
 
-The charm also has some policy defaults.  They should also be understood before
-being overridden.  It is possible to break the system (for tenants and other
-services) if policies are incorrectly applied to the service.
+> **Caution**: It is possible to break the system (for tenants and other
+  services) if policies are incorrectly applied to the service.
 
 Policy overrides are YAML files that contain rules that will add to, or
 override, existing policy rules in the service.  The `policy.d` directory is
@@ -149,30 +149,16 @@ a place to put the YAML override files.  This charm owns the
 `/etc/keystone/policy.d` directory, and as such, any manual changes to it will
 be overwritten on charm upgrades.
 
-Policy overrides are provided to the charm using a resource file called
-`policyd-override`.  This is attached to the charm using (for example):
+Overrides are provided to the charm using a Juju resource called
+`policyd-override`.  The resource is a ZIP file.  This file, say
+`overrides.zip`, is attached to the charm by:
 
-    juju attach-resource <charm-name> policyd-override=<some-file>
 
-The `<charm-name>` is the name that this charm is deployed as, with
-`<some-file>` being the resource file containing the policy overrides.
+    juju attach-resource <charm-name> policyd-override=overrides.zip
 
-The format of the resource file is a ZIP file (.zip extension) containing at
-least one YAML file with an extension of `.yaml` or `.yml`.  Note that any
-directories in the ZIP file are ignored; all of the files are flattened into a
-single directory.  There must not be any duplicated filenames; this will cause
-an error and nothing in the resource file will be applied.
+The policy override is enabled in the charm using:
 
-(ed. next part is optional is the charm supports some form of
-template/substitution on a read file)
-
-If a (ed. "one or more of") [`.j2`, `.tmpl`, `.tpl`] file is found in the
-resource file then the charm will perform a substitution with charm variables
-taken from the config or relations.  (ed. edit as appropriate to include the
-variable).
-
-To enable the policy overrides the config option `use-policyd-override` must be
-set to `True`.
+    juju config <charm-name> use-policyd-override=true
 
 When `use-policyd-override` is `True` the status line of the charm will be
 prefixed with `PO:` indicating that policies have been overridden.  If the
@@ -180,12 +166,8 @@ installation of the policy override YAML files failed for any reason then the
 status line will be prefixed with `PO (broken):`.  The log file for the charm
 will indicate the reason.  No policy override files are installed if the `PO
 (broken):` is shown.  The status line indicates that the overrides are broken,
-not that the policy for the service has failed - they will be the defaults for
-the charm and service.
-
-If the policy overrides did not install then *either* attach a new, corrected,
-resource file *or* disable the policy overrides by setting
-`use-policyd-override` to False.
+not that the policy for the service has failed. The policy will be the defaults
+for the charm and service.
 
 Policy overrides on one service may affect the functionality of another
 service. Therefore, it may be necessary to provide policy overrides for


### PR DESCRIPTION
When the charms' README and config.yaml files were reviewed some
changes were introduced.  This PR simply updates the equivalent
docstrings in the policyd module.