### PR TITLE
Changing the master/slave words

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Compatibility with the nrpe-external-master charm"""
+"""Compatibility with the nrpe-external-main charm"""
 # Copyright 2012 Canonical Ltd.
 #
 # Authors:
@@ -42,15 +42,15 @@ from charmhelpers.core.hookenv import (
 from charmhelpers.core.host import service
 from charmhelpers.core import host
 
-# This module adds compatibility with the nrpe-external-master and plain nrpe
+# This module adds compatibility with the nrpe-external-main and plain nrpe
 # subordinate charms. To use it in your charm:
 #
 # 1. Update metadata.yaml
 #
 #   provides:
 #     (...)
-#     nrpe-external-master:
-#       interface: nrpe-external-master
+#     nrpe-external-main:
+#       interface: nrpe-external-main
 #       scope: container
 #
 #   and/or
@@ -81,7 +81,7 @@ from charmhelpers.core import host
 #        A comma-separated list of nagios servicegroups.
 #        If left empty, the nagios_context will be used as the servicegroup
 #
-# 3. Add custom checks (Nagios plugins) to files/nrpe-external-master
+# 3. Add custom checks (Nagios plugins) to files/nrpe-external-main
 #
 # 4. Update your hooks.py with something like this:
 #
@@ -105,7 +105,7 @@ from charmhelpers.core import host
 #        (...)
 #        update_nrpe_config()
 #
-#    def nrpe_external_master_relation_changed():
+#    def nrpe_external_main_relation_changed():
 #        update_nrpe_config()
 #
 #    def local_monitors_relation_changed():
@@ -118,7 +118,7 @@ from charmhelpers.core import host
 #    def update_nrpe_config():
 #        nrpe_compat = NRPE(primary=False)
 #
-# 5. ln -s hooks.py nrpe-external-master-relation-changed
+# 5. ln -s hooks.py nrpe-external-main-relation-changed
 #    ln -s hooks.py local-monitors-relation-changed
 
 
@@ -257,8 +257,8 @@ class NRPE(object):
             else:
                 self.hostname = "{}-{}".format(self.nagios_context, self.unit_name)
         self.checks = []
-        # Iff in an nrpe-external-master relation hook, set primary status
-        relation = relation_ids('nrpe-external-master')
+        # Iff in an nrpe-external-main relation hook, set primary status
+        relation = relation_ids('nrpe-external-main')
         if relation:
             log("Setting charm primary status {}".format(primary))
             for rid in relation:
@@ -336,7 +336,7 @@ class NRPE(object):
             service('restart', 'nagios-nrpe-server')
 
         monitor_ids = relation_ids("local-monitors") + \
-            relation_ids("nrpe-external-master")
+            relation_ids("nrpe-external-main")
         for rid in monitor_ids:
             reldata = relation_get(unit=local_unit(), rid=rid)
             if 'monitors' in reldata:
@@ -358,7 +358,7 @@ class NRPE(object):
         self.remove_check_queue.clear()
 
 
-def get_nagios_hostcontext(relation_name='nrpe-external-master'):
+def get_nagios_hostcontext(relation_name='nrpe-external-main'):
     """
     Query relation with nrpe subordinate, return the nagios_host_context
 
@@ -369,7 +369,7 @@ def get_nagios_hostcontext(relation_name='nrpe-external-master'):
             return rel['nagios_host_context']
 
 
