### PR TITLE
Fix the py35 issue with json not accepting bytestrings

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -422,6 +422,8 @@ def enabled_manager_modules():
     cmd = ['ceph', 'mgr', 'module', 'ls']
     try:
         modules = check_output(cmd)
+        if six.PY3:
+            modules = modules.decode('UTF-8')
     except CalledProcessError as e:
         log("Failed to list ceph modules: {}".format(e), WARNING)
         return []

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -178,7 +178,7 @@ class CephBasicUtilsTests(TestCase):
         setattr(self, method, mock)
 
     def test_enabled_manager_modules(self):
-        self.check_output.return_value = '{"enabled_modules": []}'
+        self.check_output.return_value = b'{"enabled_modules": []}'
         ceph_utils.enabled_manager_modules()
         self.check_output.assert_called_once_with(['ceph', 'mgr', 'module', 'ls'])
 


### PR DESCRIPTION
So Python 3.6+ is magic, in that it will accept any str type
(str or bytes) in the json.loads() method.  Unfortunately, xenial
(py35) doesn't have this feature.  This patch correctly handles the
check_output output for the enabled_manager_modules() function.