### PR TITLE
status_set refinements

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -36,7 +36,7 @@ from charmhelpers.contrib.network import ip
 from charmhelpers.core import unitdata
 
 from charmhelpers.core.hookenv import (
-    WL_STATES,
+    WORKLOAD_STATES,
     action_fail,
     action_set,
     config,
@@ -1827,7 +1827,7 @@ def os_application_status_set(check_function):
     :type check_function: function
     """
     state, message = check_function()
-    status_set(state, message, application_status=True)
+    status_set(state, message, application=True)
 
 
 def enable_memcache(source=None, release=None, package=None):
@@ -2295,7 +2295,7 @@ def check_api_unit_ready(check_db_ready=True):
     :rtype: (bool, str)
     """
     unit_state, msg = get_api_unit_status(check_db_ready=check_db_ready)
-    return unit_state == WL_STATES.ACTIVE, msg
+    return unit_state == WORKLOAD_STATES.ACTIVE, msg
 
 
 def get_api_unit_status(check_db_ready=True):
@@ -2306,22 +2306,22 @@ def get_api_unit_status(check_db_ready=True):
     :returns: Workload state and message
     :rtype: (bool, str)
     """
-    unit_state = WL_STATES.ACTIVE
+    unit_state = WORKLOAD_STATES.ACTIVE
     msg = 'Unit is ready'
     if is_db_maintenance_mode():
-        unit_state = WL_STATES.MAINTENANCE
+        unit_state = WORKLOAD_STATES.MAINTENANCE
         msg = 'Database in maintenance mode.'
     elif is_unit_paused_set():
-        unit_state = WL_STATES.BLOCKED
+        unit_state = WORKLOAD_STATES.BLOCKED
         msg = 'Unit paused.'
     elif check_db_ready and not is_db_ready():
-        unit_state = WL_STATES.WAITING
+        unit_state = WORKLOAD_STATES.WAITING
         msg = 'Allowed_units list provided but this unit not present'
     elif not is_db_initialised():
-        unit_state = WL_STATES.WAITING
+        unit_state = WORKLOAD_STATES.WAITING
         msg = 'Database not initialised'
     elif not is_expected_scale():
-        unit_state = WL_STATES.WAITING
+        unit_state = WORKLOAD_STATES.WAITING
         msg = 'Charm and its dependencies not yet at expected scale'
     juju_log(msg, 'DEBUG')
     return unit_state, msg
@@ -2334,7 +2334,7 @@ def check_api_application_ready():
     :rtype: (bool, str)
     """
     app_state, msg = get_api_application_status()
-    return app_state == WL_STATES.ACTIVE, msg
+    return app_state == WORKLOAD_STATES.ACTIVE, msg
 
 
 def get_api_application_status():
@@ -2344,9 +2344,9 @@ def get_api_application_status():
     :rtype: (bool, str)
     """
     app_state, msg = get_api_unit_status()
-    if app_state == WL_STATES.ACTIVE:
+    if app_state == WORKLOAD_STATES.ACTIVE:
         if are_peers_ready():
-            return WL_STATES.ACTIVE, 'Application Ready'
+            return WORKLOAD_STATES.ACTIVE, 'Application Ready'
         else:
-            return WL_STATES.WAITING, 'Some units are not ready'
+            return WORKLOAD_STATES.WAITING, 'Some units are not ready'
     return app_state, msg

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -59,7 +59,7 @@ RANGE_WARNING = ('Passing NO_PROXY string that includes a cidr. '
                  'running in your shell.')
 
 
-class WL_STATES(Enum):
+class WORKLOAD_STATES(Enum):
     ACTIVE = 'active'
     BLOCKED = 'blocked'
     MAINTENANCE = 'maintenance'
@@ -1097,31 +1097,33 @@ def function_tag():
     return os.environ.get('JUJU_FUNCTION_TAG') or action_tag()
 
 
-def status_set(workload_state, message, application_status=False):
+def status_set(workload_state, message, application=False):
     """Set the workload state with a message
 
     Use status-set to set the workload state with a message which is visible
     to the user via juju status. If the status-set command is not found then
     assume this is juju < 1.23 and juju-log the message instead.
 
-    workload_state     -- valid juju workload state. str or WL_STATES
-    message            -- status update message
-    application_status -- Whether this is an application state set
+    workload_state   -- valid juju workload state. str or WORKLOAD_STATES
+    message          -- status update message
+    application      -- Whether this is an application state set
     """
-    # Extract the value if workload_state is an Enum
-    try:
-        workload_state = workload_state.value
-    except AttributeError:
-        pass
-    workload_state = workload_state.lower()
-    if workload_state not in [s.lower() for s in WL_STATES.__members__.keys()]:
-        raise ValueError(
-            '{!r} is not a valid workload state'.format(workload_state)
-        )
+    bad_state_msg = '{!r} is not a valid workload state'
+
+    if isinstance(workload_state, str):
+        try:
+            # Convert string to enum.
+            workload_state = WORKLOAD_STATES[workload_state.upper()]
+        except KeyError:
+            raise ValueError(bad_state_msg.format(workload_state))
+
+    if workload_state not in WORKLOAD_STATES:
+        raise ValueError(bad_state_msg.format(workload_state))
+
     cmd = ['status-set']
-    if application_status:
+    if application:
         cmd.append('--application')
-    cmd.extend([workload_state, message])
+    cmd.extend([workload_state.value, message])
     try:
         ret = subprocess.call(cmd)
         if ret == 0:
@@ -1129,7 +1131,7 @@ def status_set(workload_state, message, application_status=False):
     except OSError as e:
         if e.errno != errno.ENOENT:
             raise
-    log_message = 'status-set failed: {} {}'.format(workload_state,
+    log_message = 'status-set failed: {} {}'.format(workload_state.value,
                                                     message)
     log(log_message, level='INFO')
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -9,7 +9,7 @@ from testtools import TestCase
 from mock import MagicMock, patch, call
 
 from charmhelpers.fetch import ubuntu as fetch
-from charmhelpers.core.hookenv import WL_STATES, flush
+from charmhelpers.core.hookenv import WORKLOAD_STATES, flush
 
 import charmhelpers.contrib.openstack.utils as openstack
 
@@ -2319,18 +2319,18 @@ class OpenStackUtilsAdditionalTests(TestCase):
 
     @patch.object(openstack, 'get_api_unit_status')
     def test_check_api_application_ready(self, get_api_unit_status):
-        get_api_unit_status.return_value = (WL_STATES.ACTIVE, 'Hurray')
+        get_api_unit_status.return_value = (WORKLOAD_STATES.ACTIVE, 'Hurray')
         self.assertTrue(openstack.check_api_application_ready()[0])
-        get_api_unit_status.return_value = (WL_STATES.BLOCKED, ':-(')
+        get_api_unit_status.return_value = (WORKLOAD_STATES.BLOCKED, ':-(')
         self.assertFalse(openstack.check_api_application_ready()[0])
 
     @patch.object(openstack, 'get_api_unit_status')
     def test_get_api_application_status(self, get_api_unit_status):
-        get_api_unit_status.return_value = (WL_STATES.ACTIVE, 'Hurray')
+        get_api_unit_status.return_value = (WORKLOAD_STATES.ACTIVE, 'Hurray')
         self.assertEqual(
             openstack.get_api_application_status()[0].value,
             'active')
-        get_api_unit_status.return_value = (WL_STATES.BLOCKED, ':-(')
+        get_api_unit_status.return_value = (WORKLOAD_STATES.BLOCKED, ':-(')
         self.assertEqual(
             openstack.get_api_application_status()[0].value,
             'blocked')

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -6,6 +6,7 @@ import tempfile
 import types
 from mock import call, MagicMock, mock_open, patch, sentinel
 from testtools import TestCase
+from enum import Enum
 import yaml
 
 import six
@@ -1862,6 +1863,16 @@ class HooksTest(TestCase):
     def test_status_set_invalid_state(self):
         self.assertRaises(ValueError, hookenv.status_set, 'random', 'message')
 
+    def test_status_set_invalid_state_enum(self):
+
+        class RandomEnum(Enum):
+            FOO = 1
+        self.assertRaises(
+            ValueError,
+            hookenv.status_set,
+            RandomEnum.FOO,
+            'message')
+
     @patch('subprocess.call')
     def test_status(self, call):
         call.return_value = 0
@@ -1871,7 +1882,9 @@ class HooksTest(TestCase):
     @patch('subprocess.call')
     def test_status_enum(self, call):
         call.return_value = 0
-        hookenv.status_set(hookenv.WL_STATES.ACTIVE, 'Everything is Awesome!')
+        hookenv.status_set(
+            hookenv.WORKLOAD_STATES.ACTIVE,
+            'Everything is Awesome!')
         call.assert_called_with(['status-set', 'active', 'Everything is Awesome!'])
 
     @patch('subprocess.call')
@@ -1880,7 +1893,7 @@ class HooksTest(TestCase):
         hookenv.status_set(
             'active',
             'Everything is Awesome!',
-            application_status=True)
+            application=True)
         call.assert_called_with([
             'status-set',
             '--application',


### PR DESCRIPTION
Some refinements to status_set following feedback after
https://github.com/juju/charm-helpers/pull/456 had landed.

* Change WL_STATES to WORKLOAD_STATES which is clearer
* Admit defeat and use isinstance to check type of `workload_state`
  in status_set. Using it makes the code more legible and input
  validation easier.
* Switch the new option for doing an application level status set
  from `application_status` to `application`. This now matches the
  Juju `status-set` option.
* Update small amount of code which was expecting the previous
  behaviour.