### PR TITLE
Correct name of CA cert file

### DIFF
--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -34,7 +34,9 @@ from charmhelpers.core.hookenv import (
     INFO,
 )
 
-KEYSTONE_CA_CERT_FILE = 'keystone_juju_ca_cert'
+# This file contains the CA cert from the charms ssl_ca configuration
+# option, in future the file name should be updated reflect that.
+CONFIG_CA_CERT_FILE = 'keystone_juju_ca_cert'
 
 
 def get_cert(cn=None):
@@ -85,4 +87,4 @@ def retrieve_ca_cert(cert_file):
 
 
 def install_ca_cert(ca_cert):
-    host.install_ca_cert(ca_cert, KEYSTONE_CA_CERT_FILE)
+    host.install_ca_cert(ca_cert, CONFIG_CA_CERT_FILE)

--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -34,6 +34,8 @@ from charmhelpers.core.hookenv import (
     INFO,
 )
 
+KEYSTONE_CA_CERT_FILE = 'keystone_juju_ca_cert'
+
 
 def get_cert(cn=None):
     # TODO: deal with multiple https endpoints via charm config
@@ -83,4 +85,4 @@ def retrieve_ca_cert(cert_file):
 
 
 def install_ca_cert(ca_cert):
-    host.install_ca_cert(ca_cert, 'keystone_juju_ca_cert')
+    host.install_ca_cert(ca_cert, KEYSTONE_CA_CERT_FILE)

