### PR TITLE
Update haproxy.cfg template for tls backends

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -71,6 +71,9 @@ backend {{ service }}_{{ frontend }}
     {% endif -%}
     {% for unit, address in frontends[frontend]['backends'].items() -%}
     server {{ unit }} {{ address }}:{{ ports[1] }} check
+    {%- if backend_options -%}
+    {%- if backend_options['check_ssl'] %} check-ssl verify none{% endif -%}
+    {%- endif %}
     {% endfor %}
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
Adds a switch so that if the context for haproxy config includes
backend_options['check_ssl'] then haproxy will run http checks via
https.