### PR TITLE
contrib/ovs: Fix deletion of virtual bridge ports

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -246,20 +246,23 @@ def add_bridge_port(name, port, promisc=False, ifdata=None, exclusive=False,
         subprocess.check_call(["ip", "link", "set", port, "promisc", "off"])
 
 
-def del_bridge_port(name, port):
+def del_bridge_port(name, port, linkdown=True):
     """Delete a port from the named openvswitch bridge
 
     :param name: Name of bridge to remove port from
     :type name: str
     :param port: Name of port to remove
     :type port: str
+    :param linkdown: Whether to set link down on interface (default: True)
+    :type linkdown: bool
     :raises: subprocess.CalledProcessError
     """
     log('Deleting port {} from bridge {}'.format(port, name))
     subprocess.check_call(["ovs-vsctl", "--", "--if-exists", "del-port",
                            name, port])
-    subprocess.check_call(["ip", "link", "set", port, "down"])
-    subprocess.check_call(["ip", "link", "set", port, "promisc", "off"])
+    if linkdown:
+        subprocess.check_call(["ip", "link", "set", port, "down"])
+        subprocess.check_call(["ip", "link", "set", port, "promisc", "off"])
 
 
 def add_bridge_bond(bridge, port, interfaces, portdata=None, ifdatamap=None,

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -125,6 +125,23 @@ class TestOVS(test_utils.BaseTestCase):
             mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
         ])
 
+    def test_del_bridge_port(self):
+        self.patch_object(ovs.subprocess, 'check_call')
+        self.patch_object(ovs, 'log')
+        ovs.del_bridge_port('test', 'eth1')
+        self.check_call.assert_has_calls([
+            mock.call(['ovs-vsctl', '--', '--if-exists', 'del-port',
+                       'test', 'eth1']),
+            mock.call(['ip', 'link', 'set', 'eth1', 'down']),
+            mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
+        ])
+        self.assertTrue(self.log.call_count == 1)
+        self.assertTrue(self.check_call.call_count == 3)
+        self.check_call.reset_mock()
+        ovs.del_bridge_port('test', 'eth1', linkdown=False)
+        self.check_call.assert_called_once_with(
+            ['ovs-vsctl', '--', '--if-exists', 'del-port', 'test', 'eth1'])
+
     def test_ovs_appctl(self):
         self.patch_object(ovs.subprocess, 'check_output')
         ovs.ovs_appctl('ovs-vswitchd', ('ofproto/list',))

--- a/tests/contrib/network/test_ovs.py
+++ b/tests/contrib/network/test_ovs.py
@@ -1,7 +1,7 @@
 import subprocess
 import unittest
 
-from mock import patch, call, MagicMock
+from mock import patch, MagicMock
 
 import charmhelpers.contrib.network.ovs as ovs
 
@@ -161,17 +161,6 @@ class OVSHelpersTest(unittest.TestCase):
         ovs.del_bridge('test')
         check_call.assert_called_with(["ovs-vsctl", "--", "--if-exists",
                                        "del-br", 'test'])
-        self.assertTrue(self.log.call_count == 1)
-
-    @patch('subprocess.check_call')
-    def test_del_bridge_port(self, check_call):
-        ovs.del_bridge_port('test', 'eth1')
-        check_call.assert_has_calls([
-            call(["ovs-vsctl", "--", "--if-exists", "del-port",
-                  'test', 'eth1']),
-            call(['ip', 'link', 'set', 'eth1', 'down']),
-            call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
-        ])
         self.assertTrue(self.log.call_count == 1)
 
     @patch.object(ovs, 'port_to_br')


### PR DESCRIPTION
The OVS `del_bridge_port` helper currently assumes it will be used
with interfaces that actually exist in the system.

This is not always the case. Add arguments that allow the caller
to decide whether a interface link and promiscuous settings should
be touched after removing the port from a OVS bridge. Defaults to
being compatible with the current behaviour.