### PR TITLE
Handle older versions of hvac library

### DIFF
--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -163,7 +163,16 @@ def retrieve_secret_id(url, token):
     :returns: secret_id to use for Vault Access
     :rtype: str"""
     import hvac
-    client = hvac.Client(url=url, token=token, adapter=hvac.adapters.Request)
+    try:
+        # hvac 0.10.1 changed default adapter to JSONAdapter
+        client = hvac.Client(url=url, token=token, adapter=hvac.adapters.Request)
+    except AttributeError:
+        # hvac < 0.6.2 doesn't have adapter but uses the same response interface
+        client = hvac.Client(url=url, token=token)
+    else:
+        # hvac < 0.9.2 assumes adapter is an instance, so doesn't instantiate
+        if not isinstance(client.adapter, hvac.adapters.Request):
+            client.adapter = hvac.adapters.Request(base_uri=url, token=token)
     response = client._post('/v1/sys/wrapping/unwrap')
     if response.status_code == 200:
         data = response.json()


### PR DESCRIPTION
The fix in #466 didn't take into account older versions (specifically, 0.5.0 from deb and <0.7.0 from charm pins) of the hvac library.