### PR TITLE
Use paramertierised sets for lookups rather than hardcoded lists

### DIFF
--- a/charmhelpers/core/strutils.py
+++ b/charmhelpers/core/strutils.py
@@ -18,8 +18,10 @@
 import six
 import re
 
+TRUTHY_STRINGS = {'y', 'yes', 'true', 't', 'on'}
+FALSEY_STRINGS = {'n', 'no', 'false', 'f', 'off'}
 
-def bool_from_string(value):
+def bool_from_string(value, truthy_strings=TRUTHY_STRINGS, falsey_strings=FALSEY_STRINGS, assume_false=False):
     """Interpret string value as boolean.
 
     Returns True if value translates to True otherwise False.
@@ -32,9 +34,12 @@ def bool_from_string(value):
 
     value = value.strip().lower()
 
-    if value in ['y', 'yes', 'true', 't', 'on']:
+    if value in truthy_strings:
         return True
-    elif value in ['n', 'no', 'false', 'f', 'off']:
+    elif value in falsey_strings:
+        return False
+    
+    if assume_false:
         return False
 
     msg = "Unable to interpret string value '%s' as boolean" % (value)

--- a/charmhelpers/core/strutils.py
+++ b/charmhelpers/core/strutils.py
@@ -21,6 +21,7 @@ import re
 TRUTHY_STRINGS = {'y', 'yes', 'true', 't', 'on'}
 FALSEY_STRINGS = {'n', 'no', 'false', 'f', 'off'}
 
+
 def bool_from_string(value, truthy_strings=TRUTHY_STRINGS, falsey_strings=FALSEY_STRINGS, assume_false=False):
     """Interpret string value as boolean.
 
@@ -36,10 +37,7 @@ def bool_from_string(value, truthy_strings=TRUTHY_STRINGS, falsey_strings=FALSEY
 
     if value in truthy_strings:
         return True
-    elif value in falsey_strings:
-        return False
-    
-    if assume_false:
+    elif value in falsey_strings or assume_false:
         return False
 
     msg = "Unable to interpret string value '%s' as boolean" % (value)


### PR DESCRIPTION
Improve the O() behaviour by using sets rather than lists. Also allow callers to supply their own patterns for matching.

Makes the bool_from_string more flexible by allowing callers to opt-out of raising exceptions.