### PR TITLE
Fix SubordinateConfigContext complete

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1534,8 +1534,23 @@ class SubordinateConfigContext(OSContextGenerator):
                                         ctxt[k][section] = config_list
                             else:
                                 ctxt[k] = v
-        log("%d section(s) found" % (len(ctxt['sections'])), level=DEBUG)
-        return ctxt
+        if self.context_complete(ctxt):
+            log("%d section(s) found" % (len(ctxt['sections'])), level=DEBUG)
+            return ctxt
+        else:
+            return {}
+
+    def context_complete(self, ctxt):
+        """Overridden here to ensure the context is actually complete.
+
+        :param ctxt: The current context members
+        :type ctxt: Dict[str, ANY]
+        :returns: True if the context is complete
+        :rtype: bool
+        """
+        if not ctxt.get('sections'):
+            return False
+        return super(SubordinateConfigContext, self).context_complete(ctxt)
 
 
 class LogLevelContext(OSContextGenerator):

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -595,6 +595,7 @@ SUB_CONFIG_RELATION = {
                 yaml.safe_load(CINDER_SUB_CONFIG2)),
         },
     },
+    'empty:0': {},
 }
 
 SUB_CONFIG_RELATION2 = {
@@ -3105,6 +3106,11 @@ class ContextTests(unittest.TestCase):
             config_file='/etc/foo/foo.conf',
             interface='foo-subordinate',
         )
+        empty_sub_ctxt = context.SubordinateConfigContext(
+            service='empty',
+            config_file='/etc/foo/foo.conf',
+            interface='empty-subordinate',
+        )
         self.assertEquals(
             nova_sub_ctxt(),
             {'sections': {
@@ -3131,13 +3137,18 @@ class ContextTests(unittest.TestCase):
 
             }, 'not-a-section': 1234}
         )
+        self.assertTrue(
+            cinder_sub_ctxt.context_complete(cinder_sub_ctxt()))
 
         # subrodinate supplies nothing for given config
         glance_sub_ctxt.config_file = '/etc/glance/glance-api-paste.ini'
-        self.assertEquals(glance_sub_ctxt(), {'sections': {}})
+        self.assertEquals(glance_sub_ctxt(), {})
 
         # subordinate supplies bad input
-        self.assertEquals(foo_sub_ctxt(), {'sections': {}})
+        self.assertEquals(foo_sub_ctxt(), {})
+        self.assertEquals(empty_sub_ctxt(), {})
+        self.assertFalse(
+            empty_sub_ctxt.context_complete(empty_sub_ctxt()))
 
     def test_os_subordinate_config_context_multiple(self):
         relation = FakeRelation(relation_data=SUB_CONFIG_RELATION2)


### PR DESCRIPTION
Fix SubordinateConfigContext so that if the context is empty it
is marked as incomplete. Closes issue 518.