### PR TITLE
Guarantee all SAN addresses are symlinked to certs

### DIFF
--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -34,12 +34,14 @@ from charmhelpers.core.hookenv import (
     WARNING,
 )
 from charmhelpers.contrib.openstack.ip import (
-    ADMIN,
     resolve_address,
     get_vip_in_network,
-    INTERNAL,
-    PUBLIC,
-    ADDRESS_MAP)
+    ADDRESS_MAP,
+    get_default_api_bindings,
+)
+from charmhelpers.contrib.network.ip import (
+    get_relation_ip,
+)
 
 from charmhelpers.core.host import (
     mkdir,
@@ -113,36 +115,82 @@ class CertRequest(object):
         return req
 
 
-def get_certificate_request(json_encode=True):
+def get_certificate_request(json_encode=True, bindings=None):
     """Generate a certificatee requests based on the network confioguration
 
     """
+    if bindings:
+        # Add default API bindings to bindings list
+        bindings = set(bindings + get_default_api_bindings())
+    else:
+        # Use default API bindings
+        bindings = get_default_api_bindings()
     req = CertRequest(json_encode=json_encode)
     req.add_hostname_cn()
     # Add os-hostname entries
-    for net_type in [INTERNAL, ADMIN, PUBLIC]:
-        net_config = config(ADDRESS_MAP[net_type]['override'])
+    _sans = get_certificate_sans()
+
+    # Handle specific hostnames per binding
+    for binding in bindings:
+        hostname_override = config(ADDRESS_MAP[binding]['override'])
         try:
-            net_addr = resolve_address(endpoint_type=net_type)
+            net_addr = resolve_address(endpoint_type=binding)
             ip = network_get_primary_address(
-                ADDRESS_MAP[net_type]['binding'])
+                ADDRESS_MAP[binding]['binding'])
             addresses = [net_addr, ip]
             vip = get_vip_in_network(resolve_network_cidr(ip))
             if vip:
                 addresses.append(vip)
-            if net_config:
+            # Add hostname certificate request
+            if hostname_override:
                 req.add_entry(
-                    net_type,
-                    net_config,
+                    binding,
+                    hostname_override,
                     addresses)
-            else:
-                # There is network address with no corresponding hostname.
-                # Add the ip to the hostname cert to allow for this.
-                req.add_hostname_cn_ip(addresses)
+            # Remove hostname specific addresses from _sans
+            for addr in addresses:
+                try:
+                    _sans.remove(addr)
+                except (ValueError, KeyError):
+                    pass
+
         except NoNetworkBinding:
             log("Skipping request for certificate for ip in {} space, no "
-                "local address found".format(net_type), WARNING)
+                "local address found".format(binding), WARNING)
+    # Gurantee all SANs are covered
+    # These are network addresses with no corresponding hostname.
+    # Add the ips to the hostname cert to allow for this.
+    req.add_hostname_cn_ip(_sans)
     return req.get_request()
+
+
+def get_certificate_sans(bindings=None):
+    """Get all possible IP addresses for certificate SANs.
+    """
+    _sans = [unit_get('private-address')]
+    if bindings:
+        # Add default API bindings to bindings list
+        bindings = set(bindings + get_default_api_bindings())
+    else:
+        # Use default API bindings
+        bindings = get_default_api_bindings()
+
+    for binding in bindings:
+        # Check for config override
+        try:
+            net_config = config(ADDRESS_MAP[binding]['config'])
+        except KeyError:
+            # There is no configuration network for this binding name
+            net_config = None
+        # Using resolve_address is likely redundant. Keeping it here in
+        # case there is an edge case it handles.
+        net_addr = resolve_address(endpoint_type=binding)
+        ip = get_relation_ip(binding, cidr_network=net_config)
+        _sans = _sans + [net_addr, ip]
+        vip = get_vip_in_network(resolve_network_cidr(ip))
+        if vip:
+            _sans.append(vip)
+    return set(_sans)
 
 
 def create_ip_cert_links(ssl_dir, custom_hostname_link=None):
