### PR TITLE
Fix exception from vaultlocker code due to upstream change

### DIFF
--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -163,7 +163,7 @@ def retrieve_secret_id(url, token):
     :returns: secret_id to use for Vault Access
     :rtype: str"""
     import hvac
-    client = hvac.Client(url=url, token=token)
+    client = hvac.Client(url=url, token=token, adapter=hvac.adapters.Request)
     response = client._post('/v1/sys/wrapping/unwrap')
     if response.status_code == 200:
         data = response.json()


### PR DESCRIPTION
Fixes https://github.com/juju/charm-helpers/issues/463

The upstream release of hvac 0.10.1 changed the default adapter from Request to JSONAdapter, which causes responses to be returned as dictionaries instead of Response objects.

This PR fixes the issue by explicitly setting the Request adapter.