### PR TITLE
Yum + LSB fix making package installation on CentOS possible

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -313,8 +313,17 @@ SYSTEMD_SYSTEM = '/run/systemd/system'
 
 def init_is_systemd():
     """Return True if the host system uses systemd, False otherwise."""
-    if lsb_release()['DISTRIB_CODENAME'] == 'trusty':
-        return False
+
+    if __platform__ == "centos":
+        # CentOS/RHEL 7 is the first version with systemd, identified by
+        # VERSION_ID="7" in /etc/os-release, or "8" for CentOS/RHEL 8. 
+        # /etc/os-release does not exist on CentOS 6 and below, thus:
+        if not os.path.isfile('/etc/os-release'):
+            return False
+    else:
+        if lsb_release()['DISTRIB_CODENAME'] == 'trusty':
+            return False
+
     return os.path.isdir(SYSTEMD_SYSTEM)
 
 

--- a/charmhelpers/fetch/__init__.py
+++ b/charmhelpers/fetch/__init__.py
@@ -84,11 +84,6 @@ module = "charmhelpers.fetch.%s" % __platform__
 fetch = importlib.import_module(module)
 
 filter_installed_packages = fetch.filter_installed_packages
-filter_missing_packages = fetch.filter_missing_packages
-install = fetch.apt_install
-upgrade = fetch.apt_upgrade
-update = _fetch_update = fetch.apt_update
-purge = fetch.apt_purge
 add_source = fetch.add_source
 
 if __platform__ == "ubuntu":
@@ -103,10 +98,19 @@ if __platform__ == "ubuntu":
     apt_unhold = fetch.apt_unhold
     import_key = fetch.import_key
     get_upstream_version = fetch.get_upstream_version
+    filter_missing_packages = fetch.filter_missing_packages
+    install = fetch.apt_install
+    upgrade = fetch.apt_upgrade
+    update = _fetch_update = fetch.apt_update
+    purge = fetch.apt_purge
     apt_pkg = fetch.ubuntu_apt_pkg
     get_apt_dpkg_env = fetch.get_apt_dpkg_env
 elif __platform__ == "centos":
     yum_search = fetch.yum_search
+    install = fetch.install
+    upgrade = fetch.upgrade
+    update = _fetch_update = fetch.update
+    purge = fetch.purge
 
 
 def configure_sources(update=False,


### PR DESCRIPTION
When using Python 3, package installation with fetch in charmhelpers does not work since the Python module "yum" is only available for Python2. Simple tasks like checking if packages are installed can easily be performed by RPM instead.

Furthermore, package installations on CentOS were previously carried out with apt (which fails), this has been fixed.

LSB: The variable DISTRIB_CODENAME used for checking if we're using a systemd system is not available in /etc/os-release on CentOS, which throws a KeyError. This information is available in /etc/os-release from CentOS/RHEL 7 and above, which also use systemd.