@@ -151,6 +199,26 @@ def create_ip_cert_links(ssl_dir, custom_hostname_link=None):
     :param ssl_dir: str Directory to create symlinks in
     :param custom_hostname_link: str Additional link to be created
     """
+
+    # This includes the hostname cert and any specific bindng certs:
+    # admin, internal, public
+    req = get_certificate_request(json_encode=False)["cert_requests"]
+    # Specific certs
+    for cert_req in req.keys():
+        requested_cert = os.path.join(
+            ssl_dir,
+            'cert_{}'.format(cert_req))
+        requested_key = os.path.join(
+            ssl_dir,
+            'key_{}'.format(cert_req))
+        for addr in req[cert_req]['sans']:
+            cert = os.path.join(ssl_dir, 'cert_{}'.format(addr))
+            key = os.path.join(ssl_dir, 'key_{}'.format(addr))
+            if os.path.isfile(requested_cert) and not os.path.isfile(cert):
+                os.symlink(requested_cert, cert)
+                os.symlink(requested_key, key)
+
+    # Handle custom hostnames
     hostname = get_hostname(unit_get('private-address'))
     hostname_cert = os.path.join(
         ssl_dir,
@@ -158,18 +226,6 @@ def create_ip_cert_links(ssl_dir, custom_hostname_link=None):
     hostname_key = os.path.join(
         ssl_dir,
         'key_{}'.format(hostname))
-    # Add links to hostname cert, used if os-hostname vars not set
-    for net_type in [INTERNAL, ADMIN, PUBLIC]:
-        try:
-            addr = resolve_address(endpoint_type=net_type)
-            cert = os.path.join(ssl_dir, 'cert_{}'.format(addr))
-            key = os.path.join(ssl_dir, 'key_{}'.format(addr))
-            if os.path.isfile(hostname_cert) and not os.path.isfile(cert):
-                os.symlink(hostname_cert, cert)
-                os.symlink(hostname_key, key)
-        except NoNetworkBinding:
-            log("Skipping creating cert symlink for ip in {} space, no "
-                "local address found".format(net_type), WARNING)
     if custom_hostname_link:
         custom_cert = os.path.join(
             ssl_dir,

--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -116,8 +116,16 @@ class CertRequest(object):
 
 
 def get_certificate_request(json_encode=True, bindings=None):
-    """Generate a certificatee requests based on the network confioguration
+    """Generate a certificate requests based on the network configuration
 
+    :param json_encode: Encode request in JSON or not. Used for setting
+                        directly on a relation.
+    :type json_encode: boolean
+    :param bindings: List of bindings to check in addition to default api
+                     bindings.
+    :type bindings: list of strings
+    :returns: CertRequest request as dictionary or JSON string.
+    :rtype: Union[dict, json]
     """
     if bindings:
         # Add default API bindings to bindings list

--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -33,6 +33,7 @@ INTERNAL = 'int'
 ADMIN = 'admin'
 ACCESS = 'access'
 
+# TODO: reconcile 'int' vs 'internal' binding names
 ADDRESS_MAP = {
     PUBLIC: {
         'binding': 'public',
@@ -57,6 +58,14 @@ ADDRESS_MAP = {
         'config': 'access-network',
         'fallback': 'private-address',
         'override': 'os-access-hostname',
+    },
+    # Note (thedac) bridge to begin the reconciliation between 'int' vs
+    # 'internal' binding names
+    'internal': {
+        'binding': 'internal',
+        'config': 'os-internal-network',
+        'fallback': 'private-address',
+        'override': 'os-internal-hostname',
     },
 }
 
@@ -195,3 +204,10 @@ def get_vip_in_network(network):
             if is_address_in_network(network, vip):
                 matching_vip = vip
     return matching_vip
+
+
+def get_default_api_bindings():
+    _default_bindings = []
+    for binding in [INTERNAL, ADMIN, PUBLIC]:
+        _default_bindings.append(ADDRESS_MAP[binding]['binding'])
+    return _default_bindings

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -64,6 +64,7 @@ class CertUtilsTests(unittest.TestCase):
                  '"10.1.2.4"]}}'),
              'unit_name': 'unit_2'})
 
+    @mock.patch.object(cert_utils, 'get_certificate_sans')
     @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
