### PR TITLE
Duplicate resource retry fix from reactive

### DIFF
--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -157,10 +157,11 @@ def generate_ha_relation_data(service,
     _relation_data = {'resources': {}, 'resource_params': {}}
 
     if haproxy_enabled:
+        _meta = 'meta migration-threshold="INFINITY" failure-timeout="5s"'
         _haproxy_res = 'res_{}_haproxy'.format(service)
         _relation_data['resources'] = {_haproxy_res: 'lsb:haproxy'}
         _relation_data['resource_params'] = {
-            _haproxy_res: 'op monitor interval="5s"'
+            _haproxy_res: '{} op monitor interval="5s"'.format(_meta)
         }
         _relation_data['init_services'] = {_haproxy_res: 'haproxy'}
         _relation_data['clones'] = {

--- a/tests/contrib/openstack/ha/test_ha_utils.py
+++ b/tests/contrib/openstack/ha/test_ha_utils.py
@@ -360,7 +360,9 @@ class HATests(unittest.TestCase):
                 'res_testservice_f563c5d_vip':
                     ('params ipv6addr="ffaa::1" op monitor '
                      'timeout="20s" interval="10s" depth="0"'),
-                'res_testservice_haproxy': 'op monitor interval="5s"',
+                'res_testservice_haproxy':
+                    ('meta migration-threshold="INFINITY" failure-timeout="5s" '
+                     'op monitor interval="5s"'),
             },
             'resources': {
                 'res_testservice_242d562_vip': 'ocf:heartbeat:IPaddr2',
@@ -418,7 +420,9 @@ class HATests(unittest.TestCase):
                     'params fqdn="test.internal.maas" ip_address="10.0.0.1"',
                 'res_testservice_public_hostname':
                     'params fqdn="test.public.maas" ip_address="10.0.0.1"',
-                'res_testservice_haproxy': 'op monitor interval="5s"',
+                'res_testservice_haproxy':
+                    ('meta migration-threshold="INFINITY" failure-timeout="5s" '
+                     'op monitor interval="5s"'),
             },
             'resources': {
                 'res_testservice_admin_hostname': 'ocf:maas:dns',


### PR DESCRIPTION
A fix landed in the reactive charms to configure pacemaker to
always retry the haproxy resource otherwise if the resource
fails during setup it is marked permanently down.

*1 https://github.com/openstack/charm-interface-hacluster/blob/master/common.py#L602