-def get_nagios_hostname(relation_name='nrpe-external-master'):
+def get_nagios_hostname(relation_name='nrpe-external-main'):
     """
     Query relation with nrpe subordinate, return the nagios_hostname
 
@@ -380,7 +380,7 @@ def get_nagios_hostname(relation_name='nrpe-external-master'):
             return rel['nagios_hostname']
 
 
-def get_nagios_unit_name(relation_name='nrpe-external-master'):
+def get_nagios_unit_name(relation_name='nrpe-external-main'):
     """
     Return the nagios unit name prepended with host_context if needed
 

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -35,7 +35,7 @@ BRIDGE_TEMPLATE = """\
 auto {linuxbridge_port}
 iface {linuxbridge_port} inet manual
     pre-up ip link add name {linuxbridge_port} type veth peer name {ovsbridge_port}
-    pre-up ip link set {ovsbridge_port} master {bridge}
+    pre-up ip link set {ovsbridge_port} main {bridge}
     pre-up ip link set {ovsbridge_port} up
     up ip link set {linuxbridge_port} up
     down ip link del {linuxbridge_port}

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -63,7 +63,7 @@ from charmhelpers.core.strutils import bool_from_string
 from charmhelpers.contrib.openstack.exceptions import OSContextError
 
 from charmhelpers.core.host import (
-    get_bond_master,
+    get_bond_main,
     is_phy_iface,
     list_nics,
     get_nic_hwaddr,
@@ -1329,14 +1329,14 @@ class NeutronPortContext(OSContextGenerator):
         extant_nics = list_nics()
 
         for nic in extant_nics:
-            # Ignore virtual interfaces (bond masters will be identified from
-            # their slaves)
+            # Ignore virtual interfaces (bond mains will be identified from
+            # their subordinates)
             if not is_phy_iface(nic):
                 continue
 
-            _nic = get_bond_master(nic)
+            _nic = get_bond_main(nic)
             if _nic:
-                log("Replacing iface '%s' with bond master '%s'" % (nic, _nic),
+                log("Replacing iface '%s' with bond main '%s'" % (nic, _nic),
                     level=DEBUG)
                 nic = _nic
 
@@ -2721,7 +2721,7 @@ class BridgePortInterfaceMap(object):
             self._mac_ifname_map[mac] = ifname
 
             # check if interface is part of a linux bond
-            _bond_name = get_bond_master(ifname)
+            _bond_name = get_bond_main(ifname)
             if _bond_name and _bond_name != ifname:
                 log('Add linux bond "{}" to map for physical interface "{}" '
                     'with mac "{}".'.format(_bond_name, ifname, mac),
@@ -2857,7 +2857,7 @@ class BridgePortInterfaceMap(object):
         :rtype: str
         :raises: KeyError
         """
