### PR TITLE
Updates for the Cinder Ceph Replication spec

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -788,13 +788,14 @@ class CephContext(OSContextGenerator):
         ctxt = {
             'use_syslog': str(config('use-syslog')).lower()
         }
+        rbd_mirroring_mode = config('rbd-mirroring-mode')
         for rid in relation_ids('ceph'):
             for unit in related_units(rid):
                 if not ctxt.get('auth'):
                     ctxt['auth'] = relation_get('auth', rid=rid, unit=unit)
                 if not ctxt.get('key'):
                     ctxt['key'] = relation_get('key', rid=rid, unit=unit)
-                if not ctxt.get('rbd_features'):
+                if rbd_mirroring_mode != "image" and not ctxt.get('rbd_features'):
                     default_features = relation_get('rbd-features', rid=rid, unit=unit)
                     if default_features is not None:
                         ctxt['rbd_features'] = default_features

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -777,10 +777,13 @@ class AMQPContext(OSContextGenerator):
 
 class CephContext(OSContextGenerator):
     """Generates context for /etc/ceph/ceph.conf templates."""
-    interfaces = ['ceph']
+
+    def __init__(self, ceph_relation='ceph'):
+        self._ceph_relation = ceph_relation
+        self.interfaces = [ceph_relation]
 
     def __call__(self):
-        if not relation_ids('ceph'):
+        if not relation_ids(self._ceph_relation):
             return {}
 
         log('Generating template context for ceph', level=DEBUG)
@@ -789,7 +792,7 @@ class CephContext(OSContextGenerator):
             'use_syslog': str(config('use-syslog')).lower()
         }
         rbd_mirroring_mode = config('rbd-mirroring-mode')
-        for rid in relation_ids('ceph'):
+        for rid in relation_ids(self._ceph_relation):
             for unit in related_units(rid):
                 if not ctxt.get('auth'):
                     ctxt['auth'] = relation_get('auth', rid=rid, unit=unit)

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -268,6 +268,7 @@ class BasePool(object):
         'compression-max-blob-size': (int, None),
         'compression-max-blob-size-hdd': (int, None),
         'compression-max-blob-size-ssd': (int, None),