@@ -76,7 +77,7 @@ class CertUtilsTests(unittest.TestCase):
                                      config, resolve_address,
                                      network_get_primary_address,
                                      get_vip_in_network, resolve_network_cidr,
-                                     local_unit):
+                                     local_unit, get_certificate_sans):
         unit_get.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {
@@ -86,6 +87,7 @@ class CertUtilsTests(unittest.TestCase):
         }
         _resolve_address = {
             'int': '10.0.0.2',
+            'internal': '10.0.0.2',
             'admin': '10.10.0.2',
             'public': '10.20.0.2',
         }
@@ -104,6 +106,10 @@ class CertUtilsTests(unittest.TestCase):
             '10.10.0.3': '10.10.0.0/16',
             '10.20.0.3': '10.20.0.0/16',
         }
+        get_certificate_sans.return_value = set(
+            list(_resolve_address.values()) +
+            list(_npa.values()) +
+            list(_vips.values()))
         expect = {
             'admin.openstack.local': {
                 'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
@@ -125,39 +131,66 @@ class CertUtilsTests(unittest.TestCase):
             output,
             expect)
 
+    @mock.patch.object(cert_utils, 'get_certificate_request')
     @mock.patch.object(cert_utils, 'unit_get')
     @mock.patch.object(cert_utils.os, 'symlink')
     @mock.patch.object(cert_utils.os.path, 'isfile')
-    @mock.patch.object(cert_utils, 'resolve_address')
     @mock.patch.object(cert_utils, 'get_hostname')
-    def test_create_ip_cert_links(self, get_hostname, resolve_address, isfile,
-                                  symlink, unit_get):
-        unit_get.return_value = '10.1.2.3'
-        get_hostname.return_value = 'juju-unit-2'
-        _resolve_address = {
-            'int': '10.0.0.2',
-            'admin': '10.10.0.2',
-            'public': '10.20.0.2',
-        }
-        resolve_address.side_effect = \
-            lambda endpoint_type: _resolve_address[endpoint_type]
+    def test_create_ip_cert_links(self, get_hostname, isfile,
+                                  symlink, unit_get, get_cert_request):
+        cert_request = {'cert_requests': {
+            'admin.openstack.local': {
+                'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
+            'internal.openstack.local': {
+                'sans': ['10.0.0.100', '10.0.0.2', '10.0.0.3']},
+            'juju-unit-2': {'sans': ['10.1.2.3']},
+            'public.openstack.local': {
+                'sans': ['10.20.0.100', '10.20.0.2', '10.20.0.3']}}}
+        get_cert_request.return_value = cert_request
         _files = {
             '/etc/ssl/cert_juju-unit-2': True,
+            '/etc/ssl/cert_10.1.2.3': False,
+            '/etc/ssl/cert_admin.openstack.local': True,
+            '/etc/ssl/cert_10.10.0.100': False,
+            '/etc/ssl/cert_10.10.0.2': False,
+            '/etc/ssl/cert_10.10.0.3': False,
+            '/etc/ssl/cert_internal.openstack.local': True,
+            '/etc/ssl/cert_10.0.0.100': False,
             '/etc/ssl/cert_10.0.0.2': False,
-            '/etc/ssl/cert_10.10.0.2': True,
+            '/etc/ssl/cert_10.0.0.3': False,
+            '/etc/ssl/cert_public.openstack.local': True,
+            '/etc/ssl/cert_10.20.0.100': False,
             '/etc/ssl/cert_10.20.0.2': False,
+            '/etc/ssl/cert_10.20.0.3': False,
             '/etc/ssl/cert_funky-name': False,
         }
         isfile.side_effect = lambda x: _files[x]
         expected = [
-            mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_10.0.0.2'),
-            mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_10.0.0.2'),
-            mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_10.20.0.2'),
-            mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_10.20.0.2'),
-        ]
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.100'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.100'),
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.2'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.2'),
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.3'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.3'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.100'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.100'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.2'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.2'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.3'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.3'),
+            mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_10.1.2.3'),
+            mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_10.1.2.3'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.100'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.100'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.2'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.2'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.3'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.3')]
         cert_utils.create_ip_cert_links('/etc/ssl')
         symlink.assert_has_calls(expected)
