### PR TITLE
contrib/ovs: Handle ovs-vsctl's duality on list type fields

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -618,7 +618,11 @@ def bridge_for_port(port_uuid):
     """
     for bridge in ch_ovsdb.SimpleOVSDB(
             'ovs-vsctl').bridge:
-        if port_uuid in bridge['ports']:
+        # If there is a single port on a bridge the ports property will not be
+        # a list. ref: juju/charm-helpers#510
+        if (isinstance(bridge['ports'], list) and
+                port_uuid in bridge['ports'] or
+                port_uuid == bridge['ports']):
             return bridge['name']
 
 

--- a/charmhelpers/contrib/network/ovs/ovsdb.py
+++ b/charmhelpers/contrib/network/ovs/ovsdb.py
@@ -36,6 +36,11 @@ class SimpleOVSDB(object):
     for br in ovsdb.bridge:
         if br['name'] == 'br-test':
             ovsdb.bridge.set(br['uuid'], 'external_ids:charm', 'managed')
+
+    WARNING: If a list type field only have one item `ovs-vsctl` will present
+    it as a single item. Since we do not know the schema we have no way of
+    knowing what fields should be de-serialized as lists so the caller has
+    to be careful of checking the type of values returned from this library.
     """
 
     # For validation we keep a complete map of currently known good tool and

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -215,6 +215,15 @@ class TestOVS(test_utils.BaseTestCase):
         ]
         self.SimpleOVSDB.return_value = ovsdb
         self.assertEquals(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
+        # If there is a single port on a bridge the ports property will not be
+        # a list. ref: juju/charm-helpers#510
+        ovsdb.bridge.__iter__.return_value = [
+            {
+                'name': 'fake-bridge',
+                'ports': fake_uuid,
+            },
+        ]
+        self.assertEquals(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
 
     def test_patch_ports_on_bridge(self):
         self.patch_object(ovs.ch_ovsdb, 'SimpleOVSDB')


### PR DESCRIPTION
Document that if a list type field only have one item `ovs-vsctl` will present it as a single item. Since we do not know the schema we have no way of knowing what fields should be de-serialized as lists so the caller has to be careful of checking the type of values returned from the SimpleOVSDB API.

Also handle this in the one higher level helper in charm-helpers that is affected by this.

Fixes #510