### PR TITLE
Add common functions for sharing unit state

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2220,7 +2220,7 @@ UNIT_STATES = [UNIT_READY, UNIT_NOTREADY, UNIT_UNKNOWN]
 
 
 def get_peers_unit_state(relation_name='cluster'):
-    """Get peers the state of all peers.
+    """Get the state of all peers.
 
     :param relation_name: Name of relation to check peers on.
     :type relation_name: string

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2183,3 +2183,133 @@ def is_expected_scale(peer_relation_name='cluster'):
         return True
     juju_log('All checks have passed, unit is at expected scale', 'DEBUG')
     return True
+
+
+def get_peer_key(unit_name):
+    """Get the peer key for this unit.
+
+    The peer key is the key a unit uses to publish its status down the peer
+    relation
+
+    :param unit_name: Name of unit
+    :type unit_name: string
+    :returns: Peer key for given unit
+    :rtype: string
+    """
+    return 'unit-state-{}'.format(unit_name.replace('/', '-'))
+
+
+def inform_peers_unit_state(state, relation_name='cluster'):
+    """Inform peers of the state of this unit.
+
+    :param state: State of unit to publish
+    :type state: string
+    :param relation_name: Name of relation to publish state on
+    :type relation_name: string
+    """
+    for r_id in relation_ids(relation_name):
+        relation_set(relation_id=r_id,
+                     relation_settings={
+                         get_peer_key(local_unit()): state})
+
+
+UNIT_READY = 'READY'
+UNIT_NOTREADY = 'NOTREADY'
+UNIT_UNKNOWN = 'UNKNOWN'
+UNIT_STATES = [UNIT_READY, UNIT_NOTREADY, UNIT_UNKNOWN]
+
+
+def get_peers_unit_state(relation_name='cluster'):
+    """Get peers the state of all peers.
+
+    :param relation_name: Name of relation to check peers on.
+    :type relation_name: string
+    :returns: Unit states keyed on unit name.
+    :rtype: dict
+    :raises: ValueError
+    """
+    r_ids = relation_ids(relation_name)
+    rids_units = [(r, u) for r in r_ids for u in related_units(r)]
+    unit_states = {}
+    for r_id, unit in rids_units:
+        settings = relation_get(unit=unit, rid=r_id)
+        unit_states[unit] = settings.get(get_peer_key(unit), UNIT_UNKNOWN)
+        if unit_states[unit] not in UNIT_STATES:
+            raise ValueError(
+                "Unit in unknown state {}".format(unit_states[unit]))
+    return unit_states
+
+
+def is_peers_ready(relation_name='cluster'):
+    """Check if all peers are ready.
+
+    :param relation_name: Name of relation to check peers on.
+    :type relation_name: string
+    :returns: Whether all units are ready.
+    :rtype: bool
+    """
+    unit_states = get_peers_unit_state(relation_name)
+    return all(v == UNIT_READY for v in unit_states.values())
+
+
+def inform_peers_if_ready(check_unit_ready_func, relation_name='cluster'):
+    """If this unit is ready inform peers.
+
+    The check function should return a tuple (state, message). A state
+    of 'READY' indicates the unit is READY.
+
+    :param check_unit_ready_func: Function to run to check readiness
+    :type check_unit_ready_func: function
+    :param relation_name: Name of relation to check peers on.
+    :type relation_name: string
+    """
+    unit_ready, msg = check_unit_ready_func()
+    if unit_ready:
+        state = UNIT_READY
+    else:
+        state = UNIT_NOTREADY
+    juju_log('Telling peers this unit is: {}'.format(msg), 'DEBUG')
+    inform_peers_unit_state(state, relation_name)
+
+
+def check_api_unit_ready(check_db_ready=True):
+    """Check if this unit is ready.
+
+    :param check_db_ready: Include checks of database readiness.
+    :type check_db_ready: bool
+    :returns: Whether unit state is ready and status message
+    :rtype: (bool, str)
+    """
+    unit_ready = True
+    msg = ''
+    if is_db_maintenance_mode():
+        msg = 'Database in maintenance mode.'
+    elif is_unit_paused_set():
+        msg = 'Unit paused.'
+    elif check_db_ready and not is_db_ready():
+        msg = 'Allowed_units list provided but this unit not present'
+    elif not is_db_initialised():
+        msg = 'Database not initialised'
+    elif not is_expected_scale():
+        msg = 'Charm and its dependencies not yet at expected scale'
+    if msg:
+        unit_ready = False
+    else:
+        msg = 'Unit has passed checks and is ready'
+    juju_log(msg, 'DEBUG')
+    return unit_ready, msg
+
+
+def check_api_application_ready():
+    """Check if this application is ready.
+
+    :returns: Whether unit state is ready and status message
+    :rtype: (bool, str)
+    """
+    unit_ready, msg = check_api_unit_ready(check_db_ready=True)
+    if not unit_ready:
+        return unit_ready, msg
+    if is_peers_ready():
+        return True, 'All units have passed checks and are ready'
+    else:
+        return False, 'This unit is ready but peers are not'

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -2204,11 +2204,11 @@ class OpenStackUtilsAdditionalTests(TestCase):
             openstack.get_peers_unit_state(),
             {'keystone/1': 'READY', 'keystone/2': 'UNKNOWN'})
 
