### PR TITLE
add helpers for log with levels

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -121,6 +121,30 @@ def log(message, level=None):
             raise
 
 
+def log_trace(message):
+    return log(message, level=TRACE)
+
+
+def log_debug(message):
+    return log(message, level=DEBUG)
+
+
+def log_info(message):
+    return log(message, level=INFO)
+
+
+def log_warning(message):
+    return log(message, level=WARNING)
+
+
+def log_error(message):
+    return log(message, level=ERROR)
+
+
+def log_critical(message):
+    return log(message, level=CRITICAL)
+
+
 def function_log(message):
     """Write a function progress message"""
     command = ['function-log']


### PR DESCRIPTION
currently to write an error log with charmhelpers.hookenv:

    hookenv.log('this is an error!', level=hookenv.ERROR)

The `level` arg is a bit overwhelmed for user.
Thus, it ends up ignored normally, and defaults to INFO even it's an ERROR in a lot of charms.

Add simple helpers, so we can write a log with correct level without thinking.

Signed-off-by: Joe Guo <joe.guo@canonical.com>