### PR TITLE
Add support for pmd-socket-cores

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2566,12 +2566,30 @@ class OVSDPDKDeviceContext(OSContextGenerator):
         :returns: hex formatted CPU mask
         :rtype: str
         """
-        num_cores = config('dpdk-socket-cores')
-        mask = 0
+        return self.cpu_masks()['dpdk_lcore_mask']
+
+    def cpu_masks(self):
+        """Get hex formatted CPU masks
+
+        The mask is based on using the first config:dpdk-socket-cores
+        cores of each NUMA node in the unit, followed by the
+        next config:pmd-socket-cores
+
+        :returns: Dict of hex formatted CPU masks
+        :rtype: Dict[str, str]
+        """
+        num_lcores = config('dpdk-socket-cores')
+        pmd_cores = config('pmd-socket-cores')
+        lcore_mask = 0
+        pmd_mask = 0
         for cores in self._numa_node_cores().values():
-            for core in cores[:num_cores]:
-                mask = mask | 1 << core
-        return format(mask, '#04x')
+            for core in cores[:num_lcores]:
+                lcore_mask = lcore_mask | 1 << core
+            for core in cores[num_lcores:][:pmd_cores]:
+                pmd_mask = pmd_mask | 1 << core
+        return {
+            'pmd_cpu_mask': format(pmd_mask, '#04x'),
+            'dpdk_lcore_mask': format(lcore_mask, '#04x')}
 
     def socket_memory(self):
         """Formatted list of socket memory configuration per NUMA node

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4565,6 +4565,17 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
         }.get(x)
         self.assertEqual(self.target.cpu_mask(), '0x33')
 
+    def test_cpu_masks(self):
+        self.patch_target('_numa_node_cores')
+        self._numa_node_cores.return_value = NUMA_CORES_MULTI
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 1,
+            'pmd-socket-cores': 2,
+        }.get(x)
+        self.assertEqual(
+            self.target.cpu_masks(),
+            {'dpdk_lcore_mask': '0x11', 'pmd_cpu_mask': '0x66'})
+
     def test_context_no_devices(self):
         """Ensure that DPDK is disable when no devices detected"""
         self.patch_object(context, 'resolve_pci_from_mapping_config')


### PR DESCRIPTION
The OpenStack charms allow a user to specify how many cores in
each NUMA socket will be dedicated to non-datapath DPDK threads
via the dpdk-socket-cores config option. This change adds support
for a new config option, pmd-socket-cores. pmd-socket-cores
specifies how many cores in each NUMA socket will be dedicated to
packet processing.