### PR TITLE
Fix directory /etc/nagios/nrpe.d/  issue

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -18,7 +18,6 @@
 # Authors:
 #  Matthew Wedgwood <matthew.wedgwood@canonical.com>
 
-import errno
 import glob
 import grp
 import os
@@ -267,21 +266,9 @@ class NRPE(object):
         self.remove_check_queue = set()
 
     @classmethod
-    def can_write_nrpe_conf_dir(cls):
-        """Return True if can write to the nrpe_confdif directory."""
-        try:
-            test_file = os.path.join(cls.nrpe_confdir, "__test_write__")
-            with open(test_file, "wt") as f:
-                f.write("test write")
-            os.remove(test_file)
-        except EnvironmentError as e:
-            if e.errno != errno.ENOENT:
-                log("Unhandled error when checking if can write to {}: '{}'"
-                    .format(cls.nrpe_confdir, str(e)))
-            else:
-                log("Can't write to {} yet: nagios not installed?")
-            return False
-        return True
+    def does_nrpe_conf_dir_exist(cls):
+        """Return True if th nrpe_confdif directory exists."""
+        return os.path.isdir(cls.nrpe_confdir)
 
     def add_check(self, *args, **kwargs):
         shortname = None
@@ -331,7 +318,7 @@ class NRPE(object):
 
         # check that the charm can write to the conf dir.  If not, then nagios
         # probably isn't installed, and we can defer.
-        if not self.can_write_nrpe_conf_dir():
+        if not self.does_nrpe_conf_dir_exist():
             return
 
         for nrpecheck in self.checks:

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -145,10 +145,9 @@ class NRPETestCase(NRPEBaseTestCase):
 
         self.assertEqual(None, checker.write())
 
-        self.assertEqual(3, self.patched['open'].call_count)
+        self.assertEqual(2, self.patched['open'].call_count)
         filename = 'check_myservice.cfg'
         expected = [
-            ('/etc/nagios/nrpe.d/__test_write__', 'wt'),
             ('/etc/nagios/nrpe.d/%s' % filename, 'w'),
             ('/var/lib/nagios/export/service__a-testunit_%s' % filename, 'w'),
         ]
@@ -168,7 +167,6 @@ define service {
 }
 """
         expected = [
-            'test write',
             '# check myservice\n',
             '# The following header was added automatically by juju\n',
             '# Modifying it will affect nagios monitoring and alerting\n',
@@ -189,7 +187,7 @@ define service {
         ]
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
-                               exists=4, open=3, listdir=1, relation_get=2,
+                               exists=4, open=2, listdir=1, relation_get=2,
                                relation_ids=3, relation_set=3)
 
 

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -145,9 +145,10 @@ class NRPETestCase(NRPEBaseTestCase):
 
         self.assertEqual(None, checker.write())
 
-        self.assertEqual(2, self.patched['open'].call_count)
+        self.assertEqual(3, self.patched['open'].call_count)
         filename = 'check_myservice.cfg'
         expected = [
+            ('/etc/nagios/nrpe.d/__test_write__', 'wt'),
             ('/etc/nagios/nrpe.d/%s' % filename, 'w'),
             ('/var/lib/nagios/export/service__a-testunit_%s' % filename, 'w'),
         ]
@@ -167,6 +168,7 @@ define service {
 }
 """
         expected = [
+            'test write',
             '# check myservice\n',
             '# The following header was added automatically by juju\n',
             '# Modifying it will affect nagios monitoring and alerting\n',
@@ -187,7 +189,7 @@ define service {
         ]
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
-                               exists=4, open=2, listdir=1, relation_get=2,
+                               exists=4, open=3, listdir=1, relation_get=2,
                                relation_ids=3, relation_set=3)
 
 


### PR DESCRIPTION
Under certain deployment conditions, the charm can attempt to write to
the /etc/nagios/nrpe.d/ directory before it exists.  This directory is
created by the nrpe charm, but if the hacluster gets installed first,
then it can be triggered to attempt to set up the nrpe entries before
the directory can be created by nrpe.  This change (and the associated
charm-helpers change) ensures that the charm will delay the nrpe config
until the directory is available (and thus, the nrpe charm is fully
installed)

Related Bug: LP: #1882557