### PR TITLE
Update now-deprecated usage of platform.dist

### DIFF
--- a/charmhelpers/osplatform.py
+++ b/charmhelpers/osplatform.py
@@ -1,4 +1,5 @@
-import platform
+# -*- coding=utf-8 -*-
+import distro
 
 
 def get_platform():
@@ -8,18 +9,10 @@ def get_platform():
     will be returned (which is the name of the module).
     This string is used to decide which platform module should be imported.
     """
-    # linux_distribution is deprecated and will be removed in Python 3.7
-    # Warings *not* disabled, as we certainly need to fix this.
-    tuple_platform = platform.linux_distribution()
-    current_platform = tuple_platform[0]
-    if "Ubuntu" in current_platform:
+    distro_name = distro.name()
+    if distro_name.lower() in ("ubuntu", "debian"):
         return "ubuntu"
-    elif "CentOS" in current_platform:
-        return "centos"
-    elif "debian" in current_platform:
-        # Stock Python does not detect Ubuntu and instead returns debian.
-        # Or at least it does in some build environments like Travis CI
-        return "ubuntu"
-    else:
-        raise RuntimeError("This module is not supported on {}."
-                           .format(current_platform))
+    elif distro_name.lower() == "centos":
+        return distro_name.lower()
+    raise RuntimeError("This module is not supported on {}."
+                        .format(distro_name))


### PR DESCRIPTION
- Rely instead on `distro.name` which is also `python2.7` compatible
- `distro.name` does not return a tuple but instead only the name of the
  distro which seems to be what is needed
- Fixes #293

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>