### PR TITLE
ovs/ovsdb: Improve SimpleOVSDB API

### DIFF
--- a/charmhelpers/contrib/network/ovs/ovsdb.py
+++ b/charmhelpers/contrib/network/ovs/ovsdb.py
@@ -28,74 +28,183 @@ class SimpleOVSDB(object):
     appears to be a bit too involved for our simple use case.
 
     Examples:
-    chassis = SimpleOVSDB('ovn-sbctl', 'chassis')
-    for chs in chassis:
+    sbdb = SimpleOVSDB('ovn-sbctl')
+    for chs in sbdb.chassis:
         print(chs)
 
-    bridges = SimpleOVSDB('ovs-vsctl', 'bridge')
-    for br in bridges:
+    ovsdb = SimpleOVSDB('ovs-vsctl')
+    for br in ovsdb.bridge:
         if br['name'] == 'br-test':
-            bridges.set(br['uuid'], 'external_ids:charm', 'managed')
+            ovsdb.bridge.set(br['uuid'], 'external_ids:charm', 'managed')
     """
 
-    def __init__(self, tool, table):
-        """SimpleOVSDB constructor
+    # For validation we keep a complete map of currently known good tool and
+    # table combinations.  This requires maintenance down the line whenever
+    # upstream adds things that downstream wants, and the cost of maintaining
+    # that will most likely be lower then the cost of finding the needle in
+    # the haystack whenever downstream code misspells something.
+    _tool_table_map = {
+        'ovs-vsctl': (
+            'autoattach',
+            'bridge',
+            'ct_timeout_policy',
+            'ct_zone',
+            'controller',
+            'datapath',
+            'flow_sample_collector_set',
+            'flow_table',
+            'ipfix',
+            'interface',
+            'manager',
+            'mirror',
+            'netflow',
+            'open_vswitch',
+            'port',
+            'qos',
+            'queue',
+            'ssl',
+            'sflow',
+        ),
+        'ovn-nbctl': (
+            'acl',
+            'address_set',
+            'connection',
+            'dhcp_options',
+            'dns',
+            'forwarding_group',
+            'gateway_chassis',
+            'ha_chassis',
+            'ha_chassis_group',
+            'load_balancer',
+            'load_balancer_health_check',
+            'logical_router',
+            'logical_router_policy',
+            'logical_router_port',
+            'logical_router_static_route',
+            'logical_switch',
+            'logical_switch_port',
+            'meter',
+            'meter_band',
+            'nat',
+            'nb_global',
+            'port_group',
+            'qos',
+            'ssl',
+        ),
+        'ovn-sbctl': (
+            'address_set',
+            'chassis',
+            'connection',
+            'controller_event',
+            'dhcp_options',
+            'dhcpv6_options',
+            'dns',
+            'datapath_binding',
+            'encap',
+            'gateway_chassis',
+            'ha_chassis',
+            'ha_chassis_group',
+            'igmp_group',
+            'ip_multicast',
+            'logical_flow',
+            'mac_binding',
+            'meter',
+            'meter_band',
+            'multicast_group',
+            'port_binding',
+            'port_group',
+            'rbac_permission',
+            'rbac_role',
+            'sb_global',
+            'ssl',
+            'service_monitor',
+        ),
+    }
+
+    def __init__(self, tool):
+        """SimpleOVSDB constructor.
 
         :param tool: Which tool with database commands to operate on.
                      Usually one of `ovs-vsctl`, `ovn-nbctl`, `ovn-sbctl`
         :type tool: str
-        :param table: Which table to operate on
-        :type table: str
         """
-        if tool not in ('ovs-vsctl', 'ovn-nbctl', 'ovn-sbctl'):
+        if tool not in self._tool_table_map:
             raise RuntimeError(
-                "tool must be one of 'ovs-vsctl', 'ovn-nbctl', 'ovn-sbctl'")
+                'tool must be one of "{}"'.format(self._tool_table_map.keys()))
         self.tool = tool
-        self.tbl = table
+        self._tool = tool
+        self._tableobject = {}
 
