### PR TITLE
core/host: Speedup chownr by avoiding a couple of syscalls

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -924,9 +924,10 @@ def chownr(path, owner, group, follow_links=True, chowntopdir=False):
     for root, dirs, files in os.walk(path, followlinks=follow_links):
         for name in dirs + files:
             full = os.path.join(root, name)
-            broken_symlink = os.path.lexists(full) and not os.path.exists(full)
-            if not broken_symlink:
+            try:
                 chown(full, uid, gid)
+            except FileNotFoundError:
+                pass
 
 
 def lchownr(path, owner, group):


### PR DESCRIPTION
`chownr` function calls `os.path.exists` and `os.path.lexists` for every file. This can be avoided by checking the error
case that they were meant to handle (i.e. the symlink's target is missing).

As noted in [1898605](https://bugs.launchpad.net/charm-helpers/+bug/1898605), this is particularly noticeable in ceph-osd charms.

Closes-bug: #1898605

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>