### PR TITLE
openstack: add notification_topics option

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -730,6 +730,10 @@ class AMQPContext(OSContextGenerator):
         if notification_format:
             ctxt['notification_format'] = notification_format
 
+        notification_topics = conf.get('notification-topics', None)
+        if notification_topics:
+            ctxt['notification_topics'] = notification_topics
+
         send_notifications_to_logs = conf.get('send-notifications-to-logs', None)
         if send_notifications_to_logs:
             ctxt['send_notifications_to_logs'] = send_notifications_to_logs

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -278,6 +278,10 @@ AMQP_NOTIFICATION_FORMAT = {
     'notification-format': 'both'
 }
 
+AMQP_NOTIFICATION_TOPICS = {
+    'notification-topics': 'foo,bar'
+}
+
 AMQP_NOTIFICATIONS_LOGS = {
     'send-notifications-to-logs': True
 }
@@ -1468,6 +1472,26 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_user': 'adam',
             'rabbitmq_virtual_host': 'foo',
             'notification_format': 'both',
+            'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
+        }
+
+        self.assertEquals(result, expected)
+
+    def test_amqp_context_with_notification_topics(self):
+        """Test amqp context with notification_topics option"""
+        relation = FakeRelation(relation_data=AMQP_RELATION)
+        self.relation_get.side_effect = relation.get
+        AMQP_NOTIFICATION_TOPICS.update(AMQP_CONFIG)
+        self.config.return_value = AMQP_NOTIFICATION_TOPICS
+        amqp = context.AMQPContext()
+        result = amqp()
+        expected = {
+            'oslo_messaging_driver': 'messagingv2',
+            'rabbitmq_host': 'rabbithost',
+            'rabbitmq_password': 'foobar',
+            'rabbitmq_user': 'adam',
+            'rabbitmq_virtual_host': 'foo',
+            'notification_topics': 'foo,bar',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 


### PR DESCRIPTION
This new option introduced will give to the charms ability to set
oslo notification topics.

Signed-off-by: Stamatis Katsaounis <katsaouniss@gmail.com>