### PR TITLE
Refresh cipher suites and protocols

### DIFF
--- a/charmhelpers/contrib/openstack/templates/openstack_https_frontend
+++ b/charmhelpers/contrib/openstack/templates/openstack_https_frontend
@@ -6,8 +6,18 @@ Listen {{ ext_port }}
 <VirtualHost {{ address }}:{{ ext }}>
     ServerName {{ endpoint }}
     SSLEngine on
-    SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2
-    SSLCipherSuite HIGH:!RC4:!MD5:!aNULL:!eNULL:!EXP:!LOW:!MEDIUM
+
+    # This section is based on Mozilla's recommendation
+    # as the "intermediate" profile as of July 7th, 2020.
+    # https://wiki.mozilla.org/Security/Server_Side_TLS
+    SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    SSLHonorCipherOrder off
+    # SSLSessionTickets is supported by Apache 2.4.11 or later.
+    # The following line can be enabled when trusty support is dropped.
+    # https://httpd.apache.org/docs/trunk/mod/mod_ssl.html#sslsessiontickets
+    # SSLSessionTickets off
+
     SSLCertificateFile /etc/apache2/ssl/{{ namespace }}/cert_{{ endpoint }}
     # See LP 1484489 - this is to support <= 2.4.7 and >= 2.4.8
     SSLCertificateChainFile /etc/apache2/ssl/{{ namespace }}/cert_{{ endpoint }}

--- a/charmhelpers/contrib/openstack/templates/openstack_https_frontend
+++ b/charmhelpers/contrib/openstack/templates/openstack_https_frontend
@@ -13,10 +13,6 @@ Listen {{ ext_port }}
     SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
     SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
     SSLHonorCipherOrder off
-    # SSLSessionTickets is supported by Apache 2.4.11 or later.
-    # The following line can be enabled when trusty support is dropped.
-    # https://httpd.apache.org/docs/trunk/mod/mod_ssl.html#sslsessiontickets
-    # SSLSessionTickets off
 
     SSLCertificateFile /etc/apache2/ssl/{{ namespace }}/cert_{{ endpoint }}
     # See LP 1484489 - this is to support <= 2.4.7 and >= 2.4.8


### PR DESCRIPTION
The last update was 2016, and it's time to drop TLSv1 and TLSv1.1 as the
base configuration recommended by Mozilla.
https://wiki.mozilla.org/Security/Server_Side_TLS

Follow-up of the following commits:
cac799b31e94341c7ff03f6bda2d5688bcb1b483
14ca7a00ea99bce03261f14abfba020281437d90

Closes-Bug: LP: #1886630