### PR TITLE
Add max_check_attempts support for nrpe checks

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -142,7 +142,7 @@ define service {{
 }}
 """)
 
-    def __init__(self, shortname, description, check_cmd):
+    def __init__(self, shortname, description, check_cmd, max_check_attempts=None):
         super(Check, self).__init__()
         # XXX: could be better to calculate this from the service name
         if not re.match(self.shortname_re, shortname):
@@ -155,6 +155,7 @@ define service {{
         # The default is: illegal_object_name_chars=`~!$%^&*"|'<>?,()=
         self.description = description
         self.check_cmd = self._locate_cmd(check_cmd)
+        self.max_check_attempts = max_check_attempts
 
     def _get_check_filename(self):
         return os.path.join(NRPE.nrpe_confdir, '{}.cfg'.format(self.command))
@@ -327,6 +328,11 @@ class NRPE(object):
             nrpe_monitors[nrpecheck.shortname] = {
                 "command": nrpecheck.command,
             }
+            # If we were passed max_check_attempts, add that to the relation data
+            try:
+                nrpe_monitors[nrpecheck.shortname]['max_check_attempts'] = nrpecheck.max_check_attempts
+            except AttributeError:
+                pass
 
         # update-status hooks are configured to firing every 5 minutes by
         # default. When nagios-nrpe-server is restarted, the nagios server

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -139,6 +139,7 @@ define service {{
                         """{description}
     check_command                   check_nrpe!{command}
     servicegroups                   {nagios_servicegroup}
+{service_config_overrides}
 }}
 """)
 
@@ -217,12 +218,19 @@ define service {{
                              nagios_servicegroups):
         self._remove_service_files()
 
+        if self.max_check_attempts:
+            service_config_overrides = '    max_check_attempts              {}'.format(
+                self.max_check_attempts
+            )  # Note indentation is here rather than in the template to avoid trailing spaces
+        else:
+            service_config_overrides = ''  # empty string to avoid printing 'None'
         templ_vars = {
             'nagios_hostname': hostname,
             'nagios_servicegroup': nagios_servicegroups,
             'description': self.description,
             'shortname': self.shortname,
             'command': self.command,
+            'service_config_overrides': service_config_overrides,
         }
         nrpe_service_text = Check.service_template.format(**templ_vars)
         nrpe_service_file = self._get_service_filename(hostname)

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -178,7 +178,9 @@ define service {
         self.assertEqual(expected, actual)
 
         nrpe_monitors = {'myservice':
-                         {'command': 'check_myservice'}}
+                         {'command': 'check_myservice',
+                          'max_check_attempts': None,
+                          }}
         monitors = yaml.dump(
             {"monitors": {"remote": {"nrpe": nrpe_monitors}}})
         relation_set_calls = [

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -164,6 +164,7 @@ define service {
     service_description             a-testunit[myservice] Check MyService
     check_command                   check_nrpe!check_myservice
     servicegroups                   a
+
 }
 """
         expected = [
@@ -180,6 +181,81 @@ define service {
         nrpe_monitors = {'myservice':
                          {'command': 'check_myservice',
                           'max_check_attempts': None,
+                          }}
+        monitors = yaml.dump(
+            {"monitors": {"remote": {"nrpe": nrpe_monitors}}})
+        relation_set_calls = [
+            call(monitors=monitors, relation_id="local-monitors:1"),
+            call(monitors=monitors, relation_id="nrpe-external-master:2"),
+        ]
+        self.patched['relation_set'].assert_has_calls(relation_set_calls, any_order=True)
+        self.check_call_counts(config=1, getpwnam=1, getgrnam=1,
+                               exists=4, open=2, listdir=1, relation_get=2,
+                               relation_ids=3, relation_set=3)
+
+    def test_max_check_attmpts(self):
+        self.patched['config'].return_value = {'nagios_context': 'a',
+                                               'nagios_servicegroups': ''}
+        self.patched['exists'].return_value = True
+        self.patched['relation_get'].return_value = {
+            'egress-subnets': '10.66.111.24/32',
+            'ingress-address': '10.66.111.24',
+            'private-address': '10.66.111.24'
+        }
+
+        def _rels(rname):
+            relations = {
+                'local-monitors': 'local-monitors:1',
+                'nrpe-external-master': 'nrpe-external-master:2',
+            }
+            return [relations[rname]]
+        self.patched['relation_ids'].side_effect = _rels
+
+        checker = nrpe.NRPE()
+        checker.add_check(shortname="myservice",
+                          description="Check MyService",
+                          check_cmd="check_http http://localhost",
+                          max_check_attempts=8,
+                          )
+
+        self.assertEqual(None, checker.write())
+
+        self.assertEqual(2, self.patched['open'].call_count)
+        filename = 'check_myservice.cfg'
+        expected = [
+            ('/etc/nagios/nrpe.d/%s' % filename, 'w'),
+            ('/var/lib/nagios/export/service__a-testunit_%s' % filename, 'w'),
+        ]
+        actual = [x[0] for x in self.patched['open'].call_args_list]
+        self.assertEqual(expected, actual)
+        outfile = self.patched['open'].return_value.__enter__.return_value
+        service_file_contents = """
+#---------------------------------------------------
+# This file is Juju managed
+#---------------------------------------------------
+define service {
+    use                             active-service
+    host_name                       a-testunit
+    service_description             a-testunit[myservice] Check MyService
+    check_command                   check_nrpe!check_myservice
+    servicegroups                   a
+    max_check_attempts              8
+}
+"""
+        expected = [
+            '# check myservice\n',
+            '# The following header was added automatically by juju\n',
+            '# Modifying it will affect nagios monitoring and alerting\n',
+            '# servicegroups: a\n',
+            'command[check_myservice]=/usr/lib/nagios/plugins/check_http http://localhost\n',
+            service_file_contents,
+        ]
+        actual = [x[0][0] for x in outfile.write.call_args_list]
+        self.assertEqual(expected, actual)
+
+        nrpe_monitors = {'myservice':
+                         {'command': 'check_myservice',
+                          'max_check_attempts': 8,
                           }}
         monitors = yaml.dump(
             {"monitors": {"remote": {"nrpe": nrpe_monitors}}})


### PR DESCRIPTION
Add support to nrpe for optional attribute max_check_attempts.  If
supplied, max_check_attempts is added to the NRPE check when consumed by
the Nagios host, overriding the default.