### PR TITLE
core.hookenv.Config: Handle invalid state files

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -372,8 +372,10 @@ class Config(dict):
             try:
                 self._prev_dict = json.load(f)
             except ValueError as e:
-                log('Unable to parse previous config data - {}'.format(str(e)),
-                    level=ERROR)
+                log('Found but was unable to parse previous config data, '
+                    'ignoring which will report all values as changed - {}'
+                    .format(str(e)), level=ERROR)
+                return
         for k, v in copy.deepcopy(self._prev_dict).items():
             if k not in self:
                 self[k] = v

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -66,21 +66,26 @@ class ConfigTest(TestCase):
         d = dict(foo='bar')
         c = hookenv.Config(d)
 
-        with open(c.path, 'w') as f:
+        state_path = os.path.join(self.charm_dir, hookenv.Config.CONFIG_FILE_NAME)
+        with open(state_path, 'w') as f:
             f.close()
 
         self.assertEqual(c['foo'], 'bar')
         self.assertEqual(c._prev_dict, None)
+        self.assertEqual(c.path, state_path)
 
     def test_init_invalid_state_file(self):
         d = dict(foo='bar')
-        c = hookenv.Config(d)
 
-        with open(c.path, 'w') as f:
+        state_path = os.path.join(self.charm_dir, hookenv.Config.CONFIG_FILE_NAME)
+        with open(state_path, 'w') as f:
             f.write('blah')
+
+        c = hookenv.Config(d)
 
         self.assertEqual(c['foo'], 'bar')
         self.assertEqual(c._prev_dict, None)
+        self.assertEqual(c.path, state_path)
 
     def test_load_previous(self):
         d = dict(foo='bar')


### PR DESCRIPTION
When initialising core.hookenv.Config a blank or corrupt state file
(.juju-persistent-config) caused the following exception to be raised:

  File "charmhelpers/core/hookenv.py", line 348, in load_previous
    for k, v in copy.deepcopy(self._prev_dict).items():
AttributeError: 'NoneType' object has no attribute 'items'

Handle this situation and return a blank previous state instead to
recover from this situation.

A previous attempt to fix this was made in #166 (LP #1768018) however it
did not work because while it caught the error loading the JSON file, it
then tried to call .items() on the object copy which is set to None.
Fix that by returning from the function after catching the exception.

The test cases (test_init_empty_state_file,
test_init_invalid_state_file) were also incorrectly passing because they
wrote to the test state file after initialising the Config object when
it had already been read. Fix that by writing to the file before Config
is initialised instead.

Note that in such a case where the file was corrupt, we will log an
error but otherwise silently "fix" this by loading a blank dictionary
causing Config() to report that all config values have changed even
though they may not have. Even though the code already intended (but
failed) to do this, we should ensure that is acceptable when reviewing
this change. I have updated the logged error to make this explicit.