### PR TITLE
Ensure python3-hvac is installed for charms with encypt option

### DIFF
--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -37,7 +37,19 @@ class VaultKVContext(context.OSContextGenerator):
         )
 
     def __call__(self):
-        import hvac
+        try:
+            import hvac
+        except ImportError:
+            # BUG: #1862085 - if the relation is made to vault, but the
+            # 'encrypt' option is not made, then the charm errors with an
+            # import warning.  This catches that, logs a warning, and returns
+            # with an empty context.
+            hookenv.log("VaultKVContext: trying to use hvac pythong module "
+                        "but it's not available.  Is secrets-stroage relation "
+                        "made, but encrypt option not set?",
+                        level=hookenv.WARNING)
+            # return an emptry context on hvac import error
+            return {}
         ctxt = {}
         # NOTE(hopem): see https://bugs.launchpad.net/charm-helpers/+bug/1849323
         db = unitdata.kv()


### PR DESCRIPTION
The referenced bug is essentially: make vault:secrets relation to vault
but keep the 'encrypt' option as False. In this case, the Context
handling code in charm-helpers is expecting python3-hvac to be
available, but it is only installed if the encrypt option is set to
True.  Hence the charm crashes.  This resolves that crash.

The VautlKVContext()() returns {} if the hvac module isn't isntalled,
which essentially deactivates it.

Closes-bug: #1862085