### PR TITLE
Handle exceptions in containers when setting sysctl keys

### DIFF
--- a/charmhelpers/core/sysctl.py
+++ b/charmhelpers/core/sysctl.py
@@ -17,12 +17,16 @@
 
 import yaml
 
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 
 from charmhelpers.core.hookenv import (
     log,
     DEBUG,
     ERROR,
+)
+
+from charmhelpers.core.host import (
+    is_containr,
 )
 
 __author__ = 'Jorge Niedbalski R. <jorge.niedbalski@canonical.com>'
@@ -62,4 +66,10 @@ def create(sysctl_dict, sysctl_file, ignore=False):
     if ignore:
         call.append("-e")
 
-    check_call(call)
+    try:
+        check_call(call)
+    except CalledProcessError as e:
+        if is_container():
+            print ("Error setting some systcl keys in this container: {}".format(e.output))
+        else:
+            raise e

--- a/charmhelpers/core/sysctl.py
+++ b/charmhelpers/core/sysctl.py
@@ -25,9 +25,7 @@ from charmhelpers.core.hookenv import (
     ERROR,
 )
 
-from charmhelpers.core.host import (
-    is_containr,
-)
+from charmhelpers.core.host import is_container
 
 __author__ = 'Jorge Niedbalski R. <jorge.niedbalski@canonical.com>'
 
@@ -70,6 +68,6 @@ def create(sysctl_dict, sysctl_file, ignore=False):
         check_call(call)
     except CalledProcessError as e:
         if is_container():
-            print ("Error setting some systcl keys in this container: {}".format(e.output))
+            print("Error setting some systcl keys in this container: {}".format(e.output))
         else:
             raise e


### PR DESCRIPTION
Prior to focal, when setting some sysctl keys in a container, sysctl returned an exit code of 0. Now, the same error returns a 255. This commit ensures the same behaviour as prior to focal.