### PR TITLE
Ansible: add proxy settings support

### DIFF
--- a/charmhelpers/contrib/ansible/__init__.py
+++ b/charmhelpers/contrib/ansible/__init__.py
@@ -199,6 +199,9 @@ def apply_playbook(playbook, tags=None, extra_vars=None):
 
     # we want ansible's log output to be unbuffered
     env = os.environ.copy()
+    proxy_settings = charmhelpers.core.hookenv.env_proxy_settings()
+    if proxy_settings:
+        env.update(proxy_settings)
     env['PYTHONUNBUFFERED'] = "1"
     call = [
         'ansible-playbook',


### PR DESCRIPTION
If a Juju environment exposes proxy settings, the call to
ansible-playbook needs to use http(s) proxy settings or it could
potentially fail due to network timeout.