### PR TITLE
Gate on 'password' from rabbit units for amqp ctxt

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -721,6 +721,12 @@ class AMQPContext(OSContextGenerator):
                 rabbitmq_hosts = []
                 for unit in related_units(rid):
                     host = relation_get('private-address', rid=rid, unit=unit)
+                    if not relation_get('password', rid=rid, unit=unit):
+                        log(
+                            ("Skipping {} password not sent which indicates "
+                             "unit is not ready.".format(host)),
+                            level=DEBUG)
+                        continue
                     host = format_ipv6_addr(host) or host
                     rabbitmq_hosts.append(host)
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -270,6 +270,10 @@ AMQP_AA_RELATION = {
         },
         'rabbitmq/1': {
             'private-address': 'rabbithost2',
+            'password': 'foobar',
+        },
+        'rabbitmq/2': {  # Should be ignored because password is missing.
+            'private-address': 'rabbithost3',
         }
     }
 }


### PR DESCRIPTION
Currently a rabbit host is added to the list of available hosts
in the rabbit context if the `private-address` key is available on
the relation. But at the start of the relation `private-address` is
always present, even before the corresponding `amqp-relation-joined`
hook has run on the rabbit unit. So the rabbit unit has no control
over when that is first presented as its set by juju itself (the
value of `private-address` is subsequently overridden by the
charm but the charm does not control when it first appears).

This change checks that the rabbit unit has set `password` on
the relation before adding it to the list of available rabbit
units. The setting of `password` is entirely within the control
of the rabbit charm and the rabbit charm should ensure it is only
set when the corresponding unit is ready and clustered.