### PR TITLE
get_hostname(): handle exception on no answer from DNS server

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -519,7 +519,10 @@ def get_hostname(address, fqdn=True):
             import dns.reversename
 
         rev = dns.reversename.from_address(address)
-        result = ns_query(rev)
+        try:
+            result = ns_query(rev)
+        except:
+            result = None
 
         if not result:
             try:


### PR DESCRIPTION
The function `get_hostname()` raises an exception vs. just `return None`
if DNS reverse query by IP address fails (eg, DNS server fail/no answer.)

In this case, it does not reach `socket.gethostbyaddr()`, which could be
used for a workaround with `/etc/hosts` (eg, while fixing DNS server.)

In Xenial `/etc/hosts` is not taken into account because of the exception.

In Bionic `/etc/hosts` is taken into account before the exception, but if
the hostname/IP is not there, that exception does happen anyway.

So, add a `try/except` block to catch the exception so to try `/etc/hosts`
in Xenial and silence the exception in Bionic / `return None` as planned.

Fixes LP: #1903414

Example:
---

In this trace, the `install` hook of `rabbitmq-server` failed:

```
	2020-11-07 10:15:55 DEBUG install Traceback (most recent call last):
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/install.real", line 989, in <module>
	2020-11-07 10:15:55 DEBUG install     rabbit.assess_status(rabbit.ConfigRenderer(rabbit.CONFIG_FILES))
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/rabbit_utils.py", line 150, in __init__
	2020-11-07 10:15:55 DEBUG install     ctxt.update(svc_context())
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/rabbitmq_context.py", line 137, in __call__
	2020-11-07 10:15:55 DEBUG install     ssl_mode, external_ca = ssl_utils.get_ssl_mode()
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/ssl_utils.py", line 61, in get_ssl_mode
	2020-11-07 10:15:55 DEBUG install     relation_certs = get_relation_cert_data()
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/ssl_utils.py", line 56, in get_relation_cert_data
	2020-11-07 10:15:55 DEBUG install     _, hostname = get_unit_amqp_endpoint_data()
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/hooks/ssl_utils.py", line 47, in get_unit_amqp_endpoint_data
	2020-11-07 10:15:55 DEBUG install     return ip, get_hostname(ip)
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/charmhelpers/contrib/network/ip.py", line 522, in get_hostname
	2020-11-07 10:15:55 DEBUG install     result = ns_query(rev)
	2020-11-07 10:15:55 DEBUG install   File "/var/lib/juju/agents/unit-rabbitmq-server-8/charm/charmhelpers/contrib/network/ip.py", line 478, in ns_query
	2020-11-07 10:15:55 DEBUG install     answers = dns.resolver.query(address, rtype)
	2020-11-07 10:15:55 DEBUG install   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 979, in query
	2020-11-07 10:15:55 DEBUG install     raise_on_no_answer, source_port)
	2020-11-07 10:15:55 DEBUG install   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 821, in query
	2020-11-07 10:15:55 DEBUG install     raise NoNameservers
	2020-11-07 10:15:55 DEBUG install dns.resolver.NoNameservers
	2020-11-07 10:15:55 ERROR juju.worker.uniter.operation runhook.go:132 hook "install" failed: exit status 1
```

Steps to reproduce/verify:
---

Deploy in Xenial/Bionic, SSH in, and run `python3` / import `get_hostname()`:
```
	$ juju deploy rabbitmq-server rmq --series xenial # or bionic

	$ juju status | grep rmq
	rmq  3.5.7    active      1  rabbitmq-server  jujucharms  106  ubuntu
	rmq/0*  active    idle   3        10.191.59.36    5672/tcp  Unit is ready

	$ juju ssh rmq/0

	$ python3
	>>> import sys
	>>> sys.path.append('/var/lib/juju/agents/unit-rmq-0/charm/')
	>>> from charmhelpers.contrib.network.ip import get_hostname
```
Xenial / original:
```
	>>> get_hostname('10.10.10.10')
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/var/lib/juju/agents/unit-rmq-3/charm/charmhelpers/contrib/network/ip.py", line 522, in get_hostname
	    result = ns_query(rev)
	  File "/var/lib/juju/agents/unit-rmq-3/charm/charmhelpers/contrib/network/ip.py", line 478, in ns_query
	    answers = dns.resolver.query(address, rtype)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 979, in query
	    raise_on_no_answer, source_port)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 821, in query
	    raise NoNameservers
	dns.resolver.NoNameservers

	>>> ^Z
	[1]+  Stopped                 python3

	$ echo '10.10.10.10 test-hostname' | sudo tee -a /etc/hosts
	10.10.10.10 test-hostname

	$ fg
	python3

	>>> get_hostname('10.10.10.10')
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/var/lib/juju/agents/unit-rmq-3/charm/charmhelpers/contrib/network/ip.py", line 522, in get_hostname
	    result = ns_query(rev)
	  File "/var/lib/juju/agents/unit-rmq-3/charm/charmhelpers/contrib/network/ip.py", line 478, in ns_query
	    answers = dns.resolver.query(address, rtype)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 979, in query
	    raise_on_no_answer, source_port)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 821, in query
	    raise NoNameservers
	dns.resolver.NoNameservers

	>>> quit()
```
Xenial / patched:
```
	$ sudo sed -i '/test-hostname/d' /etc/hosts  # remove entry

	>>> get_hostname('10.10.10.10')
	>>>

	>>> ^Z
	[1]+  Stopped                 python3

	$ echo '10.10.10.10 test-hostname' | sudo tee -a /etc/hosts
	10.10.10.10 test-hostname

	$ fg
	python3

	>>> get_hostname('10.10.10.10')
	'test-hostname'

	>>> quit()
```
Bionic / original:
```
	>>> get_hostname('10.10.10.10')
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/var/lib/juju/agents/unit-rmq-0/charm/charmhelpers/contrib/network/ip.py", line 522, in get_hostname
	    result = ns_query(rev)
	  File "/var/lib/juju/agents/unit-rmq-0/charm/charmhelpers/contrib/network/ip.py", line 478, in ns_query
	    answers = dns.resolver.query(address, rtype)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 1132, in query
	    raise_on_no_answer, source_port)
	  File "/usr/lib/python3/dist-packages/dns/resolver.py", line 947, in query
	    raise NoNameservers(request=request, errors=errors)
	dns.resolver.NoNameservers: All nameservers failed to answer the query 10.10.10.10.in-addr.arpa. IN PTR: Server 127.0.0.53 UDP port 53 answered SERVFAIL

	>>> ^Z
	[1]+  Stopped                 python3

	$ echo '10.10.10.10 test-hostname' | sudo tee -a /etc/hosts
	10.10.10.10 test-hostname

	$ fg
	python3

	>>> get_hostname('10.10.10.10')
	'test-hostname'
```
Bionic / patched:
```
	$ sudo sed -i '/test-hostname/d' /etc/hosts  # remove entry

	>>> get_hostname('10.10.10.10')
	>>>

	[1]+  Stopped                 python3

	$ echo '10.10.10.10 test-hostname' | sudo tee -a /etc/hosts
	10.10.10.10 test-hostname

	$ fg
	python3

	>>> get_hostname('10.10.10.10')
	'test-hostname'

	>>> quit()
```

Signed-off-by: Mauricio Faria de Oliveira `<mfo@canonical.com>`