### PR TITLE
Add support for setting application status

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1104,10 +1104,15 @@ def status_set(workload_state, message, application_status=False):
     to the user via juju status. If the status-set command is not found then
     assume this is juju < 1.23 and juju-log the message instead.
 
-    workload_state     -- valid juju workload state.
+    workload_state     -- valid juju workload state. str or WL_STATES
     message            -- status update message
     application_status -- Whether this is an application state set
     """
+    # Extract the value if workload_state is an Enum
+    try:
+        workload_state = workload_state.value
+    except AttributeError:
+        pass
     workload_state = workload_state.lower()
     if workload_state not in [s.lower() for s in WL_STATES.__members__.keys()]:
         raise ValueError(

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -21,6 +21,7 @@
 from __future__ import print_function
 import copy
 from distutils.version import LooseVersion
+from enum import Enum
 from functools import wraps
 from collections import namedtuple
 import glob
@@ -57,16 +58,13 @@ RANGE_WARNING = ('Passing NO_PROXY string that includes a cidr. '
                  'This may not be compatible with software you are '
                  'running in your shell.')
 
-WL_STATE_ACTIVE = 'active'
-WL_STATE_BLOCKED = 'blocked'
-WL_STATE_MAINTENANCE = 'maintenance'
-WL_STATE_WAITING = 'waiting'
 
-WL_STATES = [
-    WL_STATE_ACTIVE,
-    WL_STATE_BLOCKED,
-    WL_STATE_MAINTENANCE,
-    WL_STATE_WAITING]
+class WL_STATES(Enum):
+    ACTIVE = 'active'
+    BLOCKED = 'blocked'
+    MAINTENANCE = 'maintenance'
+    WAITING = 'waiting'
+
 
 cache = {}
 
@@ -1111,7 +1109,7 @@ def status_set(workload_state, message, application_status=False):
     application_status -- Whether this is an application state set
     """
     workload_state = workload_state.lower()
-    if workload_state not in WL_STATES:
+    if workload_state not in [s.lower() for s in WL_STATES.__members__.keys()]:
         raise ValueError(
             '{!r} is not a valid workload state'.format(workload_state)
         )

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1869,6 +1869,19 @@ class HooksTest(TestCase):
         call.assert_called_with(['status-set', 'active', 'Everything is Awesome!'])
 
     @patch('subprocess.call')
+    def test_status_app(self, call):
+        call.return_value = 0
+        hookenv.status_set(
+            'active',
+            'Everything is Awesome!',
+            application_status=True)
+        call.assert_called_with([
+            'status-set',
+            '--application',
+            'active',
+            'Everything is Awesome!'])
+
+    @patch('subprocess.call')
     @patch.object(hookenv, 'log')
     def test_status_enoent(self, log, call):
         call.side_effect = OSError(2, 'fail')

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1869,6 +1869,12 @@ class HooksTest(TestCase):
         call.assert_called_with(['status-set', 'active', 'Everything is Awesome!'])
 
     @patch('subprocess.call')
+    def test_status_enum(self, call):
+        call.return_value = 0
+        hookenv.status_set(hookenv.WL_STATES.ACTIVE, 'Everything is Awesome!')
+        call.assert_called_with(['status-set', 'active', 'Everything is Awesome!'])
+
+    @patch('subprocess.call')
     def test_status_app(self, call):
         call.return_value = 0
         hookenv.status_set(


### PR DESCRIPTION
The status-set command can take a 'application' switch which causes
the state and message to be set at the application level rather
than the unit level. This change adds support for that switch.