+        # Customer hostname
         symlink.reset_mock()
+        get_hostname.return_value = 'juju-unit-2'
         cert_utils.create_ip_cert_links(
             '/etc/ssl',
             custom_hostname_link='funky-name')
@@ -306,3 +339,58 @@ class CertUtilsTests(unittest.TestCase):
                 'cert': 'INTERNALCERT',
                 'chain': 'MYCHAIN',
                 'key': 'INTERNALKEY'})
+
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
+    @mock.patch.object(cert_utils, 'resolve_network_cidr')
+    @mock.patch.object(cert_utils, 'get_vip_in_network')
+    @mock.patch.object(cert_utils, 'get_relation_ip')
+    @mock.patch.object(cert_utils, 'resolve_address')
+    @mock.patch.object(cert_utils, 'config')
+    @mock.patch.object(cert_utils, 'get_hostname')
+    @mock.patch.object(cert_utils, 'unit_get')
+    def test_get_certificate_sans(self, unit_get, get_hostname,
+                                  config, resolve_address,
+                                  get_relation_ip,
+                                  get_vip_in_network, resolve_network_cidr,
+                                  local_unit):
+        unit_get.return_value = '10.1.2.3'
+        get_hostname.return_value = 'juju-unit-2'
+        _config = {
+            'os-internal-hostname': 'internal.openstack.local',
+            'os-admin-hostname': 'admin.openstack.local',
+            'os-public-hostname': 'public.openstack.local',
+        }
+        _resolve_address = {
+            'int': '10.0.0.2',
+            'internal': '10.0.0.2',
+            'admin': '10.10.0.2',
+            'public': '10.20.0.2',
+        }
+        _npa = {
+            'internal': '10.0.0.3',
+            'admin': '10.10.0.3',
+            'public': '10.20.0.3',
+        }
+        _vips = {
+            '10.0.0.0/16': '10.0.0.100',
+            '10.10.0.0/16': '10.10.0.100',
+            '10.20.0.0/16': '10.20.0.100',
+        }
+        _resolve_nets = {
+            '10.0.0.3': '10.0.0.0/16',
+            '10.10.0.3': '10.10.0.0/16',
+            '10.20.0.3': '10.20.0.0/16',
+        }
+        expect = set([
+            '10.10.0.100', '10.10.0.2', '10.10.0.3',
+            '10.0.0.100', '10.0.0.2', '10.0.0.3',
+            '10.1.2.3',
+            '10.20.0.100', '10.20.0.2', '10.20.0.3'])
+        self.maxDiff = None
+        config.side_effect = lambda x: _config.get(x)
+        get_vip_in_network.side_effect = lambda x: _vips.get(x)
+        resolve_network_cidr.side_effect = lambda x: _resolve_nets.get(x)
+        get_relation_ip.side_effect = lambda x, cidr_network: _npa.get(x)
+        resolve_address.side_effect = \
+            lambda endpoint_type: _resolve_address[endpoint_type]
+        self.assertEqual(cert_utils.get_certificate_sans(), expect)

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -187,7 +187,7 @@ class CertUtilsTests(unittest.TestCase):
             mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.3'),
             mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.3')]
         cert_utils.create_ip_cert_links('/etc/ssl')
-        symlink.assert_has_calls(expected)
+        symlink.assert_has_calls(expected, any_order=True)
         # Customer hostname
         symlink.reset_mock()
         get_hostname.return_value = 'juju-unit-2'
@@ -198,7 +198,7 @@ class CertUtilsTests(unittest.TestCase):
             mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_funky-name'),
             mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_funky-name'),
         ])
-        symlink.assert_has_calls(expected)
+        symlink.assert_has_calls(expected, any_order=True)
 
     @mock.patch.object(cert_utils, 'write_file')
     def test_install_certs(self, write_file):


### PR DESCRIPTION
Prior to this change the algorithm used for requesting certificates was
different from the one used to set up symlinks. This change does the
following:

* Breaks out the SAN IP address gathering into get_certificate_sans
* Changes variable names to better describe what they are for
* Uses the request object to determine which IPs map to which
certificates
* Begins the process of fixing the "int" vs "internal" binding name

Closes-Bug: #1893847