+        'rbd-mirroring-mode': (str, ('image', 'pool'))
     }
 
     def __init__(self, service, name=None, percent_data=None, app_name=None,
@@ -1767,6 +1768,7 @@ class CephBrokerRq(object):
                                         max_bytes=None,
                                         max_objects=None,
                                         namespace=None,
+                                        rbd_mirroring_mode='pool',
                                         weight=None):
         """Build common part of a create pool operation.
 
@@ -1825,6 +1827,9 @@ class CephBrokerRq(object):
         :type max_objects: Optional[int]
         :param namespace: Group namespace
         :type namespace: Optional[str]
+        :param rbd_mirroring_mode: Pool mirroring mode used when Ceph RBD
+                                   mirroring is enabled.
+        :type rbd_mirroring_mode: Optional[str]
         :param weight: The percentage of data that is expected to be contained
                        in the pool from the total available space on the OSDs.
                        Used to calculate number of Placement Groups to create
@@ -1849,6 +1854,7 @@ class CephBrokerRq(object):
             'max-bytes': max_bytes,
             'max-objects': max_objects,
             'group-namespace': namespace,
+            'rbd-mirroring-mode': rbd_mirroring_mode,
             'weight': weight,
         }
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -329,6 +329,27 @@ CEPH_RELATION = {
     }
 }
 
+CEPH_REPLICATION_DEVICE_RELATION = {
+    'ceph-replication-device:0': {
+        'ceph/0': {
+            'private-address': 'ceph_node1',
+            'auth': 'foo',
+            'key': 'bar',
+            'rbd-pool': 'test1',
+            'pool-type': 'replicated',
+            'rbd-mirroring-mode': 'pool'
+        },
+        'ceph/1': {
+            'private-address': 'ceph_node2',
+            'auth': 'foo',
+            'key': 'bar',
+            'rbd-pool': 'test2',
+            'pool-type': 'replicated',
+            'rbd-mirroring-mode': 'image'
+        }
+    }
+}
+
 CEPH_RELATION_WITH_PUBLIC_ADDR = {
     'ceph:0': {
         'ceph/0': {
@@ -1582,6 +1603,34 @@ class ContextTests(unittest.TestCase):
         ceph = context.CephContext()
         result = ceph()
         self.assertEquals(result, {})
+
+    @patch('os.path.isdir')
+    @patch('os.mkdir')
+    @patch.object(context, 'config')
+    @patch.object(context, 'ensure_packages')
+    def test_ceph_rel_replication_device(self, ensure_packages, mock_config, mkdir, isdir):
+        '''Test ceph context with ceph-replication-device relation'''
+        config_dict = {'use-syslog': True}
+
+        def fake_config(key):
+            return config_dict.get(key)
+
+        isdir.return_value = True
+        mock_config.side_effect = fake_config
+        relation = FakeRelation(relation_data=CEPH_REPLICATION_DEVICE_RELATION)
+        self.relation_get.side_effect = relation.get
+        self.relation_ids.side_effect = relation.relation_ids
+        self.related_units.side_effect = relation.relation_units
+        ceph = context.CephContext(ceph_relation='ceph-replication-device')
+        result = ceph()
+        expected = {
+            'auth': 'foo',
+            'key': 'bar',
+            'mon_hosts': 'ceph_node1 ceph_node2',
+            'use_syslog': 'true'
+        }
+        self.assertEquals(result, expected)
+        self.assertEquals(ceph.interfaces, ['ceph-replication-device'])
 
     @patch.object(context, 'config')
     @patch('os.path.isdir')

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -138,7 +138,7 @@ CEPH_CLIENT_RELATION = {
             'private-address': '10.5.44.105',
         },
         'glance/0': {
-            'broker_req': '{"api-version": 1, "request-id": "0bc7dc54", "ops": [{"replicas": 3, "name": "glance", "op": "create-pool"}]}',
+            'broker_req': '{"api-version": 1, "request-id": "0bc7dc54", "ops": [{"replicas": 3, "name": "glance", "op": "create-pool", "rbd-mirroring-mode": "pool"}]}',
             'private-address': '10.5.44.109',
         },
     }
@@ -2007,6 +2007,7 @@ class CephUtilsTests(TestCase):
             'max-bytes': None,
             'max-objects': None,
             'group-namespace': None,
+            'rbd-mirroring-mode': 'pool',
             'weight': None,
         }
         self.assertDictEqual(
@@ -2040,6 +2041,7 @@ class CephUtilsTests(TestCase):
                    'name': 'apool',
                    'op': 'create-pool',
                    'pg_num': None,
+                   'rbd-mirroring-mode': 'pool',
                    'replicas': 3,
                    'weight': None}
         rq = ceph_utils.CephBrokerRq()
@@ -2133,6 +2135,16 @@ class CephUtilsTests(TestCase):
         op = base_op.copy()
         op['max-objects'] = 42
         self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_replicated_pool('apool', rbd_mirroring_mode='pool')
+        op = base_op.copy()
+        op['rbd-mirroring-mode'] = 'pool'
+        self.assertEqual(rq.ops, [op])
+        rq = ceph_utils.CephBrokerRq()
+        rq.add_op_create_replicated_pool('apool', rbd_mirroring_mode='image')
+        op = base_op.copy()
+        op['rbd-mirroring-mode'] = 'image'
+        self.assertEqual(rq.ops, [op])
 
     def test_add_op_create_erasure_pool(self):
         base_op = {'app-name': None,
@@ -2154,6 +2166,7 @@ class CephUtilsTests(TestCase):
                    'name': 'apool',
                    'op': 'create-pool',
                    'pool-type': 'erasure',
+                   'rbd-mirroring-mode': 'pool',
                    'weight': None}
         rq = ceph_utils.CephBrokerRq()
         rq.add_op_create_erasure_pool('apool')


### PR DESCRIPTION
These changes are part of the implementation of the [Cinder Ceph Replication](https://opendev.org/openstack/charm-specs/src/commit/40367522bf03cb18cc4d1c0d055aab6065f41fcc/specs/wallaby/backlog/cinder-ceph-replication.rst) spec:

- Update the broker request handler to take into consideration the new rbd-mirroring-mode flag.
   Add 'rbd-mirroring-mode' as part of the 'create-pool' operation 
   This value is going to be parsed by the ceph-rbd-mirror charm when enabling pool mirroring.
   It defaults to 'pool', since this was the only mode handled previously by the ceph-rbd-mirror charm.

- Update CephContext to ignore advertised default RBD features from the relation with ceph-mon, if the client charm implements the new 'rbd-mirroring-mode' flag, and that's set to 'image'.

- Add Ceph relation name parameter to the CephContext constructor. The current implementation assumes that the clients will name their relation 'ceph'. This will remove the hard-coded value, and make it the default parameter value. Thus, we will maintain the backwards compatibility.
This is going to be useful for charms that implement the ceph-client interface, but the relation name is not ceph.
