### PR TITLE
Partially revert "Updates for the Cinder Ceph Replication spec (#526)"

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -777,13 +777,10 @@ class AMQPContext(OSContextGenerator):
 
 class CephContext(OSContextGenerator):
     """Generates context for /etc/ceph/ceph.conf templates."""
-
-    def __init__(self, ceph_relation='ceph'):
-        self._ceph_relation = ceph_relation
-        self.interfaces = [ceph_relation]
+    interfaces = ['ceph']
 
     def __call__(self):
-        if not relation_ids(self._ceph_relation):
+        if not relation_ids('ceph'):
             return {}
 
         log('Generating template context for ceph', level=DEBUG)
@@ -792,7 +789,7 @@ class CephContext(OSContextGenerator):
             'use_syslog': str(config('use-syslog')).lower()
         }
         rbd_mirroring_mode = config('rbd-mirroring-mode')
-        for rid in relation_ids(self._ceph_relation):
+        for rid in relation_ids('ceph'):
             for unit in related_units(rid):
                 if not ctxt.get('auth'):
                     ctxt['auth'] = relation_get('auth', rid=rid, unit=unit)

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -788,14 +788,13 @@ class CephContext(OSContextGenerator):
         ctxt = {
             'use_syslog': str(config('use-syslog')).lower()
         }
-        rbd_mirroring_mode = config('rbd-mirroring-mode')
         for rid in relation_ids('ceph'):
             for unit in related_units(rid):
                 if not ctxt.get('auth'):
                     ctxt['auth'] = relation_get('auth', rid=rid, unit=unit)
                 if not ctxt.get('key'):
                     ctxt['key'] = relation_get('key', rid=rid, unit=unit)
-                if rbd_mirroring_mode != "image" and not ctxt.get('rbd_features'):
+                if not ctxt.get('rbd_features'):
                     default_features = relation_get('rbd-features', rid=rid, unit=unit)
                     if default_features is not None:
                         ctxt['rbd_features'] = default_features

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1853,40 +1853,6 @@ class ContextTests(unittest.TestCase):
     @patch('os.path.isdir')
     @patch('os.mkdir')
     @patch.object(context, 'ensure_packages')
-    def test_ceph_context_with_mirror_image(
-            self, ensure_packages, mkdir, isdir, mock_config):
-        '''Test ceph context in host with rbd_mirroring_mode  set to "image"
-        We expect rbd_features to not be set'''
-        isdir.return_value = False
-        config_dict = {
-            'use-syslog': True,
-            'rbd-mirroring-mode': 'image'
-        }
-
-        def fake_config(key):
-            return config_dict.get(key)
-
-        mock_config.side_effect = fake_config
-        relation = FakeRelation(relation_data=CEPH_REL_WITH_DEFAULT_FEATURES)
-        self.relation_get.side_effect = relation.get
-        self.relation_ids.side_effect = relation.relation_ids
-        self.related_units.side_effect = relation.relation_units
-        ceph = context.CephContext()
-        result = ceph()
-        expected = {
-            'mon_hosts': 'ceph_node1 ceph_node2',
-            'auth': 'foo',
-            'key': 'bar',
-            'use_syslog': "true"
-        }
-        self.assertEquals(result, expected)
-        ensure_packages.assert_called_with(['ceph-common'])
-        mkdir.assert_called_with('/etc/ceph')
-
-    @patch.object(context, 'config')
-    @patch('os.path.isdir')
-    @patch('os.mkdir')
-    @patch.object(context, 'ensure_packages')
     def test_ceph_context_ec_pool_no_rbd_pool(
             self, ensure_packages, mkdir, isdir, mock_config):
         '''Test ceph context with erasure coded pools'''

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -329,27 +329,6 @@ CEPH_RELATION = {
     }
 }
 
-CEPH_REPLICATION_DEVICE_RELATION = {
-    'ceph-replication-device:0': {
-        'ceph/0': {
-            'private-address': 'ceph_node1',
-            'auth': 'foo',
-            'key': 'bar',
-            'rbd-pool': 'test1',
-            'pool-type': 'replicated',
-            'rbd-mirroring-mode': 'pool'
-        },
-        'ceph/1': {
-            'private-address': 'ceph_node2',
-            'auth': 'foo',
-            'key': 'bar',
-            'rbd-pool': 'test2',
-            'pool-type': 'replicated',
-            'rbd-mirroring-mode': 'image'
-        }
-    }
-}
-
 CEPH_RELATION_WITH_PUBLIC_ADDR = {
     'ceph:0': {
         'ceph/0': {
@@ -1603,34 +1582,6 @@ class ContextTests(unittest.TestCase):
         ceph = context.CephContext()
         result = ceph()
         self.assertEquals(result, {})
-
-    @patch('os.path.isdir')
-    @patch('os.mkdir')
-    @patch.object(context, 'config')
-    @patch.object(context, 'ensure_packages')
-    def test_ceph_rel_replication_device(self, ensure_packages, mock_config, mkdir, isdir):
-        '''Test ceph context with ceph-replication-device relation'''
-        config_dict = {'use-syslog': True}
-
-        def fake_config(key):
-            return config_dict.get(key)
-
-        isdir.return_value = True
-        mock_config.side_effect = fake_config
-        relation = FakeRelation(relation_data=CEPH_REPLICATION_DEVICE_RELATION)
-        self.relation_get.side_effect = relation.get
-        self.relation_ids.side_effect = relation.relation_ids
-        self.related_units.side_effect = relation.relation_units
-        ceph = context.CephContext(ceph_relation='ceph-replication-device')
-        result = ceph()
-        expected = {
-            'auth': 'foo',
-            'key': 'bar',
-            'mon_hosts': 'ceph_node1 ceph_node2',
-            'use_syslog': 'true'
-        }
-        self.assertEquals(result, expected)
-        self.assertEquals(ceph.interfaces, ['ceph-replication-device'])
 
     @patch.object(context, 'config')
     @patch('os.path.isdir')


### PR DESCRIPTION
Partially revert "Updates for the Cinder Ceph Replication spec (#526)"
This partially reverts commit ead529b.

When pulled into charm-ceph-radosgw the reverted change
leads to both an incomplete context when rendering ceph.conf
and a missing 'mon' relation.

@ionutbalutoiu @oprinmarius Please re-create the reverted change as a new pull request and validate it against charm-ceph-radosgw, thanks!