### PR TITLE
Fix virtualenv creation on bionic

### DIFF
--- a/charmhelpers/fetch/python/packages.py
+++ b/charmhelpers/fetch/python/packages.py
@@ -142,8 +142,10 @@ def pip_create_virtualenv(path=None):
     """Create an isolated Python environment."""
     if six.PY2:
         apt_install('python-virtualenv')
+        extra_flags = []
     else:
-        apt_install('python3-virtualenv')
+        apt_install(['python3-virtualenv', 'virtualenv'])
+        extra_flags = ['--python=python3']
 
     if path:
         venv_path = path
@@ -151,4 +153,4 @@ def pip_create_virtualenv(path=None):
         venv_path = os.path.join(charm_dir(), 'venv')
 
     if not os.path.exists(venv_path):
-        subprocess.check_call(['virtualenv', venv_path])
+        subprocess.check_call(['virtualenv', venv_path] + extra_flags)

--- a/tests/fetch/python/test_packages.py
+++ b/tests/fetch/python/test_packages.py
@@ -172,6 +172,8 @@ class PipTestCase(TestCase):
         packages.pip_create_virtualenv()
         if six.PY2:
             self.apt_install.assert_called_with('python-virtualenv')
+            expect_flags = []
         else:
-            self.apt_install.assert_called_with('python3-virtualenv')
-        check_call.assert_called_with(['virtualenv', 'joined-path'])
+            self.apt_install.assert_called_with(['python3-virtualenv', 'virtualenv'])
+            expect_flags = ['--python=python3']
+        check_call.assert_called_with(['virtualenv', 'joined-path'] + expect_flags)


### PR DESCRIPTION
The virtualenv executable wasn't shipped with python3-virtualenv but
in a separate package for bionic. For focal the virtualenv package is
a dependency only package.

Also, we need to specify the python version for python3 virtualenvs
now.

Fixes issue #528