-    def _find_tbl(self, condition=None):
-        """Run and parse output of OVSDB `find` command.
+    def __getattr__(self, table):
+        if table not in self._tool_table_map[self._tool]:
+            raise AttributeError(
+                'table "{}" not known for use with "{}"'
+                .format(table, self._tool))
+        if table not in self._tableobject:
+            self._tableobject[table] = self.Table(self._tool, table)
+        return self._tableobject[table]
 
-        :param condition: An optional RFC 7047 5.1 match condition
-        :type condition: Optional[str]
-        :returns: Dictionary with data
-        :rtype: Iterator[Dict[str, ANY]]
+    class Table(object):
+        """Methods to interact with contents of OVSDB tables.
+
+        NOTE: At the time of this writing ``find`` is the only command
+        line argument to OVSDB manipulating tools that actually supports
+        JSON output.
         """
-        # When using json formatted output to OVS commands Internal OVSDB
-        # notation may occur that require further deserializing.
-        # Reference: https://tools.ietf.org/html/rfc7047#section-5.1
-        ovs_type_cb_map = {
-            'uuid': uuid.UUID,
-            # FIXME sets also appear to sometimes contain type/value tuples
-            'set': list,
-            'map': dict,
-        }
-        cmd = [self.tool, '-f', 'json', 'find', self.tbl]
-        if condition:
-            cmd.append(condition)
-        output = utils._run(*cmd)
-        data = json.loads(output)
-        for row in data['data']:
-            values = []
-            for col in row:
-                if isinstance(col, list):
-                    f = ovs_type_cb_map.get(col[0], str)
-                    values.append(f(col[1]))
-                else:
-                    values.append(col)
-            yield dict(zip(data['headings'], values))
 
-    def __iter__(self):
-        return self._find_tbl()
+        def __init__(self, tool, table):
+            """SimpleOVSDBTable constructor.
 
-    def clear(self, rec, col):
-        utils._run(self.tool, 'clear', self.tbl, rec, col)
+            :param table: Which table to operate on
+            :type table: str
+            """
+            self._tool = tool
+            self._table = table
 
-    def find(self, condition):
-        return self._find_tbl(condition=condition)
+        def _find_tbl(self, condition=None):
+            """Run and parse output of OVSDB `find` command.
 
-    def remove(self, rec, col, value):
-        utils._run(self.tool, 'remove', self.tbl, rec, col, value)
+            :param condition: An optional RFC 7047 5.1 match condition
+            :type condition: Optional[str]
+            :returns: Dictionary with data
+            :rtype: Dict[str, any]
+            """
+            # When using json formatted output to OVS commands Internal OVSDB
+            # notation may occur that require further deserializing.
+            # Reference: https://tools.ietf.org/html/rfc7047#section-5.1
+            ovs_type_cb_map = {
+                'uuid': uuid.UUID,
+                # FIXME sets also appear to sometimes contain type/value tuples
+                'set': list,
+                'map': dict,
+            }
+            cmd = [self._tool, '-f', 'json', 'find', self._table]
+            if condition:
+                cmd.append(condition)
+            output = utils._run(*cmd)
+            data = json.loads(output)
+            for row in data['data']:
+                values = []
+                for col in row:
+                    if isinstance(col, list):
+                        f = ovs_type_cb_map.get(col[0], str)
+                        values.append(f(col[1]))
+                    else:
+                        values.append(col)
+                yield dict(zip(data['headings'], values))
 
-    def set(self, rec, col, value):
-        utils._run(self.tool, 'set', self.tbl, rec, '{}={}'.format(col, value))
+        def __iter__(self):
+            return self._find_tbl()
+
+        def clear(self, rec, col):
+            utils._run(self._tool, 'clear', self._table, rec, col)
+
+        def find(self, condition):
+            return self._find_tbl(condition=condition)
+
+        def remove(self, rec, col, value):
+            utils._run(self._tool, 'remove', self._table, rec, col, value)
+
+        def set(self, rec, col, value):
+            utils._run(self._tool, 'set', self._table, rec,
+                       '{}={}'.format(col, value))

--- a/charmhelpers/contrib/network/ovs/ovsdb.py
+++ b/charmhelpers/contrib/network/ovs/ovsdb.py
@@ -131,18 +131,14 @@ class SimpleOVSDB(object):
         if tool not in self._tool_table_map:
             raise RuntimeError(
                 'tool must be one of "{}"'.format(self._tool_table_map.keys()))
-        self.tool = tool
         self._tool = tool
-        self._tableobject = {}
 
     def __getattr__(self, table):
         if table not in self._tool_table_map[self._tool]:
             raise AttributeError(
                 'table "{}" not known for use with "{}"'
                 .format(table, self._tool))
-        if table not in self._tableobject:
-            self._tableobject[table] = self.Table(self._tool, table)
-        return self._tableobject[table]
+        return self.Table(self._tool, table)
 
     class Table(object):
         """Methods to interact with contents of OVSDB tables.

