### PR TITLE
ovs: Fix error in patch_ports_on_bridge

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -649,6 +649,11 @@ def patch_ports_on_bridge(bridge):
                         interface['options']['peer'])),
                     interface['options']['peer'])
                 yield(Patch(this_end, other_end))
+            # We expect one result and it is ok if it turns out to be a port
+            # for a different bridge. However we need a break here to satisfy
+            # the for/else check which is in place to detect interface refering
+            # to non-existent port.
+            break
         else:
             raise ValueError('Port for interface named "{}" does unexpectedly '
                              'not exist.'.format(interface['name']))


### PR DESCRIPTION
The unit test for patch_ports_on_bridge was not quite good enough
and hid the fact that the function now always raises `ValueError`.

This patch fixes both.