### PR TITLE
Make EC profiles immutable

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1074,7 +1074,10 @@ def create_erasure_profile(service, profile_name,
                            erasure_plugin_technique=None):
     """Create a new erasure code profile if one does not already exist for it.
 
-    Updates the profile if it exists. Please refer to [0] for more details.
+    Profiles are considered immutable so will not be updated if the named
+    profile already exists.
+
+    Please refer to [0] for more details.
 
     0: http://docs.ceph.com/docs/master/rados/operations/erasure-code-profile/
 
@@ -1110,6 +1113,9 @@ def create_erasure_profile(service, profile_name,
     :type erasure_plugin_technique: str
     :return: None.  Can raise CalledProcessError, ValueError or AssertionError
     """
+    if erasure_profile_exists(service, profile_name):
+        return
+
     plugin_techniques = {
         'jerasure': [
             'reed_sol_van',
@@ -1208,9 +1214,6 @@ def create_erasure_profile(service, profile_name,
             cmd.append('d={}'.format(str(helper_chunks)))
         if scalar_mds:
             cmd.append('scalar-mds={}'.format(scalar_mds))
-
-    if erasure_profile_exists(service, profile_name):
-        cmd.append('--force')
 
     check_call(cmd)
 

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1114,6 +1114,8 @@ def create_erasure_profile(service, profile_name,
     :return: None.  Can raise CalledProcessError, ValueError or AssertionError
     """
     if erasure_profile_exists(service, profile_name):
+        log('EC profile {} exists, skipping update'.format(profile_name),
+            level=WARNING)
         return
 
     plugin_techniques = {


### PR DESCRIPTION
Changing and existing ec profile using the --force option can have
nasty side effects such as causing OSD's to crash.

If an erasure profile already exists, don't try to update it.

Actions on the ceph-mon charm can be used to create new pools
and profiles, migrate data and then rename existing pools.

Closes-Bug: 1897517