--- a/tests/contrib/network/ovs/test_ovsdb.py
+++ b/tests/contrib/network/ovs/test_ovsdb.py
@@ -44,10 +44,13 @@ class TestSimpleOVSDB(test_utils.BaseTestCase):
 
     def test___init__(self):
         with self.assertRaises(RuntimeError):
-            self.target = ovsdb.SimpleOVSDB('atool', 'atable')
+            self.target = ovsdb.SimpleOVSDB('atool')
+        with self.assertRaises(AttributeError):
+            self.target = ovsdb.SimpleOVSDB('ovs-vsctl')
+            self.target.unknown_table.find()
 
     def test__find_tbl(self):
-        self.target = ovsdb.SimpleOVSDB('ovs-vsctl', 'atable')
+        self.target = ovsdb.SimpleOVSDB('ovs-vsctl')
         self.patch_object(ovsdb.utils, '_run')
         self._run.return_value = VSCTL_BRIDGE_TBL
         self.maxDiff = None
@@ -80,41 +83,41 @@ class TestSimpleOVSDB(test_utils.BaseTestCase):
             'status': {},
             'stp_enable': False}
         # this in effect also tests the __iter__ front end method
-        for el in self.target:
+        for el in self.target.bridge:
             self.assertDictEqual(el, expect)
             break
         self._run.assert_called_once_with(
-            'ovs-vsctl', '-f', 'json', 'find', 'atable')
+            'ovs-vsctl', '-f', 'json', 'find', 'bridge')
         self._run.reset_mock()
         # this in effect also tests the find front end method
-        for el in self.target.find(condition='name=br-test'):
+        for el in self.target.bridge.find(condition='name=br-test'):
             break
         self._run.assert_called_once_with(
-            'ovs-vsctl', '-f', 'json', 'find', 'atable', 'name=br-test')
+            'ovs-vsctl', '-f', 'json', 'find', 'bridge', 'name=br-test')
 
     def test_clear(self):
-        self.target = ovsdb.SimpleOVSDB('ovs-vsctl', 'atable')
+        self.target = ovsdb.SimpleOVSDB('ovs-vsctl')
         self.patch_object(ovsdb.utils, '_run')
-        self.target.clear('1e21ba48-61ff-4b32-b35e-cb80411da351',
-                          'external_ids')
+        self.target.interface.clear('1e21ba48-61ff-4b32-b35e-cb80411da351',
+                                    'external_ids')
         self._run.assert_called_once_with(
-            'ovs-vsctl', 'clear', 'atable',
+            'ovs-vsctl', 'clear', 'interface',
             '1e21ba48-61ff-4b32-b35e-cb80411da351', 'external_ids')
 
     def test_remove(self):
-        self.target = ovsdb.SimpleOVSDB('ovs-vsctl', 'atable')
+        self.target = ovsdb.SimpleOVSDB('ovs-vsctl')
         self.patch_object(ovsdb.utils, '_run')
-        self.target.remove('1e21ba48-61ff-4b32-b35e-cb80411da351',
-                           'external_ids', 'other')
+        self.target.interface.remove('1e21ba48-61ff-4b32-b35e-cb80411da351',
+                                     'external_ids', 'other')
         self._run.assert_called_once_with(
-            'ovs-vsctl', 'remove', 'atable',
+            'ovs-vsctl', 'remove', 'interface',
             '1e21ba48-61ff-4b32-b35e-cb80411da351', 'external_ids', 'other')
 
     def test_set(self):
-        self.target = ovsdb.SimpleOVSDB('ovs-vsctl', 'atable')
+        self.target = ovsdb.SimpleOVSDB('ovs-vsctl')
         self.patch_object(ovsdb.utils, '_run')
-        self.target.set('1e21ba48-61ff-4b32-b35e-cb80411da351',
-                        'external_ids:other', 'value')
+        self.target.interface.set('1e21ba48-61ff-4b32-b35e-cb80411da351',
+                                  'external_ids:other', 'value')
         self._run.assert_called_once_with(
-            'ovs-vsctl', 'set', 'atable',
+            'ovs-vsctl', 'set', 'interface',
             '1e21ba48-61ff-4b32-b35e-cb80411da351', 'external_ids:other=value')


### PR DESCRIPTION
The current approach is string heavy and could fit better with how
Python developers expect data structures to behave.

As there has been no release of charm-helpers since the initial
commit of the API it should be safe to change it at this point.

A future improvement could still be to add a third dimension to
the data structure to allow users to operate on specific key/value
pairs in a specifc row in a specific table.  At this point in time
the underlying command line argument that would be used does not
support outputting data in JSON format so for that reason I'm
postponing implementation of that facet.