### PR TITLE
Use juju ssh for get_ubuntu_release_from_sentry

### DIFF
--- a/charmhelpers/contrib/amulet/utils.py
+++ b/charmhelpers/contrib/amulet/utils.py
@@ -88,7 +88,7 @@ class AmuletUtils(object):
         """
         msg = None
         cmd = 'lsb_release -cs'
-        release, code = sentry_unit.run(cmd)
+        release, code = sentry_unit.ssh(cmd)
         if code == 0:
             self.log.debug('{} lsb_release: {}'.format(
                 sentry_unit.info['unit_name'], release))

--- a/tests/contrib/amulet/test_utils.py
+++ b/tests/contrib/amulet/test_utils.py
@@ -40,6 +40,9 @@ class FakeSentry(object):
     def run(self, command):
         return self.commands[command]
 
+    def ssh(self, command):
+        return self.commands[command]
+
     def run_action(self, action, action_args=None):
         return 'action-id'
 


### PR DESCRIPTION
juju action does not return the output of the remote command to
stdout in juju 2.7. Switch to using juju ssh which does.