### PR TITLE
non-active local unit state in application status

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2343,11 +2343,7 @@ def get_api_application_status():
     :returns: Workload state and message
     :rtype: (bool, str)
     """
-    unit_ready, msg = check_api_unit_ready(check_db_ready=True)
-    if unit_ready and are_peers_ready():
-        app_state = WL_STATES.ACTIVE
-        msg = 'Application is ready'
-    else:
-        app_state = WL_STATES.WAITING
-        msg = 'Some units not ready'
+    app_state, msg = get_api_unit_status()
+    if app_state == WL_STATES.ACTIVE and not are_peers_ready():
+        return WL_STATES.WAITING, 'Some units are not ready'
     return app_state, msg

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2344,6 +2344,9 @@ def get_api_application_status():
     :rtype: (bool, str)
     """
     app_state, msg = get_api_unit_status()
-    if app_state == WL_STATES.ACTIVE and not are_peers_ready():
-        return WL_STATES.WAITING, 'Some units are not ready'
+    if app_state == WL_STATES.ACTIVE:
+        if are_peers_ready():
+            return WL_STATES.ACTIVE, 'Application Ready'
+        else:
+            return WL_STATES.WAITING, 'Some units are not ready'
     return app_state, msg

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -9,7 +9,7 @@ from testtools import TestCase
 from mock import MagicMock, patch, call
 
 from charmhelpers.fetch import ubuntu as fetch
-from charmhelpers.core.hookenv import flush
+from charmhelpers.core.hookenv import WL_STATES, flush
 
 import charmhelpers.contrib.openstack.utils as openstack
 
@@ -2317,23 +2317,23 @@ class OpenStackUtilsAdditionalTests(TestCase):
             openstack.get_api_unit_status()[0].value,
             'active')
 
-    @patch.object(openstack, 'check_api_unit_ready')
-    def test_check_api_application_ready(self, check_api_unit_ready):
-        check_api_unit_ready.return_value = (True, 'Hurray')
+    @patch.object(openstack, 'get_api_unit_status')
+    def test_check_api_application_ready(self, get_api_unit_status):
+        get_api_unit_status.return_value = (WL_STATES.ACTIVE, 'Hurray')
         self.assertTrue(openstack.check_api_application_ready()[0])
-        check_api_unit_ready.return_value = (False, ':-(')
+        get_api_unit_status.return_value = (WL_STATES.BLOCKED, ':-(')
         self.assertFalse(openstack.check_api_application_ready()[0])
 
-    @patch.object(openstack, 'check_api_unit_ready')
-    def test_get_api_application_status(self, check_api_unit_ready):
-        check_api_unit_ready.return_value = (True, 'Hurray')
+    @patch.object(openstack, 'get_api_unit_status')
+    def test_get_api_application_status(self, get_api_unit_status):
+        get_api_unit_status.return_value = (WL_STATES.ACTIVE, 'Hurray')
         self.assertEqual(
             openstack.get_api_application_status()[0].value,
             'active')
-        check_api_unit_ready.return_value = (False, ':-(')
+        get_api_unit_status.return_value = (WL_STATES.BLOCKED, ':-(')
         self.assertEqual(
             openstack.get_api_application_status()[0].value,
-            'waiting')
+            'blocked')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current code causes any non-active state of the local unit and
its correspoding message to be lost when setting application work
load status. This change, as suggested by cory_fu, allows a
non-active state for this unit to be displayed as it now takes
precedence over a peer not being ready.