### PR TITLE
openstack: Move bridge port interface mapping to charm helpers

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -185,7 +185,7 @@ def del_bridge(name):
 
 
 def add_bridge_port(name, port, promisc=False, ifdata=None, exclusive=False,
-                    linkup=True):
+                    linkup=True, portdata=None):
     """Add port to bridge and optionally set/update interface data for it
 
     :param name: Name of bridge to attach port to
@@ -219,15 +219,18 @@ def add_bridge_port(name, port, promisc=False, ifdata=None, exclusive=False,
     :type exclusive: bool
     :param linkup: Bring link up
     :type linkup: bool
+    :param portdata: Additional data to attach to port. Similar to ifdata.
+    :type portdata: Optional[Dict[str,Union[str,Dict[str,str]]]]
     :raises: subprocess.CalledProcessError
     """
     cmd = ['ovs-vsctl', '--']
     if not exclusive:
         cmd.append('--may-exist')
     cmd.extend(('add-port', name, port))
-    if ifdata:
-        for setcmd in _dict_to_vsctl_set(ifdata, 'Interface', port):
-            cmd.extend(setcmd)
+    for ovs_table, data in (('Interface', ifdata), ('Port', portdata)):
+        if data:
+            for setcmd in _dict_to_vsctl_set(data, ovs_table, port):
+                cmd.extend(setcmd)
 
     log('Adding port {} to bridge {}'.format(port, name))
     subprocess.check_call(cmd)

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -193,7 +193,8 @@ def add_bridge_port(name, port, promisc=False, ifdata=None, exclusive=False,
     :param port: Name of port as represented in netdev
     :type port: str
     :param promisc: Whether to set promiscuous mode on interface
-    :type promisc: bool
+                    True=on, False=off, None leave untouched
+    :type promisc: Optional[bool]
     :param ifdata: Additional data to attach to interface
         The keys in the ifdata dictionary map directly to column names in the
         OpenvSwitch Interface table as defined in DB-SCHEMA [0] referenced in
@@ -241,7 +242,7 @@ def add_bridge_port(name, port, promisc=False, ifdata=None, exclusive=False,
         subprocess.check_call(["ip", "link", "set", port, "up"])
     if promisc:
         subprocess.check_call(["ip", "link", "set", port, "promisc", "on"])
-    else:
+    elif promisc is False:
         subprocess.check_call(["ip", "link", "set", port, "promisc", "off"])
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,8 @@ import mock
 
 
 sys.modules['yum'] = mock.MagicMock()
+sys.modules['sriov_netplan_shim'] = mock.MagicMock()
+sys.modules['sriov_netplan_shim.pci'] = mock.MagicMock()
 with mock.patch('charmhelpers.deprecate') as ch_deprecate:
     def mock_deprecate(warning, date=None, log=None):
         def mock_wrap(f):

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -103,6 +103,17 @@ class TestOVS(test_utils.BaseTestCase):
             mock.call(['ip', 'link', 'set', 'eth1', 'up']),
             mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
         ])
+        self._dict_to_vsctl_set.reset_mock()
+        self.check_call.reset_mock()
+        ovs.add_bridge_port('test', 'eth1', portdata={'fakeportinput': None})
+        self._dict_to_vsctl_set.assert_called_once_with(
+            {'fakeportinput': None}, 'Port', 'eth1')
+        self.check_call.assert_has_calls([
+            mock.call(['ovs-vsctl', '--', '--may-exist', 'add-port',
+                       'test', 'eth1', '--', 'fakeextradata']),
+            mock.call(['ip', 'link', 'set', 'eth1', 'up']),
+            mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
+        ])
 
     def test_ovs_appctl(self):
         self.patch_object(ovs.subprocess, 'check_output')

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -85,6 +85,16 @@ class TestOVS(test_utils.BaseTestCase):
         self.assertTrue(self.log.call_count == 1)
 
         self.check_call.reset_mock()
