### PR TITLE
openstack/context: Fix handling of linux bond interfaces

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2714,6 +2714,19 @@ class BridgePortInterfaceMap(object):
             self._ifname_mac_map[ifname] = [mac]
             self._mac_ifname_map[mac] = ifname
 
+            # check if interface is part of a linux bond
+            _bond_name = get_bond_master(ifname)
+            if _bond_name and _bond_name != ifname:
+                log('Add linux bond "{}" to map for physical interface "{}" '
+                    'with mac "{}".'.format(_bond_name, ifname, mac),
+                    level=DEBUG)
+                # for bonds we want to be able to get a list of the mac
+                # addresses for the physical interfaces the bond is made up of.
+                if self._ifname_mac_map.get(_bond_name):
+                    self._ifname_mac_map[_bond_name].append(mac)
+                else:
+                    self._ifname_mac_map[_bond_name] = [mac]
+
         # In light of the pre-deprecation notice in the docstring of this
         # class we will expose the ability to configure OVS bonds as a
         # DPDK-only feature, but generally use the data structures internally.


### PR DESCRIPTION
At present linux bonds will be ignored when mentioned directly
in configuration options parsed by the ``BridgePortInterface``
data structure.

If a mac address of a physical interface making up the bond is
listed the code correctly finds the bond name and adds that to
the bridge.

Virtual interfaces are ignored when then map is built, linux bonds
are virtual interfaces.

This patch fixes the problem by checking physical interfaces for
bond membership while building the map. If an interface is member
of a bond add the bond name to the map.

Previously the bond membership check was only done when looking
up interface name from mac after building the map.