### PR TITLE
Unpinning Jinja2 and PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,13 @@
 # Runtime Dependencies
-# Specify precise versions of runtime dependencies where possible.
 
 # https://pyyaml.org/wiki/PyYAML#history
 # PyYAML==5.2 is last supported for py34
-PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-PyYAML;     python_version == '2.7' or python_version >= '3.5'  # all else
+PyYAML
 
 # https://jinja.palletsprojects.com/en/2.11.x/changelog/
-# Jinja2==2.10 is last supported for py34
-# Jinja2==2.11 is last supported for py27 & py35
-Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
-Jinja2;      python_version >= '3.6'                             # py36 and on
+# Jinja2==2.10 is last supported for py34 (trusty)
+# Jinja2==2.11 is last supported for py27 & py35 (xenial)
+Jinja2
 
 six
 netaddr

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,6 +12,25 @@ distro-info
 sphinx_rtd_theme
 ipaddress;python_version<'3.0'  # Py27 unit test requirement
 
+
+##########################################################
+# Specify versions of runtime dependencies where possible.
+# The requirements.txt file cannot be so specific
+
+# https://pyyaml.org/wiki/PyYAML#history
+# PyYAML==5.2 is last supported for py34
+PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
+PyYAML;     python_version == '2.7' or python_version >= '3.5'  # all else
+
+# https://jinja.palletsprojects.com/en/2.11.x/changelog/
+# Jinja2==2.10 is last supported for py34
+# Jinja2==2.11 is last supported for py27 & py35
+Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
+Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
+Jinja2;      python_version >= '3.6'                             # py36 and on
+
+##############################################################
+
 -r./requirements.txt
 
 netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -31,8 +31,6 @@ Jinja2;      python_version >= '3.6'                             # py36 and on
 
 ##############################################################
 
--r./requirements.txt
-
 netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.
 psutil==1.2.1      # trusty
 python-keystoneclient==2.3.2 # xenial


### PR DESCRIPTION
In an attempt to address https://github.com/juju-solutions/layer-basic/issues/155 and https://github.com/juju/charm-helpers/issues/433, remove specific version pinning of Jinja2 and PyYAML