+        self.log.reset_mock()
+        ovs.add_bridge_port('test', 'eth1', promisc=None)
+        self.check_call.assert_has_calls([
+            mock.call(['ovs-vsctl', '--', '--may-exist', 'add-port',
+                       'test', 'eth1']),
+            mock.call(['ip', 'link', 'set', 'eth1', 'up']),
+        ])
+        self.assertTrue(self.log.call_count == 1)
+
+        self.check_call.reset_mock()
         ovs.add_bridge_port('test', 'eth1', exclusive=True, linkup=False)
         self.check_call.assert_has_calls([
             mock.call(['ovs-vsctl', '--', 'add-port', 'test', 'eth1']),

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1,18 +1,24 @@
-import charmhelpers.contrib.openstack.context as context
 import collections
+import copy
 import json
+import mock
+import six
 import unittest
 import yaml
-from copy import copy, deepcopy
+
 from mock import (
     patch,
     Mock,
     MagicMock,
     call
 )
+
 from tests.helpers import patch_open
 
-import six
+import tests.utils
+
+import charmhelpers.contrib.openstack.context as context
+
 
 if not six.PY3:
     open_builtin = '__builtin__.open'
@@ -847,7 +853,7 @@ class ContextTests(unittest.TestCase):
     def test_shared_db_context_with_missing_relation(self, os_codename):
         '''Test shared-db context missing relation data'''
         os_codename.return_value = 'stein'
-        incomplete_relation = copy(SHARED_DB_RELATION)
+        incomplete_relation = copy.copy(SHARED_DB_RELATION)
         incomplete_relation['password'] = None
         relation = FakeRelation(relation_data=incomplete_relation)
         self.relation_get.side_effect = relation.get
@@ -858,7 +864,7 @@ class ContextTests(unittest.TestCase):
 
     def test_shared_db_context_with_missing_config(self):
         '''Test shared-db context missing relation data'''
-        incomplete_config = copy(SHARED_DB_CONFIG)
+        incomplete_config = copy.copy(SHARED_DB_CONFIG)
         del incomplete_config['database-user']
         self.config.side_effect = fake_config(incomplete_config)
         relation = FakeRelation(relation_data=SHARED_DB_RELATION)
@@ -944,7 +950,7 @@ class ContextTests(unittest.TestCase):
 
     def test_postgresql_db_context_with_missing_relation(self):
         '''Test postgresql-db context missing relation data'''
-        incomplete_relation = copy(POSTGRESQL_DB_RELATION)
+        incomplete_relation = copy.copy(POSTGRESQL_DB_RELATION)
         incomplete_relation['password'] = None
         relation = FakeRelation(relation_data=incomplete_relation)
         self.relation_get.side_effect = relation.get
@@ -955,7 +961,7 @@ class ContextTests(unittest.TestCase):
 
     def test_postgresql_db_context_with_missing_config(self):
         '''Test postgresql-db context missing relation data'''
-        incomplete_config = copy(POSTGRESQL_DB_CONFIG)
+        incomplete_config = copy.copy(POSTGRESQL_DB_CONFIG)
         del incomplete_config['database']
         self.config.side_effect = fake_config(incomplete_config)
         relation = FakeRelation(relation_data=POSTGRESQL_DB_RELATION)
@@ -1209,7 +1215,7 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'os_release', return_value='rocky')
     def test_identity_service_context_with_missing_relation(self, *args):
         '''Test shared-db context missing relation data'''
-        incomplete_relation = copy(IDENTITY_SERVICE_RELATION_UNSET)
+        incomplete_relation = copy.copy(IDENTITY_SERVICE_RELATION_UNSET)
         incomplete_relation['service_password'] = None
         relation = FakeRelation(relation_data=incomplete_relation)
         self.relation_get.side_effect = relation.get
@@ -1220,7 +1226,7 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'filter_installed_packages')
     @patch.object(context, 'os_release')
     def test_keystone_authtoken_www_authenticate_uri_stein_apiv3(self, mock_os_release, mock_filter_installed_packages):
-        relation_data = deepcopy(IDENTITY_SERVICE_RELATION_VERSIONED)
+        relation_data = copy.deepcopy(IDENTITY_SERVICE_RELATION_VERSIONED)
         relation = FakeRelation(relation_data=relation_data)
         self.relation_get.side_effect = relation.get
 
