### PR TITLE
HostInfoContext: Fix retrieval of a hosts primary FQDN

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2181,9 +2181,64 @@ class LogrotateContext(OSContextGenerator):
 class HostInfoContext(OSContextGenerator):
     """Context to provide host information."""
 
+    def _get_use_fqdn_hint(self):
+        """Get hint from local unit KV store for whether FQDN should be used
+
+        Depending on the workload a charm manages, the use of FQDN vs.
+        shortname may be a deploy-time decision, i.e. behavour can not change
+        on post deploy charm upgrade or configuration change.
+
+        The hint is passed on as a flag in the context to allow the decision to
+        be made in the Jinja2 configuration template.
+
+        :returns: True or False
+        :rtype: bool
+        """
+        db = kv()
+        return db.get('openstack-hostinfocontext-use-fqdn-hint', False)
+
+    def _get_canonical_name(self, name=None):
+        """Get the official FQDN of the host
+
+        The implementation of ``socket.getfqdn()`` in the standard Python
+        library does not exhaust all methods of getting the official name
+        of a host ref Python issue https://bugs.python.org/issue5004
+
+        This function mimics the behaviour of a call to ``hostname -f`` to
+        get the official FQDN but returns an empty string if it is
+        unsuccessful.
+
+        :param name: Shortname to get FQDN on
+        :type name: Optional[str]
+        :returns: The official FQDN for host or empty string ('')
+        :rtype: str
+        """
+        name = name or socket.gethostname()
+        fqdn = ''
+
+        if six.PY2:
+            exc = socket.error
+        else:
+            exc = OSError
+
+        try:
+            addrs = socket.getaddrinfo(
+                name, None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME)
+        except exc:
+            pass
+        else:
+            for addr in addrs:
+                if addr[3]:
+                    if '.' in addr[3]:
+                        fqdn = addr[3]
+                    break
+        return fqdn
+
     def __call__(self):
+        name = socket.gethostname()
         ctxt = {
-            'host_fqdn': socket.getfqdn(),
-            'host': socket.gethostname(),
+            'host_fqdn': self._get_canonical_name(name) or name,
+            'host': name,
+            'use_fqdn_hint': self._get_use_fqdn_hint(),
         }
         return ctxt

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1,8 +1,8 @@
-import collections
 import charmhelpers.contrib.openstack.context as context
-import yaml
+import collections
 import json
 import unittest
+import yaml
 from copy import copy, deepcopy
 from mock import (
     patch,
@@ -3983,10 +3983,42 @@ class ContextTests(unittest.TestCase):
 
     @patch.object(context, 'socket')
     def test_host_info_context(self, _socket):
-        _socket.getfqdn.return_value = 'myhost.mydomain'
+        _socket.getaddrinfo.return_value = [(None, None, None, 'myhost.mydomain', None)]
         _socket.gethostname.return_value = 'myhost'
         ctxt = context.HostInfoContext()()
         self.assertEqual({
             'host_fqdn': 'myhost.mydomain',
-            'host': 'myhost'},
+            'host': 'myhost',
+            'use_fqdn_hint': False},
+            ctxt)
+        kv = MagicMock()
+        kv().get.return_value = True
+        self.kv.side_effect = kv
+        ctxt = context.HostInfoContext()()
+        self.assertEqual({
+            'host_fqdn': 'myhost.mydomain',
+            'host': 'myhost',
+            'use_fqdn_hint': True},
+            ctxt)
+        self.kv.side_effect = TestDB
+        # if getaddrinfo is unable to find the canonical name we should return
+        # the shortname to match the behaviour of the original implementation.
+        _socket.getaddrinfo.return_value = [(None, None, None, 'localhost', None)]
+        ctxt = context.HostInfoContext()()
+        self.assertEqual({
+            'host_fqdn': 'myhost',
+            'host': 'myhost',
+            'use_fqdn_hint': False},
+            ctxt)
+        if six.PY2:
+            _socket.error = Exception
+            _socket.getaddrinfo.side_effect = Exception
+        else:
+            _socket.getaddrinfo.side_effect = OSError
+        _socket.gethostname.return_value = 'myhost'
+        ctxt = context.HostInfoContext()()
+        self.assertEqual({
+            'host_fqdn': 'myhost',
+            'host': 'myhost',
+            'use_fqdn_hint': False},
             ctxt)

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3991,16 +3991,12 @@ class ContextTests(unittest.TestCase):
             'host': 'myhost',
             'use_fqdn_hint': False},
             ctxt)
-        kv = MagicMock()
-        kv().get.return_value = True
-        self.kv.side_effect = kv
-        ctxt = context.HostInfoContext()()
+        ctxt = context.HostInfoContext(use_fqdn_hint_cb=lambda: True)()
         self.assertEqual({
             'host_fqdn': 'myhost.mydomain',
             'host': 'myhost',
             'use_fqdn_hint': True},
             ctxt)
-        self.kv.side_effect = TestDB
         # if getaddrinfo is unable to find the canonical name we should return
         # the shortname to match the behaviour of the original implementation.
         _socket.getaddrinfo.return_value = [(None, None, None, 'localhost', None)]


### PR DESCRIPTION
The implementation of ``socket.getfqdn()`` in the standard Python
library does not exhaust all methods of getting the official name
of a host ref Python issue https://bugs.python.org/issue5004