### PR TITLE
Add the EXECUTE grant for mysql router users

### DIFF
--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -723,7 +723,7 @@ class MySQL8Helper(MySQLHelper):
         try:
             cursor.execute("GRANT CREATE USER ON *.* TO '{}'@'{}' WITH GRANT "
                            "OPTION".format(db_user, remote_ip))
-            cursor.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON "
+            cursor.execute("GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON "
                            "mysql_innodb_cluster_metadata.* TO '{}'@'{}'"
                            .format(db_user, remote_ip))
             cursor.execute("GRANT SELECT ON mysql.user TO '{}'@'{}'"

--- a/tests/contrib/database/test_mysql.py
+++ b/tests/contrib/database/test_mysql.py
@@ -810,7 +810,7 @@ class Mysql8Tests(unittest.TestCase):
         _calls = [
             mock.call("GRANT CREATE USER ON *.* TO '{}'@'{}' WITH GRANT OPTION"
                       .format(self.user, self.host)),
-            mock.call("GRANT SELECT, INSERT, UPDATE, DELETE ON "
+            mock.call("GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON "
                       "mysql_innodb_cluster_metadata.* TO '{}'@'{}'"
                       .format(self.user, self.host)),
             mock.call("GRANT SELECT ON mysql.user TO '{}'@'{}'"


### PR DESCRIPTION
With mysql 8.0.19 it is necessary to add the EXECUTE grant on the
mysql_innodb_cluster_metadata table for mysqlrouter users to bootstrap.

Partial-bug: #1861234
