### PR TITLE
contrib/openstack: Add bluestore compression get_kwargs method

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -3245,6 +3245,18 @@ class CephBlueStoreCompressionContext(OSContextGenerator):
         """
         return self.op
 
+    def get_kwargs(self):
+        """Get values for use as keyword arguments.
+
+        :returns: Context values with key suitable for use as kwargs to
+                  CephBrokerRq add_op_create_*_pool methods.
+        :rtype: Dict[str,any]
+        """
+        return {
+            k.replace('-', '_'): v
+            for k, v in self.op.items()
+        }
+
     def validate(self):
         """Validate options.
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4982,6 +4982,14 @@ class TestCephBlueStoreContext(tests.utils.BaseTestCase):
         ctxt = context.CephBlueStoreCompressionContext()
         self.assertDictEqual(ctxt.get_op(), self.expected_op)
 
+    def test_get_kwargs(self):
+        ctxt = context.CephBlueStoreCompressionContext()
+        expect = {
+            k.replace('-', '_'): v
+            for k, v in self.expected_op.items()
+        }
+        self.assertDictEqual(ctxt.get_kwargs(), expect)
+
     def test_validate(self):
         self.patch_object(context.ch_ceph, 'BasePool')
         pool = MagicMock()

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4984,11 +4984,8 @@ class TestCephBlueStoreContext(tests.utils.BaseTestCase):
 
     def test_get_kwargs(self):
         ctxt = context.CephBlueStoreCompressionContext()
-        expect = {
-            k.replace('-', '_'): v
-            for k, v in self.expected_op.items()
-        }
-        self.assertDictEqual(ctxt.get_kwargs(), expect)
+        for arg in ctxt.get_kwargs().keys():
+            self.assertNotIn('-', arg, "get_kwargs() returned '-' in the key")
 
     def test_validate(self):
         self.patch_object(context.ch_ceph, 'BasePool')


### PR DESCRIPTION
The get_kwargs method provides a Dict with keys suitable for use
as kwargs to CephBrokerRq add_op_create_*_pool methods.