### PR TITLE
Pin path version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,8 @@ mock>=1.0.1,<1.1.0
 nose>=1.3.1
 flake8
 testtools==0.9.14  # Before dependent on modern 'six'
+# path 14.0.0 renamed `tempdir` to TempDir and breaks Amulet.
+path<14.0.0;python_version >= '3.5'
 amulet
 distro-info
 sphinx_rtd_theme


### PR DESCRIPTION
path 14.0.0 renamed `tempdir` to TempDir and breaks Amulet.