### PR TITLE
Add missing sphinx dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ docs:
 	- [ -z "`dpkg -l | grep python-sphinx`" ] && sudo apt-get install python-sphinx -y
 	- [ -z "`dpkg -l | grep python-pip`" ] && sudo apt-get install python-pip -y
 	- [ -z "`pip list | grep -i sphinx-pypi-upload`" ] && sudo pip install sphinx-pypi-upload
+	- [ -z "`pip list | grep -i sphinx_rtd_theme`" ] && sudo pip install sphinx_rtd_theme
 	cd docs && make html && cd -
 .PHONY: docs
 


### PR DESCRIPTION
Without this fix:

```
$ make docs
...
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.7
making output directory...
loading pickled environment... not yet created

Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)
...
```