-    def test_is_peers_ready(self):
+    def test_are_peers_ready(self):
         self.setup_relation(self.All_PEERS_READY)
-        self.assertTrue(openstack.is_peers_ready())
+        self.assertTrue(openstack.are_peers_ready())
         self.setup_relation(self.PEERS_NOT_READY)
-        self.assertFalse(openstack.is_peers_ready())
+        self.assertFalse(openstack.are_peers_ready())
 
     @patch.object(openstack, 'inform_peers_unit_state')
     def test_inform_peers_if_ready(self, inform_peers_unit_state):

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -2035,7 +2035,7 @@ class OpenStackUtilsAdditionalTests(TestCase):
     }
     SCALE_RELATIONS_HA = {
         'cluster:2': {
-            'keystone/1': {},
+            'keystone/1': {'unit-state-keystone-1': 'READY'},
             'keystone/2': {}},
         'shared-db:12': {
             'mysql-svc2/0': {
@@ -2050,6 +2050,14 @@ class OpenStackUtilsAdditionalTests(TestCase):
         'ha:32': {
             'hacluster-keystone/1': {}}
     }
+    All_PEERS_READY = {
+        'cluster:2': {
+            'keystone/1': {'unit-state-keystone-1': 'READY'},
+            'keystone/2': {'unit-state-keystone-2': 'READY'}}}
+    PEERS_NOT_READY = {
+        'cluster:2': {
+            'keystone/1': {'unit-state-keystone-1': 'READY'},
+            'keystone/2': {}}}
 
     def setUp(self):
         super(OpenStackUtilsAdditionalTests, self).setUp()
@@ -2172,6 +2180,97 @@ class OpenStackUtilsAdditionalTests(TestCase):
                 'cluster': {'interface': 'openstack-ha'}}}
         self.metadata.return_value = _metadata
         self.assertEqual(openstack.container_scoped_relations(), ['ha'])
