### PR TITLE
Add section-placement

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-placement
+++ b/charmhelpers/contrib/openstack/templates/section-placement
@@ -1,0 +1,19 @@
+[placement]
+{% if auth_host -%}
+auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
+auth_type = password
+{% if api_version == "3" -%}
+project_domain_name = {{ admin_domain_name }}
+user_domain_name = {{ admin_domain_name }}
+{% else -%}
+project_domain_name = default
+user_domain_name = default
+{% endif -%}
+project_name = {{ admin_tenant_name }}
+username = {{ admin_user }}
+password = {{ admin_password }}
+{% endif -%}
+{% if region -%}
+os_region_name = {{ region }}
+{% endif -%}
+randomize_allocation_candidates = true


### PR DESCRIPTION
The placement config may be useful among more than one charm as
more services start to use it. This patch moves the sectional
config that is currently in charm-nova-cloud-controller to a
single source in charm-helpers.

See related bug:
https://bugs.launchpad.net/charm-nova-cell-controller/+bug/1850691