--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -28,6 +28,7 @@ from charmhelpers.core.hookenv import (
     related_units,
     relation_get,
     relation_ids,
+    remote_service_name,
     unit_get,
     NoNetworkBinding,
     log,
@@ -44,12 +45,9 @@ from charmhelpers.contrib.network.ip import (
 )
 
 from charmhelpers.core.host import (
+    install_ca_cert,
     mkdir,
     write_file,
-)
-
-from charmhelpers.contrib.hahelpers.apache import (
-    install_ca_cert
 )
 
 
@@ -298,7 +296,10 @@ def process_certificates(service_name, relation_id, unit,
     ca = data.get('ca')
     if certs:
         certs = json.loads(certs)
-        install_ca_cert(ca.encode())
+        install_ca_cert(
+            ca.encode(),
+            name='{}_juju_ca_cert'.format(
+                remote_service_name(relid=relation_id)))
         install_certs(ssl_dir, certs, chain, user=user, group=group)
         create_ip_cert_links(
             ssl_dir,

--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -54,7 +54,7 @@ from charmhelpers.core.host import (
 )
 
 from charmhelpers.contrib.hahelpers.apache import (
-    KEYSTONE_CA_CERT_FILE,
+    CONFIG_CA_CERT_FILE,
 )
 
 
@@ -288,13 +288,13 @@ def _manage_ca_certs(ca, cert_relation_id):
     :type cert_relation_id: str
     """
     config_ssl_ca = config('ssl_ca')
-    config_cert_file = '{}/{}.crt'.format(CA_CERT_DIR, KEYSTONE_CA_CERT_FILE)
+    config_cert_file = '{}/{}.crt'.format(CA_CERT_DIR, CONFIG_CA_CERT_FILE)
     if config_ssl_ca:
         log("Installing CA certificate from charm ssl_ca config to {}".format(
             config_cert_file), INFO)
         install_ca_cert(
             b64decode(config_ssl_ca).rstrip(),
-            name=KEYSTONE_CA_CERT_FILE)
+            name=CONFIG_CA_CERT_FILE)
     elif os.path.exists(config_cert_file):
         log("Removing CA certificate {}".format(config_cert_file), INFO)
         os.remove(config_cert_file)

--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -16,6 +16,7 @@
 
 import os
 import json
+from base64 import b64decode
 
 from charmhelpers.contrib.network.ip import (
     get_hostname,
@@ -33,6 +34,7 @@ from charmhelpers.core.hookenv import (
     NoNetworkBinding,
     log,
     WARNING,
+    INFO,
 )
 from charmhelpers.contrib.openstack.ip import (
     resolve_address,
@@ -45,9 +47,14 @@ from charmhelpers.contrib.network.ip import (
 )
 
 from charmhelpers.core.host import (
+    CA_CERT_DIR,
     install_ca_cert,
     mkdir,
     write_file,
+)
+
+from charmhelpers.contrib.hahelpers.apache import (
+    KEYSTONE_CA_CERT_FILE,
 )
 
 
@@ -272,6 +279,32 @@ def install_certs(ssl_dir, certs, chain=None, user='root', group='root'):
             content=bundle['key'], perms=0o640)
 
 
+def _manage_ca_certs(ca, cert_relation_id):
+    """Manage CA certs.
+
+    :param ca: CA Certificate from certificate relation.
+    :type ca: str
+    :param cert_relation_id: Relation id providing the certs
+    :type cert_relation_id: str
+    """
+    config_ssl_ca = config('ssl_ca')
+    config_cert_file = '{}/{}.crt'.format(CA_CERT_DIR, KEYSTONE_CA_CERT_FILE)
+    if config_ssl_ca:
+        log("Installing CA certificate from charm ssl_ca config to {}".format(
+            config_cert_file), INFO)
+        install_ca_cert(
+            b64decode(config_ssl_ca).rstrip(),
+            name=KEYSTONE_CA_CERT_FILE)
+    elif os.path.exists(config_cert_file):
+        log("Removing CA certificate {}".format(config_cert_file), INFO)
+        os.remove(config_cert_file)
+    log("Installing CA certificate from certificate relation", INFO)
+    install_ca_cert(
+        ca.encode(),
+        name='{}_juju_ca_cert'.format(
+            remote_service_name(relid=cert_relation_id)))
+
+
 def process_certificates(service_name, relation_id, unit,
                          custom_hostname_link=None, user='root', group='root'):
     """Process the certificates supplied down the relation
@@ -296,10 +329,7 @@ def process_certificates(service_name, relation_id, unit,
     ca = data.get('ca')
     if certs:
         certs = json.loads(certs)
-        install_ca_cert(
-            ca.encode(),
-            name='{}_juju_ca_cert'.format(
-                remote_service_name(relid=relation_id)))
+        _manage_ca_certs(ca, relation_id)
         install_certs(ssl_dir, certs, chain, user=user, group=group)
         create_ip_cert_links(
             ssl_dir,

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -60,6 +60,7 @@ elif __platform__ == "centos":
     )  # flake8: noqa -- ignore F401 for this import
 
 UPDATEDB_PATH = '/etc/updatedb.conf'
+CA_CERT_DIR = '/usr/local/share/ca-certificates'
 
 
 def service_start(service_name, **kwargs):
@@ -1082,7 +1083,7 @@ def install_ca_cert(ca_cert, name=None):
         ca_cert = ca_cert.encode('utf8')
     if not name:
         name = 'juju-{}'.format(charm_name())
-    cert_file = '/usr/local/share/ca-certificates/{}.crt'.format(name)
+    cert_file = '{}/{}.crt'.format(CA_CERT_DIR, name)
     new_hash = hashlib.md5(ca_cert).hexdigest()
     if file_hash(cert_file) == new_hash:
         return

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -243,6 +243,7 @@ class CertUtilsTests(unittest.TestCase):
         ]
         write_file.assert_has_calls(expected)
 
+    @mock.patch.object(cert_utils, 'remote_service_name')
     @mock.patch.object(cert_utils, 'local_unit')
     @mock.patch.object(cert_utils, 'create_ip_cert_links')
     @mock.patch.object(cert_utils, 'install_certs')
@@ -251,7 +252,8 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'relation_get')
     def test_process_certificates(self, relation_get, mkdir, install_ca_cert,
                                   install_certs, create_ip_cert_links,
-                                  local_unit):
+                                  local_unit, remote_service_name):
+        remote_service_name.return_value = 'vault'
         local_unit.return_value = 'devnull/2'
         certs = {
             'admin.openstack.local': {
@@ -274,7 +276,9 @@ class CertUtilsTests(unittest.TestCase):
             'certificates:2',
             'vault/0',
             custom_hostname_link='funky-name'))
-        install_ca_cert.assert_called_once_with(b'ROOTCA')
+        install_ca_cert.assert_called_once_with(
+            b'ROOTCA',
+            name='vault_juju_ca_cert')
         install_certs.assert_called_once_with(
             '/etc/apache2/ssl/myservice',
             {'admin.openstack.local': {


### PR DESCRIPTION
In the past a CA could be supplied to a charm by one of three different methods:

1. From keystone

1. From ssl* config

1. From vault

Regardless of where the CA came from it was written to `keystone_juju_ca_cert.pem`. The first method has since been removed but the the name of the CA file has remained.

The purpose of this PR is to provide a tactical fix to allow a CA to be supplied via ssl_ca config option and by vault (the certificates management code still needs a complete overhaul). This is achieved by writing out the CA cert received via the certificates relation to a new name. The old file named  `keystone_juju_ca_cert.pem` cannot simply be removed because it may contain a certificate that was supplied via the ssl_ca config option and not from vault. To safely manage this situation the process_certificates method will now ensure that the CA cert from the  ssl_ca config option is written out if ssl_ca is set or the file removed if it is unset.