### PR TITLE
Add get_managed_services_and_ports

### DIFF
--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -25,6 +25,7 @@ Helpers for clustering and determining "cluster leadership" and other
 clustering-related helpers.
 """
 
+import functools
 import subprocess
 import os
 import time
@@ -281,6 +282,10 @@ def determine_apache_port(public_port, singlenode_mode=False):
     return public_port - (i * 10)
 
 
+determine_apache_port_single = functools.partial(
+    determine_apache_port, singlenode_mode=True)
+
+
 def get_hacluster_config(exclude_keys=None):
     '''
     Obtains all relevant configuration from charm configuration required
@@ -404,3 +409,43 @@ def distributed_wait(modulo=None, wait=None, operation_name='operation'):
     log(msg, DEBUG)
     status_set('maintenance', msg)
     time.sleep(calculated_wait)
+
+
+def get_managed_services_and_ports(services, external_ports,
+                                   external_services=None,
+                                   port_conv_f=determine_apache_port_single):
+    """Get the services and ports managed by this charm.
+
+    Return only the services and corresponding ports that are managed by this
+    charm. This excludes haproxy when there is a relation with hacluster. This
+    is because this charm passes responsability for stopping and starting
+    haproxy to hacluster.
+
+    Similarly, if a relation with hacluster exists then the ports returned by
+    this method correspond to those managed by the apache server rather than
+    haproxy.
+
+    :param services: List of services.
+    :type services: List[str]
+    :param external_ports: List of ports managed by external services.
+    :type external_ports: List[int]
+    :param external_services: List of services to be removed if ha relation is
+                              present.
+    :type external_services: List[str]
+    :param port_conv_f: Function to apply to ports to calculate the ports
+                        managed by services controlled by this charm.
+    :type port_convert_func: f()
+    :returns: A tuple containing a list of services first followed by a list of
+              ports.
+    :rtype: Tuple[List[str], List[int]]
+    """
+    if external_services is None:
+        external_services = ['haproxy']
+    if relation_ids('ha'):
+        for svc in external_services:
+            try:
+                services.remove(svc)
+            except ValueError:
+                pass
+        external_ports = [port_conv_f(p) for p in external_ports]
+    return services, external_ports

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -563,3 +563,28 @@ class ClusterUtilsTests(TestCase):
         cluster_utils.distributed_wait(modulo=5, wait=45)
         modulo_distribution.assert_called_with(modulo=5, wait=45,
                                                non_zero_wait=True)
+
+    @patch.object(cluster_utils, 'relation_ids')
+    def test_get_managed_services_and_ports(self, relation_ids):
+        relation_ids.return_value = ['rel:2']
+        self.assertEqual(
+            cluster_utils.get_managed_services_and_ports(
+                ['apache2', 'haproxy'],
+                [8067, 4545, 6732]),
+            (['apache2'], [8057, 4535, 6722]))
+        self.assertEqual(
+            cluster_utils.get_managed_services_and_ports(
+                ['apache2', 'haproxy'],
+                [8067, 4545, 6732],
+                external_services=['apache2']),
+            (['haproxy'], [8057, 4535, 6722]))
+
+        def add_ten(x):
+            return x + 10
+
+        self.assertEqual(
+            cluster_utils.get_managed_services_and_ports(
+                ['apache2', 'haproxy'],
+                [8067, 4545, 6732],
+                port_conv_f=add_ten),
+            (['apache2'], [8077, 4555, 6742]))


### PR DESCRIPTION
Add get_managed_services_and_ports. This is generalised version of
the keystone specific method that recently landed *1. Adding
a generalised version to reduce duplicate code when rolling out
across the OpenStack API charms.

*1 https://review.opendev.org/#/c/703655/3/hooks/keystone_utils.py