### PR TITLE
Add http_proxy to environment for add_apt_repository to address #544

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -646,7 +646,7 @@ def _add_apt_repository(spec):
     # passed as environment variables (See lp:1433761). This is not the case
     # LTS and non-LTS releases below bionic.
     _run_with_retries(['add-apt-repository', '--yes', spec],
-                      cmd_env=env_proxy_settings(['https']))
+                      cmd_env=env_proxy_settings(['https', 'http']))
 
 
 def _add_cloud_pocket(pocket):


### PR DESCRIPTION
It was recently found that some references in the ubuntu keyserver point to http:// hosted GPG keys for PPAs which will require add-apt-repository to have both https_proxy and http_proxy variables set.

See issue #544 for further details.