+
+    def test_get_peer_key(self):
+        self.assertEqual(
+            openstack.get_peer_key('cinder/0'),
+            'unit-state-cinder-0')
+
+    def test_inform_peers_unit_state(self):
+        self.local_unit.return_value = 'client/0'
+        self.setup_relation(self.All_PEERS_READY)
+        openstack.inform_peers_unit_state('READY')
+        self.relation_set.assert_called_once_with(
+            relation_id='cluster:2',
+            relation_settings={'unit-state-client-0': 'READY'})
+
+    def test_get_peers_unit_state(self):
+        self.setup_relation(self.All_PEERS_READY)
+        self.assertEqual(
+            openstack.get_peers_unit_state(),
+            {'keystone/1': 'READY', 'keystone/2': 'READY'})
+        self.setup_relation(self.PEERS_NOT_READY)
+        self.assertEqual(
+            openstack.get_peers_unit_state(),
+            {'keystone/1': 'READY', 'keystone/2': 'UNKNOWN'})
+
+    def test_is_peers_ready(self):
+        self.setup_relation(self.All_PEERS_READY)
+        self.assertTrue(openstack.is_peers_ready())
+        self.setup_relation(self.PEERS_NOT_READY)
+        self.assertFalse(openstack.is_peers_ready())
+
+    @patch.object(openstack, 'inform_peers_unit_state')
+    def test_inform_peers_if_ready(self, inform_peers_unit_state):
+        self.setup_relation(self.All_PEERS_READY)
+
+        def _not_ready():
+            return False, "Its all gone wrong"
+
+        def _ready():
+            return True, "Hurray!"
+        openstack.inform_peers_if_ready(_not_ready)
+        inform_peers_unit_state.assert_called_once_with('NOTREADY', 'cluster')
+        inform_peers_unit_state.reset_mock()
+        openstack.inform_peers_if_ready(_ready)
+        inform_peers_unit_state.assert_called_once_with('READY', 'cluster')
+
+    @patch.object(openstack, 'is_expected_scale')
+    @patch.object(openstack, 'is_db_initialised')
+    @patch.object(openstack, 'is_db_ready')
+    @patch.object(openstack, 'is_unit_paused_set')
+    @patch.object(openstack, 'is_db_maintenance_mode')
+    def test_check_api_unit_ready(self, is_db_maintenance_mode,
+                                  is_unit_paused_set, is_db_ready,
+                                  is_db_initialised, is_expected_scale):
+        is_db_maintenance_mode.return_value = True
+        self.assertFalse(openstack.check_api_unit_ready()[0])
+
+        is_db_maintenance_mode.return_value = False
+        is_unit_paused_set.return_value = True
+        self.assertFalse(openstack.check_api_unit_ready()[0])
+
+        is_db_maintenance_mode.return_value = False
+        is_unit_paused_set.return_value = False
+        is_db_ready.return_value = False
+        self.assertFalse(openstack.check_api_unit_ready()[0])
+
+        is_db_maintenance_mode.return_value = False
+        is_unit_paused_set.return_value = False
+        is_db_ready.return_value = True
+        is_db_initialised.return_value = False
+        self.assertFalse(openstack.check_api_unit_ready()[0])
+
+        is_db_maintenance_mode.return_value = False
+        is_unit_paused_set.return_value = False
+        is_db_ready.return_value = True
+        is_db_initialised.return_value = True
+        is_expected_scale.return_value = False
+        self.assertFalse(openstack.check_api_unit_ready()[0])
+
+        is_db_maintenance_mode.return_value = False
+        is_unit_paused_set.return_value = False
+        is_db_ready.return_value = True
+        is_db_initialised.return_value = True
+        is_expected_scale.return_value = True
+        self.assertTrue(openstack.check_api_unit_ready()[0])
+
+    @patch.object(openstack, 'check_api_unit_ready')
+    def test_check_api_application_ready(self, check_api_unit_ready):
+        check_api_unit_ready.return_value = (True, 'Hurray')
+        self.assertTrue(openstack.check_api_application_ready()[0])
+        check_api_unit_ready.return_value = (False, ':-(')
+        self.assertFalse(openstack.check_api_application_ready()[0])
 
 
 if __name__ == '__main__':

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,11 +71,9 @@ class FakeRelation(object):
         self.relation_get.side_affect = relation.get
         passwd = self.relation_get('password', rid='mysql:0', unit='mysql/0')
 
-    set_relation_context can be used to simulate being in a relation hook
-    context. This allows omitting a relation id or unit when calling relation
-    helpers as the related unit is present.
-
-    To set the context:
+    set_relation_context can be used to simulate being in relation hook
+    context, eg omitting a relation id or unit implies the query is against
+    the relation id and unit in the current hook context. To set the context:
 
         relation = FakeRelation(rel)
         relation.set_relation_context('mysql-svc2/0', 'shared-db:12')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,9 +71,11 @@ class FakeRelation(object):
         self.relation_get.side_affect = relation.get
         passwd = self.relation_get('password', rid='mysql:0', unit='mysql/0')
 
-    set_relation_context can be used to simulate being in relation hook
-    context, eg omitting a relation id or unit implies the query is against
-    the relation id and unit in the current hook context. To set the context:
+    set_relation_context can be used to simulate being in a relation hook
+    context. This allows omitting a relation id or unit when calling relation
+    helpers as the related unit is present.
+
+    To set the context:
 
         relation = FakeRelation(rel)
         relation.set_relation_context('mysql-svc2/0', 'shared-db:12')


### PR DESCRIPTION
Add a set of functions which can be used by openstack charms to
perform common unit state checks and advertise/consume unit state
down a peer relation.

