### PR TITLE
Add helper to send application name to ceph-mons

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -41,6 +41,7 @@ from subprocess import (
 )
 from charmhelpers import deprecate
 from charmhelpers.core.hookenv import (
+    application_name,
     config,
     service_name,
     local_unit,
@@ -160,6 +161,17 @@ def get_osd_settings(relation_name):
                 else:
                     osd_settings[key] = value
     return _order_dict_by_key(osd_settings)
+
+
+def send_application_name(relid=None):
+    """Send the application name down the relation.
+
+    :param relid: Relation id to set application name in.
+    :type relid: str
+    """
+    relation_set(
+        relation_id=relid,
+        relation_settings={'application-name': application_name()})
 
 
 def send_osd_settings():

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -267,6 +267,19 @@ class CephUtilsTests(TestCase):
             self._get_osd_settings_test_helper,
             settings)
 
+    @patch.object(ceph_utils, 'application_name')
+    def test_send_application_name(self, application_name):
+        application_name.return_value = 'client'
+        ceph_utils.send_application_name()
+        self.relation_set.assert_called_once_with(
+            relation_settings={'application-name': 'client'},
+            relation_id=None)
+        self.relation_set.reset_mock()
+        ceph_utils.send_application_name(relid='rid:1')
+        self.relation_set.assert_called_once_with(
+            relation_settings={'application-name': 'client'},
+            relation_id='rid:1')
+
     @patch.object(ceph_utils, 'get_osd_settings')
     def test_send_osd_settings(self, _get_osd_settings):
         self.relation_ids.return_value = ['client:1', 'client:3']


### PR DESCRIPTION
Add helper to send application name to ceph-mons. When clients
are connecting to the ceph-mons via a cross-model relation the
ceph-mons have no way to derive the remote application name so
they need to send it via relation data. The corresponding
ceph-mon change is here https://review.opendev.org/736709