### PR TITLE
contrib/ceph: Include common properties when comparing op equality

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1972,12 +1972,14 @@ class CephBrokerRq(object):
                            'request-id': self.request_id})
 
     def _ops_equal(self, other):
+        keys_to_compare = [
+            'replicas', 'name', 'op', 'pg_num', 'group-permission',
+            'object-prefix-permissions',
+        ]
+        keys_to_compare += list(self._partial_build_common_op_create().keys())
         if len(self.ops) == len(other.ops):
             for req_no in range(0, len(self.ops)):
-                for key in [
-                        'replicas', 'name', 'op', 'pg_num', 'weight',
-                        'group', 'group-namespace', 'group-permission',
-                        'object-prefix-permissions']:
+                for key in keys_to_compare:
                     if self.ops[req_no].get(key) != other.ops[req_no].get(key):
                         return False
         else:

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1578,6 +1578,17 @@ class CephUtilsTests(TestCase):
         rq2.add_op_request_access_to_group(name='objects',
                                            permission='r')
         self.assertFalse(rq1 == rq2)
+        # now check equality check for common properties
+        rq1 = ceph_utils.CephBrokerRq()
+        rq1.add_op_create_replicated_pool('pool1')
+        rq2 = ceph_utils.CephBrokerRq()
+        rq2.add_op_create_replicated_pool('pool1')
+        self.assertTrue(rq1 == rq2)
+        rq1 = ceph_utils.CephBrokerRq()
+        rq1.add_op_create_replicated_pool('pool1', compression_mode='none')
+        rq2 = ceph_utils.CephBrokerRq()
+        rq2.add_op_create_replicated_pool('pool1', compression_mode='passive')
+        self.assertFalse(rq1 == rq2)
 
     def test_ceph_broker_rsp_class(self):
         rsp = ceph_utils.CephBrokerRsp(json.dumps({'exit-code': 0,


### PR DESCRIPTION
At present a static set of keys are checked when comparing two
CephBrokerRq objects. Extend the list with the properties known
by the `_partial_build_common_op_create` method.