-        return (get_bond_master(self._mac_ifname_map[mac]) or
+        return (get_bond_main(self._mac_ifname_map[mac]) or
                 self._mac_ifname_map[mac])
 
     def macs_from_ifname(self, ifname):

--- a/charmhelpers/contrib/unison/__init__.py
+++ b/charmhelpers/contrib/unison/__init__.py
@@ -56,7 +56,7 @@
 # that the calling charm takes care of leader delegation.
 #
 # Additionally files can be synchronized only to an specific unit:
-# sync_to_peer(slave_address, user='juju_ssh',
+# sync_to_peer(subordinate_address, user='juju_ssh',
 #              paths=[files], verbose=False)
 
 import os

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -793,8 +793,8 @@ def is_phy_iface(interface):
     return False
 
 
-def get_bond_master(interface):
-    """Returns bond master if interface is bond slave otherwise None.
+def get_bond_main(interface):
+    """Returns bond main if interface is bond subordinate otherwise None.
 
     NOTE: the provided interface is expected to be physical
     """
@@ -804,12 +804,12 @@ def get_bond_master(interface):
             if '/virtual/' in os.path.realpath(iface_path):
                 return None
 
-            master = os.path.join(iface_path, 'master')
-            if os.path.exists(master):
-                master = os.path.realpath(master)
-                # make sure it is a bond master
-                if os.path.exists(os.path.join(master, 'bonding')):
-                    return os.path.basename(master)
+            main = os.path.join(iface_path, 'main')
+            if os.path.exists(main):
+                main = os.path.realpath(main)
+                # make sure it is a bond main
+                if os.path.exists(os.path.join(main, 'bonding')):
+                    return os.path.basename(main)
 
     return None
 

--- a/charmhelpers/fetch/giturl.py
+++ b/charmhelpers/fetch/giturl.py
@@ -40,7 +40,7 @@ class GitUrlFetchHandler(BaseFetchHandler):
         else:
             return True
 
-    def clone(self, source, dest, branch="master", depth=None):
+    def clone(self, source, dest, branch="main", depth=None):
         if not self.can_handle(source):
             raise UnhandledSource("Cannot handle {}".format(source))
 
@@ -52,7 +52,7 @@ class GitUrlFetchHandler(BaseFetchHandler):
                 cmd.extend(['--depth', depth])
         check_output(cmd, stderr=STDOUT)
 
-    def install(self, source, branch="master", dest=None, depth=None):
+    def install(self, source, branch="main", dest=None, depth=None):
         url_parts = self.parse_url(source)
         branch_name = url_parts.path.strip("/").split("/")[-1]
         if dest:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,8 +44,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Charm Helpers'

--- a/tests/contrib/ansible/test_ansible.py
+++ b/tests/contrib/ansible/test_ansible.py
@@ -91,7 +91,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
         self.mock_relations.return_value = {
             'wsgi-file': {},
             'website': {},
-            'nrpe-external-master': {},
+            'nrpe-external-main': {},
         }
         self.addCleanup(patcher.stop)
         patcher = mock.patch('charmhelpers.core.hookenv.relations_of_type')
@@ -177,12 +177,12 @@ class ApplyPlaybookTestCases(unittest.TestCase):
                     'relation-key2': 'relation_value2',
                 },
                 'relations_full': {
-                    'nrpe-external-master': {},
+                    'nrpe-external-main': {},
                     'website': {},
                     'wsgi-file': {},
                 },
                 'relations': {
-                    'nrpe-external-master': [],
+                    'nrpe-external-main': [],
                     'website': [],
                     'wsgi-file': [],
                 },

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -133,7 +133,7 @@ class NRPETestCase(NRPEBaseTestCase):
         def _rels(rname):
             relations = {
                 'local-monitors': 'local-monitors:1',
-                'nrpe-external-master': 'nrpe-external-master:2',
+                'nrpe-external-main': 'nrpe-external-main:2',
             }
             return [relations[rname]]
         self.patched['relation_ids'].side_effect = _rels
@@ -183,7 +183,7 @@ define service {
             {"monitors": {"remote": {"nrpe": nrpe_monitors}}})
         relation_set_calls = [
             call(monitors=monitors, relation_id="local-monitors:1"),
-            call(monitors=monitors, relation_id="nrpe-external-master:2"),
+            call(monitors=monitors, relation_id="nrpe-external-main:2"),
         ]
         self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
         self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
@@ -277,7 +277,7 @@ class NRPEMiscTestCase(NRPEBaseTestCase):
             'nagios_hostname': 'bob-openstack-dashboard-0',
             'private-address': '10.5.3.103',
             '__unit__': u'dashboard-nrpe/1',
-            '__relid__': u'nrpe-external-master:2',
+            '__relid__': u'nrpe-external-main:2',
             'nagios_host_context': u'bob',
         }
         self.patched['relations_of_type'].return_value = [rel_info]
@@ -288,7 +288,7 @@ class NRPEMiscTestCase(NRPEBaseTestCase):
             'nagios_hostname': 'bob-openstack-dashboard-0',
             'private-address': '10.5.3.103',
             '__unit__': u'dashboard-nrpe/1',
-            '__relid__': u'nrpe-external-master:2',
+            '__relid__': u'nrpe-external-main:2',
             'nagios_host_context': u'bob',
         }
         self.patched['relations_of_type'].return_value = [rel_info]
@@ -299,7 +299,7 @@ class NRPEMiscTestCase(NRPEBaseTestCase):
             'nagios_hostname': 'bob-openstack-dashboard-0',
             'private-address': '10.5.3.103',
             '__unit__': u'dashboard-nrpe/1',
-            '__relid__': u'nrpe-external-master:2',
+            '__relid__': u'nrpe-external-main:2',
             'nagios_host_context': u'bob',
         }
         self.patched['relations_of_type'].return_value = [rel_info]

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4549,8 +4549,8 @@ class TestBridgePortInterfaceMap(tests.utils.BaseTestCase):
         self.patch_object(context, 'is_phy_iface')
         self.is_phy_iface.side_effect = lambda x: True if not x.startswith(
             'bond') else False
-        self.patch_object(context, 'get_bond_master')
-        self.get_bond_master.side_effect = lambda x: 'bond0' if x in (
+        self.patch_object(context, 'get_bond_main')
+        self.get_bond_main.side_effect = lambda x: 'bond0' if x in (
             'eth0', 'eth1') else None
         self.patch_object(context, 'get_nic_hwaddr')
         self.get_nic_hwaddr.side_effect = lambda x: {

--- a/tests/contrib/templating/test_contexts.py
+++ b/tests/contrib/templating/test_contexts.py
@@ -38,7 +38,7 @@ class JujuState2YamlTestCase(unittest.TestCase):
         self.mock_relations.return_value = {
             'wsgi-file': {},
             'website': {},
-            'nrpe-external-master': {},
+            'nrpe-external-main': {},
         }
         self.addCleanup(patcher.stop)
         patcher = mock.patch('charmhelpers.core.hookenv.relation_type')
@@ -81,12 +81,12 @@ class JujuState2YamlTestCase(unittest.TestCase):
             "relations_full": {
                 'wsgi-file': {},
                 'website': {},
-                'nrpe-external-master': {},
+                'nrpe-external-main': {},
             },
             "relations": {
                 'wsgi-file': [],
                 'website': [],
-                'nrpe-external-master': [],
+                'nrpe-external-main': [],
             },
             "local_unit": "click-index/3",
             "unit_private_address": "10.0.3.2",
@@ -146,7 +146,7 @@ class JujuState2YamlTestCase(unittest.TestCase):
                 },
             },
             'website': {},
-            'nrpe-external-master': {},
+            'nrpe-external-main': {},
         }
         self.mock_local_unit.return_value = "click-index/3"
 

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -50,12 +50,12 @@ ID="centos"
 '''
 
 IP_LINE_ETH0 = b"""
-2: eth0: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+2: eth0: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq main bond0 state UP qlen 1000
     link/ether e4:11:5b:ab:a7:3c brd ff:ff:ff:ff:ff:ff
 """
 
 IP_LINE_ETH100 = b"""
-2: eth100: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+2: eth100: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq main bond0 state UP qlen 1000
     link/ether e4:11:5b:ab:a7:3d brd ff:ff:ff:ff:ff:ff
 """
 
@@ -1699,7 +1699,7 @@ class HelpersTest(TestCase):
     @patch('os.path.exists')
     @patch('os.path.realpath')
     @patch('os.path.isdir')
-    def test_get_bond_master(self, mock_isdir, mock_realpath, mock_exists):
+    def test_get_bond_main(self, mock_isdir, mock_realpath, mock_exists):
         mock_isdir.return_value = True
 
         def fake_realpath(soft):
@@ -1708,7 +1708,7 @@ class HelpersTest(TestCase):
                         '/0000:02:00.1/net/eth0')
             elif soft.endswith('/br0'):
                 return '/sys/devices/virtual/net/br0'
-            elif soft.endswith('/master'):
+            elif soft.endswith('/main'):
                 return '/sys/devices/virtual/net/bond0'
 
             return None
@@ -1718,8 +1718,8 @@ class HelpersTest(TestCase):
 
         mock_exists.side_effect = fake_exists
         mock_realpath.side_effect = fake_realpath
-        self.assertEqual(host.get_bond_master('eth0'), 'bond0')
-        self.assertIsNone(host.get_bond_master('br0'))
+        self.assertEqual(host.get_bond_main('eth0'), 'bond0')
+        self.assertIsNone(host.get_bond_main('br0'))
 
     @patch('subprocess.check_output')
     def test_list_nics(self, check_output):

--- a/tests/fetch/test_giturl.py
+++ b/tests/fetch/test_giturl.py
@@ -52,7 +52,7 @@ class GitUrlFetchHandlerTest(TestCase):
     @patch.object(giturl, 'check_output')
     def test_clone(self, check_output):
         dest_path = "/destination/path"
-        branch = "master"
+        branch = "main"
         for url in self.valid_urls:
             self.fh.remote_branch = MagicMock()
             self.fh.load_plugins = MagicMock()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.