### PR TITLE
Fix apt hardening module

### DIFF
--- a/charmhelpers/contrib/hardening/audits/apt.py
+++ b/charmhelpers/contrib/hardening/audits/apt.py
@@ -52,7 +52,7 @@ class RestrictedPackages(BaseAudit):
     def __init__(self, pkgs, **kwargs):
         super(RestrictedPackages, self).__init__(**kwargs)
         if isinstance(pkgs, string_types) or not hasattr(pkgs, '__iter__'):
-            self.pkgs = [pkgs]
+            self.pkgs = pkgs.split()
         else:
             self.pkgs = pkgs
 
@@ -100,4 +100,5 @@ class RestrictedPackages(BaseAudit):
             apt_purge(pkg.name)
 
     def is_virtual_package(self, pkg):
-        return pkg.has_provides and not pkg.has_versions
+        return (pkg.get('has_provides', False) and
+                not pkg.get('has_versions', False))

--- a/tests/contrib/hardening/audits/test_apt_audits.py
+++ b/tests/contrib/hardening/audits/test_apt_audits.py
@@ -19,6 +19,8 @@ from mock import MagicMock
 from mock import patch
 
 from charmhelpers.contrib.hardening.audits import apt
+from charmhelpers.fetch import ubuntu_apt_pkg as apt_pkg
+from charmhelpers.core import hookenv
 
 
 class RestrictedPackagesTestCase(TestCase):
@@ -75,3 +77,11 @@ class AptConfigTestCase(TestCase):
                                 'expected': 'false'}])
         audit.ensure_compliance()
         self.assertTrue(mock_apt_pkg.config.get.called)
+
+    @patch.object(hookenv, 'log')
+    def test_verify_config(self, mock_log):
+        cfg = apt_pkg.config
+        key, value = list(cfg.items())[0]
+        audit = apt.AptConfig([{"key": key, "expected": value}])
+        audit.ensure_compliance()
+        self.assertFalse(mock_log.called)

--- a/tests/contrib/hardening/audits/test_apt_audits.py
+++ b/tests/contrib/hardening/audits/test_apt_audits.py
@@ -33,8 +33,11 @@ class RestrictedPackagesTestCase(TestCase):
             pkgver = MagicMock()
             pkgver.parent_pkg = self.create_package('foo')
             pkg.provides_list = [('virtualfoo', None, pkgver)]
-            pkg.has_provides = True
-            pkg.has_versions = False
+            resp = {
+                'has_provides': True,
+                'has_versions': False,
+            }
+            pkg.get.side_effect = resp.get
 
         return pkg
 


### PR DESCRIPTION
Commit d2ea1b8 replaced the original apt_pkg module with a custom
implementation. This new implementation, however, has a few differences
with how the original module handled some of its calls. It is also
missing the 'config' submodule which is needed by the apt hardening
modules.

This commit implements the 'config' functionality and fixes the
compatibility issues with this new implementation.

Related-Bug: #1857258