### PR TITLE
Update swift versions for train

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -204,7 +204,7 @@ SWIFT_CODENAMES = OrderedDict([
     ('stein',
         ['2.20.0', '2.21.0']),
     ('train',
-        ['2.22.0']),
+        ['2.22.0', '2.23.0']),
 ])
 
 # >= Liberty version->codename mapping


### PR DESCRIPTION
Add 2.23.0 to the list of versions for Swift for OpenStack
Train.