### PR TITLE
Add support for Erasure Coded pools

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -58,6 +58,7 @@ from charmhelpers.core.hookenv import (
     status_set,
     network_get_primary_address,
     WARNING,
+    service_name,
 )
 
 from charmhelpers.core.sysctl import create as sysctl_create
@@ -809,6 +810,12 @@ class CephContext(OSContextGenerator):
                     mon_hosts.append(format_ipv6_addr(priv_addr) or priv_addr)
 
         ctxt['mon_hosts'] = ' '.join(sorted(mon_hosts))
+
+        if config('pool-type') and config('pool-type') == 'erasure-coded':
+            base_pool_name = config('rbd-pool') or config('rbd-pool-name')
+            if not base_pool_name:
+                base_pool_name = service_name()
+            ctxt['rbd_default_data_pool'] = base_pool_name
 
         if not os.path.isdir('/etc/ceph'):
             os.mkdir('/etc/ceph')

--- a/charmhelpers/contrib/openstack/templates/ceph.conf
+++ b/charmhelpers/contrib/openstack/templates/ceph.conf
@@ -22,3 +22,7 @@ rbd default features = {{ rbd_features }}
 {{ key }} = {{ value }}
 {% endfor -%}
 {%- endif %}
+
+{% if rbd_default_data_pool -%}
+rbd default data pool = {{ rbd_default_data_pool }}
+{% endif %}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1853,6 +1853,113 @@ class ContextTests(unittest.TestCase):
     @patch('os.path.isdir')
     @patch('os.mkdir')
     @patch.object(context, 'ensure_packages')
+    def test_ceph_context_ec_pool_no_rbd_pool(
+            self, ensure_packages, mkdir, isdir, mock_config):
+        '''Test ceph context with erasure coded pools'''
+        isdir.return_value = False
+        config_dict = {
+            'use-syslog': True,
+            'pool-type': 'erasure-coded'
+        }
+
+        def fake_config(key):
+            return config_dict.get(key)
+
+        mock_config.side_effect = fake_config
+        relation = FakeRelation(relation_data=CEPH_REL_WITH_DEFAULT_FEATURES)
+        self.relation_get.side_effect = relation.get
+        self.relation_ids.side_effect = relation.relation_ids
+        self.related_units.side_effect = relation.relation_units
+        ceph = context.CephContext()
+        result = ceph()
+        expected = {
+            'mon_hosts': 'ceph_node1 ceph_node2',
+            'auth': 'foo',
+            'key': 'bar',
+            'use_syslog': 'true',
+            'rbd_features': '1',
+            'rbd_default_data_pool': 'testing-foo',
+        }
+        self.assertEquals(result, expected)
+        ensure_packages.assert_called_with(['ceph-common'])
+        mkdir.assert_called_with('/etc/ceph')
+
+    @patch.object(context, 'config')
+    @patch('os.path.isdir')
+    @patch('os.mkdir')
+    @patch.object(context, 'ensure_packages')
+    def test_ceph_context_ec_pool_rbd_pool(
+            self, ensure_packages, mkdir, isdir, mock_config):
+        '''Test ceph context with erasure coded pools'''
+        isdir.return_value = False
+        config_dict = {
+            'use-syslog': True,
+            'pool-type': 'erasure-coded',
+            'rbd-pool': 'glance'
+        }
+
+        def fake_config(key):
+            return config_dict.get(key)
+
+        mock_config.side_effect = fake_config
+        relation = FakeRelation(relation_data=CEPH_REL_WITH_DEFAULT_FEATURES)
+        self.relation_get.side_effect = relation.get
+        self.relation_ids.side_effect = relation.relation_ids
+        self.related_units.side_effect = relation.relation_units
+        ceph = context.CephContext()
+        result = ceph()
+        expected = {
+            'mon_hosts': 'ceph_node1 ceph_node2',
+            'auth': 'foo',
+            'key': 'bar',
+            'use_syslog': 'true',
+            'rbd_features': '1',
+            'rbd_default_data_pool': 'glance',
+        }
+        self.assertEquals(result, expected)
+        ensure_packages.assert_called_with(['ceph-common'])
+        mkdir.assert_called_with('/etc/ceph')
+
+    @patch.object(context, 'config')
+    @patch('os.path.isdir')
+    @patch('os.mkdir')
+    @patch.object(context, 'ensure_packages')
+    def test_ceph_context_ec_pool_rbd_pool_name(
+            self, ensure_packages, mkdir, isdir, mock_config):
+        '''Test ceph context with erasure coded pools'''
+        isdir.return_value = False
+        config_dict = {
+            'use-syslog': True,
+            'pool-type': 'erasure-coded',
+            'rbd-pool-name': 'nova'
+        }
+
+        def fake_config(key):
+            return config_dict.get(key)
+
+        mock_config.side_effect = fake_config
+        relation = FakeRelation(relation_data=CEPH_REL_WITH_DEFAULT_FEATURES)
+        self.relation_get.side_effect = relation.get
+        self.relation_ids.side_effect = relation.relation_ids
+        self.related_units.side_effect = relation.relation_units
+        ceph = context.CephContext()
+        result = ceph()
+        expected = {
+            'mon_hosts': 'ceph_node1 ceph_node2',
+            'auth': 'foo',
+            'key': 'bar',
+            'use_syslog': 'true',
+            'rbd_features': '1',
+            'rbd_default_data_pool': 'nova',
+        }
+        self.assertEquals(result, expected)
+        ensure_packages.assert_called_with(['ceph-common'])
+        mkdir.assert_called_with('/etc/ceph')
+
+    @patch.object(context, 'config')
+    @patch('os.path.isdir')
+    @patch('os.mkdir')
+    @patch.object(context, 'ensure_packages')
     def test_ceph_context_with_rbd_cache(self, ensure_packages, mkdir, isdir,
                                          mock_config):
         isdir.return_value = False


### PR DESCRIPTION
Add support in the ceph module for creation of new erasure coding
profiles and support for setting the allow_ec_overwrites property
on erasure coded pools.  This is required to support RBD use
cases.

Update OpenStack Ceph context to detect use of EC pool type,
providing an appropriate value for the rbd default data pool
for use in ceph.conf.

This last part is a bit of a workaround due to the fact that
OpenStack services don't have native configuration options to
set the metadata and data pool options when creating new RBD
images.

Add support for configuration and validation of the erasure
plugin technique as part of the erasure profile creation.