### PR TITLE
update region_name on [placement]

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-placement
+++ b/charmhelpers/contrib/openstack/templates/section-placement
@@ -15,5 +15,6 @@ password = {{ admin_password }}
 {% endif -%}
 {% if region -%}
 os_region_name = {{ region }}
+region_name = {{ region }}
 {% endif -%}
 randomize_allocation_candidates = true


### PR DESCRIPTION
The os_region_name option has been deprecated in Rocky [0]
and removed in Stein [1], therefore the template that is
used across all OpenStack releases needs to be updated to
include the region_name option, so nova-cloud-controller and
other charms consuming this template present both config
options to OpenStack, which will use the appropriate one
for the running release.

[0] https://github.com/openstack/nova/blob/master/releasenotes/notes/placement-via-ksa-02d87c87636912f8.yaml
[1] https://github.com/openstack/nova/blob/master/releasenotes/notes/remove-deprecated-placement-opts-aeffb090a2e94bdc.yaml

Related-bug: #1903210