### PR TITLE
_locate_cmd: use shlex.join to retain word boundaries in nrpe check commands

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -173,7 +173,7 @@ define service {{
             if os.path.exists(os.path.join(path, parts[0])):
                 command = os.path.join(path, parts[0])
                 if len(parts) > 1:
-                    command += " " + " ".join(parts[1:])
+                    command += " " + shlex.join(parts[1:])
                 return command
         log('Check command not found: {}'.format(parts[0]))
         return ''


### PR DESCRIPTION
Addresses https://github.com/juju/charm-helpers/issues/408 and https://bugs.launchpad.net/charm-helpers/+bug/1706265