@@ -1348,7 +1354,7 @@ class ContextTests(unittest.TestCase):
 
     def test_amqp_context_with_data_clustered(self):
         '''Test amqp context with all required data with clustered rabbit'''
-        relation_data = copy(AMQP_RELATION)
+        relation_data = copy.copy(AMQP_RELATION)
         relation_data['clustered'] = 'yes'
         relation = FakeRelation(relation_data=relation_data)
         self.relation_get.side_effect = relation.get
@@ -1368,7 +1374,7 @@ class ContextTests(unittest.TestCase):
 
     def test_amqp_context_with_data_active_active(self):
         '''Test amqp context with required data with active/active rabbit'''
-        relation_data = copy(AMQP_AA_RELATION)
+        relation_data = copy.copy(AMQP_AA_RELATION)
         relation = FakeRelation(relation_data=relation_data)
         self.relation_get.side_effect = relation.get
         self.relation_ids.side_effect = relation.relation_ids
@@ -1390,7 +1396,7 @@ class ContextTests(unittest.TestCase):
 
     def test_amqp_context_with_missing_relation(self):
         '''Test amqp context missing relation data'''
-        incomplete_relation = copy(AMQP_RELATION)
+        incomplete_relation = copy.copy(AMQP_RELATION)
         incomplete_relation['password'] = ''
         relation = FakeRelation(relation_data=incomplete_relation)
         self.relation_get.side_effect = relation.get
@@ -1401,7 +1407,7 @@ class ContextTests(unittest.TestCase):
 
     def test_amqp_context_with_missing_config(self):
         '''Test amqp context missing relation data'''
-        incomplete_config = copy(AMQP_CONFIG)
+        incomplete_config = copy.copy(AMQP_CONFIG)
         del incomplete_config['rabbit-user']
         relation = FakeRelation(relation_data=AMQP_RELATION)
         self.relation_get.side_effect = relation.get
@@ -1412,7 +1418,7 @@ class ContextTests(unittest.TestCase):
     @patch('charmhelpers.contrib.openstack.context.format_ipv6_addr')
     def test_amqp_context_with_ipv6(self, format_ipv6_addr):
         '''Test amqp context with ipv6'''
-        relation_data = copy(AMQP_AA_RELATION)
+        relation_data = copy.copy(AMQP_AA_RELATION)
         relation = FakeRelation(relation_data=relation_data)
         self.relation_get.side_effect = relation.get
         self.relation_ids.side_effect = relation.relation_ids
@@ -1580,7 +1586,7 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'ensure_packages')
     def test_ceph_context_with_missing_data(self, ensure_packages, mkdir):
         '''Test ceph context with missing relation data'''
-        relation = deepcopy(CEPH_RELATION)
+        relation = copy.deepcopy(CEPH_RELATION)
         for k, v in six.iteritems(relation):
             for u in six.iterkeys(v):
                 del relation[k][u]['auth']
