### PR TITLE
openstack/context: allow adding unmapped interface to bridge

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2798,6 +2798,17 @@ class BridgePortInterfaceMap(object):
                 self.add_interface(
                     bridge, portname, ifname, iftype, pci_address, global_mtu)
 
+            if not macs:
+                # We have not mapped the interface and it is probably some sort
+                # of virtual interface. Our user have put it in the config with
+                # a purpose so let's carry out their wish. LP: #1884743
+                log('Add unmapped interface from config: name "{}" bridge "{}"'
+                    .format(ifname, bridge),
+                    level=DEBUG)
+                self.add_interface(
+                    bridge, ifname, ifname, self.interface_type.system, None,
+                    global_mtu)
+
     def __getitem__(self, key):
         """Provide a Dict-like interface, get value of item.
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4524,6 +4524,7 @@ class TestDPDKDeviceContext(tests.utils.BaseTestCase):
 class TestBridgePortInterfaceMap(tests.utils.BaseTestCase):
 
     def test__init__(self):
+        self.maxDiff = None
         self.patch_object(context, 'config')
         # system with three interfaces (eth0, eth1 and eth2) where
         # eth0 and eth1 is part of linux bond bond0.
@@ -4583,6 +4584,31 @@ class TestBridgePortInterfaceMap(tests.utils.BaseTestCase):
             'data-port': (
                 'br-ex:eth2 '
                 'br-provider1:bond0'),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        bpi = context.BridgePortInterfaceMap()
+        self.assertDictEqual(bpi._map, expect)
+        # and if a user asks for a purely virtual interface let's not stop them
+        expect = {
+            'br-provider1': {
+                'bond0.1234': {
+                    'bond0.1234': {
+                        'type': 'system',
+                    },
+                },
+            },
+            'br-ex': {
+                'eth2': {
+                    'eth2': {
+                        'type': 'system',
+                    },
+                },
+            },
+        }
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'br-ex:eth2 '
+                'br-provider1:bond0.1234'),
             'dpdk-bond-mappings': '',
         }.get(x)
         bpi = context.BridgePortInterfaceMap()


### PR DESCRIPTION
We iterate over and map physical interfaces when building
the bridge port interface map.

If our user have put a virtual interface name in the config they
have most likely done so with a purpose, let's not force our users
hand and carry out their wish to be compatible with existing
neutron-openvswitch / neutron-gateway deployment topologies.