### PR TITLE
Add is_db_initialised & set_db_initialised helpers

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1884,16 +1884,17 @@ def is_db_initialised():
     db_initialised = None
     if leader_get('db-initialised') is None:
         juju_log(
-            '"db-initialised key missing, assuming db is not initialised',
+            'db-initialised key missing, assuming db is not initialised',
             'DEBUG')
         db_initialised = False
     else:
         db_initialised = bool_from_string(leader_get('db-initialised'))
-    juju_log("Database initialised: {}".format(db_initialised), 'DEBUG')
+    juju_log('Database initialised: {}'.format(db_initialised), 'DEBUG')
     return db_initialised
 
 
 def set_db_initialised():
     """Add flag to leader storage to indicate database has been initialised.
     """
+    juju_log('Setting db-initialised to True', 'DEBUG')
     leader_set({'db-initialised': True})

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -50,9 +50,14 @@ from charmhelpers.core.hookenv import (
     hook_name,
     application_version_set,
     cached,
+    leader_set,
+    leader_get,
 )
 
-from charmhelpers.core.strutils import BasicStringComparator
+from charmhelpers.core.strutils import (
+    BasicStringComparator,
+    bool_from_string,
+)
 
 from charmhelpers.contrib.storage.linux.lvm import (
     deactivate_lvm_volume_group,
@@ -1868,3 +1873,27 @@ def series_upgrade_complete(resume_unit_helper=None, configs=None):
         configs.write_all()
         if resume_unit_helper:
             resume_unit_helper(configs)
+
+
+def is_db_initialised():
+    """Check leader storage to see if database has been initialised.
+
+    :returns: Whether DB has been initialised
+    :rtype: bool
+    """
+    db_initialised = None
+    if leader_get('db-initialised') is None:
+        juju_log(
+            '"db-initialised key missing, assuming db is not initialised',
+            'DEBUG')
+        db_initialised = False
+    else:
+        db_initialised = bool_from_string(leader_get('db-initialised'))
+    juju_log("Database initialised: {}".format(db_initialised), 'DEBUG')
+    return db_initialised
+
+
+def set_db_initialised():
+    """Add flag to leader storage to indicate database has been initialised.
+    """
+    leader_set({'db-initialised': True})

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1857,6 +1857,22 @@ class OpenStackHelpersTestCase(TestCase):
         fake_configs.write_all.assert_called_once()
         fake_resume_helper.assert_called_once_with(fake_configs)
 
+    @patch.object(openstack, 'juju_log')
+    @patch.object(openstack, 'leader_get')
+    def test_is_db_initialised(self, leader_get, juju_log):
+        leader_get.return_value = 'True'
+        self.assertTrue(openstack.is_db_initialised())
+        leader_get.return_value = 'False'
+        self.assertFalse(openstack.is_db_initialised())
+        leader_get.return_value = None
+        self.assertFalse(openstack.is_db_initialised())
+
+    @patch.object(openstack, 'juju_log')
+    @patch.object(openstack, 'leader_set')
+    def test_set_db_initialised(self, leader_set, juju_log):
+        openstack.set_db_initialised()
+        leader_set.assert_called_once_with({'db-initialised': True})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add is_db_initialised and set_db_initialised for use by Openstack
charms to track if a charms database has been initialised.