@@ -1605,7 +1611,7 @@ class ContextTests(unittest.TestCase):
            last unit was returned so if a valid value was supplied from an
            earlier unit it would be ignored'''
         config.side_effect = fake_config({'use-syslog': 'True'})
-        relation = deepcopy(CEPH_RELATION)
+        relation = copy.deepcopy(CEPH_RELATION)
         for k, v in six.iteritems(relation):
             last_unit = sorted(six.iterkeys(v))[-1]
             unit_data = relation[k][last_unit]
@@ -1901,7 +1907,7 @@ class ContextTests(unittest.TestCase):
             return config_dict.get(key)
 
         mock_config.side_effect = fake_config
-        relation = deepcopy(CEPH_RELATION_WITH_PUBLIC_ADDR)
+        relation = copy.deepcopy(CEPH_RELATION_WITH_PUBLIC_ADDR)
         del relation['ceph:0']['ceph/0']['ceph-public-address']
         relation = FakeRelation(relation_data=relation)
         self.relation_get.side_effect = relation.get
@@ -4239,3 +4245,305 @@ class ContextTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             ctx_object.parse_ovs_use_veth()
             _bool_from_string.assert_called_with("Invalid")
+
+
+class MockPCIDevice(object):
+    """Simple wrapper to mock pci.PCINetDevice class"""
+    def __init__(self, address):
+        self.pci_address = address
+
+
+TEST_CPULIST_1 = "0-3"
+TEST_CPULIST_2 = "0-7,16-23"
+TEST_CPULIST_3 = "0,4,8,12,16,20,24"
+DPDK_DATA_PORTS = (
+    "br-phynet3:fe:16:41:df:23:fe "
+    "br-phynet1:fe:16:41:df:23:fd "
+    "br-phynet2:fe:f2:d0:45:dc:66"
+)
+BOND_MAPPINGS = (
+    "bond0:fe:16:41:df:23:fe "
+    "bond0:fe:16:41:df:23:fd "
+    "bond1:fe:f2:d0:45:dc:66"
+)
+PCI_DEVICE_MAP = {
+    'fe:16:41:df:23:fd': MockPCIDevice('0000:00:1c.0'),
+    'fe:16:41:df:23:fe': MockPCIDevice('0000:00:1d.0'),
+}
+
+
+class TestDPDKUtils(tests.utils.BaseTestCase):
+
+    def test_resolve_pci_from_mapping_config(self):
+        # FIXME: need to mock out the unit key value store
+        self.patch_object(context, 'config')
+        self.config.side_effect = lambda x: {
+            'data-port': DPDK_DATA_PORTS,
+            'dpdk-bond-mappings': BOND_MAPPINGS,
+        }.get(x)
+        _pci_devices = Mock()
+        _pci_devices.get_device_from_mac.side_effect = PCI_DEVICE_MAP.get
+        self.patch_object(context, 'pci')
+        self.pci.PCINetDevices.return_value = _pci_devices
+        self.assertEqual(
+            context.resolve_pci_from_mapping_config('data-port'),
+            {'0000:00:1c.0': 'br-phynet1', '0000:00:1d.0': 'br-phynet3'})
+        self.config.assert_called_once_with('data-port')
+        self.config.reset_mock()
+        self.assertEqual(
+            context.resolve_pci_from_mapping_config('dpdk-bond-mappings'),
+            {'0000:00:1c.0': 'bond0', '0000:00:1d.0': 'bond0'})
+        self.config.assert_called_once_with('dpdk-bond-mappings')
+
+
+DPDK_PATCH = [
+    'resolve_pci_from_mapping_config',
+    'glob',
+]
+
+NUMA_CORES_SINGLE = {
+    '0': [0, 1, 2, 3]
+}
+
+NUMA_CORES_MULTI = {
+    '0': [0, 1, 2, 3],
+    '1': [4, 5, 6, 7]
+}
+
+
+class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
+
+    def setUp(self):
+        super(TestOVSDPDKDeviceContext, self).setUp()
+        self.patch_object(context, 'config')
+        self.config.side_effect = lambda x: {
+            'enable-dpdk': True,
+        }
+        self.target = context.OVSDPDKDeviceContext()
+
+    def patch_target(self, attr, return_value=None):
+        mocked = mock.patch.object(self.target, attr)
+        self._patches[attr] = mocked
+        started = mocked.start()
+        started.return_value = return_value
+        self._patches_start[attr] = started
+        setattr(self, attr, started)
+
+    def test__parse_cpu_list(self):
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_1),
+                         [0, 1, 2, 3])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_2),
+                         [0, 1, 2, 3, 4, 5, 6, 7,
+                          16, 17, 18, 19, 20, 21, 22, 23])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_3),
+                         [0, 4, 8, 12, 16, 20, 24])
+
+    def test__numa_node_cores(self):
+        self.patch_target('_parse_cpu_list')
+        self._parse_cpu_list.return_value = [0, 1, 2, 3]
+        self.patch_object(context, 'glob')
+        self.glob.glob.return_value = [
+            '/sys/devices/system/node/node0'
+        ]
+        with patch_open() as (_, mock_file):
+            mock_file.read.return_value = TEST_CPULIST_1
+            self.target._numa_node_cores()
+            self.assertEqual(self.target._numa_node_cores(),
+                             {'0': [0, 1, 2, 3]})
+        self.glob.glob.assert_called_with('/sys/devices/system/node/node*')
+        self._parse_cpu_list.assert_called_with(TEST_CPULIST_1)
+
+    def test_device_whitelist(self):
+        """Test device whitelist generation"""
+        self.patch_object(
+            context, 'resolve_pci_from_mapping_config',
+            return_value=collections.OrderedDict(
+                sorted({
+                    '0000:00:1c.0': 'br-data',
+                    '0000:00:1d.0': 'br-data',
+                }.items())))
+        self.assertEqual(self.target.device_whitelist(),
+                         '-w 0000:00:1c.0 -w 0000:00:1d.0')
+        self.resolve_pci_from_mapping_config.assert_has_calls([
+            call('data-port'),
+            call('dpdk-bond-mappings'),
+        ])
+
+    def test_socket_memory(self):
+        """Test socket memory configuration"""
+        self.patch_object(context, 'glob')
+        self.patch_object(context, 'config')
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-memory': 1024,
+        }.get(x)
+        self.glob.glob.return_value = ['a']
+        self.assertEqual(self.target.socket_memory(),
+                         '1024')
+
+        self.glob.glob.return_value = ['a', 'b']
+        self.assertEqual(self.target.socket_memory(),
+                         '1024,1024')
+
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-memory': 2048,
+        }.get(x)
+        self.assertEqual(self.target.socket_memory(),
+                         '2048,2048')
+
+    def test_cpu_mask(self):
+        """Test generation of hex CPU masks"""
+        self.patch_target('_numa_node_cores')
+        self._numa_node_cores.return_value = NUMA_CORES_SINGLE
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 1,
+        }.get(x)
+        self.assertEqual(self.target.cpu_mask(), '0x01')
+
+        self._numa_node_cores.return_value = NUMA_CORES_MULTI
+        self.assertEqual(self.target.cpu_mask(), '0x11')
+
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 2,
+        }.get(x)
+        self.assertEqual(self.target.cpu_mask(), '0x33')
+
+    def test_context_no_devices(self):
+        """Ensure that DPDK is disable when no devices detected"""
+        self.patch_object(context, 'resolve_pci_from_mapping_config')
+        self.resolve_pci_from_mapping_config.return_value = {}
+        self.assertEqual(self.target(), {})
+        self.resolve_pci_from_mapping_config.assert_has_calls([
+            call('data-port'),
+            call('dpdk-bond-mappings'),
+        ])
+
+    def test_context_devices(self):
+        """Ensure DPDK is enabled when devices are detected"""
+        self.patch_target('_numa_node_cores')
+        self.patch_target('devices')
+        self.devices.return_value = collections.OrderedDict(sorted({
+            '0000:00:1c.0': 'br-data',
+            '0000:00:1d.0': 'br-data',
+        }.items()))
+        self._numa_node_cores.return_value = NUMA_CORES_SINGLE
+        self.patch_object(context, 'glob')
+        self.glob.glob.return_value = ['a']
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 1,
+            'dpdk-socket-memory': 1024,
+            'enable-dpdk': True,
+        }.get(x)
+        self.assertEqual(self.target(), {
+            'cpu_mask': '0x01',
+            'device_whitelist': '-w 0000:00:1c.0 -w 0000:00:1d.0',
+            'dpdk_enabled': True,
+            'socket_memory': '1024'
+        })
+
+
+class TestDPDKDeviceContext(tests.utils.BaseTestCase):
+
+    _dpdk_bridges = {
+        '0000:00:1c.0': 'br-data',
+        '0000:00:1d.0': 'br-physnet1',
+    }
+    _dpdk_bonds = {
+        '0000:00:1c.1': 'dpdk-bond0',
+        '0000:00:1d.1': 'dpdk-bond0',
+    }
+
+    def setUp(self):
+        super(TestDPDKDeviceContext, self).setUp()
+        self.target = context.DPDKDeviceContext()
+        self.patch_object(context, 'resolve_pci_from_mapping_config')
+        self.resolve_pci_from_mapping_config.side_effect = [
+            self._dpdk_bridges,
+            self._dpdk_bonds,
+        ]
+
+    def test_context(self):
+        self.patch_object(context, 'config')
+        self.config.side_effect = lambda x: {
+            'dpdk-driver': 'uio_pci_generic',
+        }.get(x)
+        devices = copy.deepcopy(self._dpdk_bridges)
+        devices.update(self._dpdk_bonds)
+        self.assertEqual(self.target(), {
+            'devices': devices,
+            'driver': 'uio_pci_generic'
+        })
+        self.config.assert_called_with('dpdk-driver')
+
+    def test_context_none_driver(self):
+        self.patch_object(context, 'config')
+        self.config.return_value = None
+        self.assertEqual(self.target(), {})
+        self.config.assert_called_with('dpdk-driver')
+
+
+class TestBridgeBondMap(tests.utils.BaseTestCase):
+
+    def test_add_interface(self):
+        ctx = context.BridgeBondMap()
+        ctx.add_interface("br1", "bond1", "port1", ctx.interface_type.dpdk,
+                          "00:00:00:00:00:01", 1500)
+        ctx.add_interface("br1", "bond1", "port2", ctx.interface_type.dpdk,
+                          "00:00:00:00:00:02", 1500)
+        ctx.add_interface("br1", "bond2", "port3", ctx.interface_type.dpdk,
+                          "00:00:00:00:00:03", 1500)
+        ctx.add_interface("br1", "bond2", "port4", ctx.interface_type.dpdk,
+                          "00:00:00:00:00:04", 1500)
+
+        expected = (
+            'br1', {
+                'bond1': {
+                    'port1': {
+                        'type': 'dpdk',
+                        'pci-address': '00:00:00:00:00:01',
+                        'mtu-request': '1500',
+                    },
+                    'port2': {
+                        'type': 'dpdk',
+                        'pci-address': '00:00:00:00:00:02',
+                        'mtu-request': '1500',
+                    },
+                },
+                'bond2': {
+                    'port3': {
+                        'type': 'dpdk',
+                        'pci-address': '00:00:00:00:00:03',
+                        'mtu-request': '1500',
+                    },
+                    'port4': {
+                        'type': 'dpdk',
+                        'pci-address': '00:00:00:00:00:04',
+                        'mtu-request': '1500',
+                    },
+                },
+            },
+        )
+        for br, bonds in ctx.items():
+            self.maxDiff = None
+            self.assertEqual(br, expected[0])
+            self.assertDictEqual(bonds, expected[1])
+
+
+class TestBondConfig(tests.utils.BaseTestCase):
+
+    def test_get_bond_config(self):
+        self.patch_object(context, 'config')
+        self.config.side_effect = lambda x: {
+            'dpdk-bond-config': ':active-backup bond1:balance-slb:off',
+        }.get(x)
+        bonds_config = context.BondConfig()
+
+        self.assertEqual(bonds_config.get_bond_config('bond0'),
+                         {'mode': 'active-backup',
+                          'lacp': 'active',
+                          'lacp-time': 'fast'
+                          })
+        self.assertEqual(bonds_config.get_bond_config('bond1'),
+                         {'mode': 'balance-slb',
+                          'lacp': 'off',
+                          'lacp-time': 'fast'
+                          })


### PR DESCRIPTION
This will allow uniform handling of network configuration
across ``neutron-openvswitch``, ``neutron-gateway`` and
the OVN chassis charms.

Note that the handling of this detail in the charm is
pre-deprecated.

The long term goal is for network connectivity detail to be
modelled in the server provisioning layer (such as MAAS) which in
turn will provide a Netplan YAML description that will be used to
drive Open vSwitch.

Until we get to that reality the charm will need to configure
this detail based on application level configuration options.