### PR TITLE
Make linter happy

### DIFF
--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -307,9 +307,9 @@ def maybe_do_policyd_overrides(openstack_release,
                                   blacklist_paths,
                                   user=_user,
                                   group=_group)
-            if (os.path.isfile(_policy_success_file())
-                    and restart_handler is not None
-                    and callable(restart_handler)):
+            if (os.path.isfile(_policy_success_file()) and
+                    restart_handler is not None and
+                    callable(restart_handler)):
                 restart_handler()
             remove_policy_success_file()
             return

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -674,7 +674,7 @@ def openstack_upgrade_available(package):
     else:
         try:
             avail_vers = get_os_version_install_source(src)
-        except:
+        except Exception:
             avail_vers = cur_vers
     apt.init()
     return apt.version_compare(avail_vers, cur_vers) >= 1


### PR DESCRIPTION
Without this, you get the following errors:

```
$ lxc launch ubuntu-daily:bionic mycontainer
$ lxc exec mycontainer bash
# apt update && apt install make sudo git gcc virtualenv zip snapd
# snap install juju --classic
# git clone https://github.com/juju/charm-helpers
# cd charm-helpers/
# make lint
Checking for Python syntax...
charmhelpers/contrib/openstack/policyd.py:311:21: W503 line break before binary operator
charmhelpers/contrib/openstack/policyd.py:312:21: W503 line break before binary operator
charmhelpers/contrib/openstack/utils.py:677:9: E722 do not use bare 'except'
Makefile:72: recipe for target 'lint' failed
```