### PR TITLE
 Add 'is_ssl_enabled' for bug 1851610 to check if SSL module is enabled

### DIFF
--- a/charmhelpers/contrib/hardening/audits/apache.py
+++ b/charmhelpers/contrib/hardening/audits/apache.py
@@ -98,3 +98,8 @@ class DisabledModuleAudit(BaseAudit):
     def _restart_apache():
         """Restarts the apache process"""
         subprocess.check_output(['service', 'apache2', 'restart'])
+
+    @staticmethod
+    def is_ssl_enabled():
+        """Check if SSL module is enabled or not"""
+        return 'ssl' in DisabledModuleAudit._get_loaded_modules()

--- a/tests/contrib/hardening/audits/test_apache_audits.py
+++ b/tests/contrib/hardening/audits/test_apache_audits.py
@@ -84,3 +84,14 @@ class DisabledModuleAuditsTest(TestCase):
         audit = apache.DisabledModuleAudit('bar')
         result = audit._get_loaded_modules()
         self.assertEqual(['foo', 'bar'], result)
+
+    @patch('subprocess.check_output')
+    def test_is_ssl_enabled(self, mock_check_output):
+        mock_check_output.return_value = (b'Loaded Modules:\n'
+                                          b' foo_module (static)\n'
+                                          b' bar_module (shared)\n'
+                                          b' ssl_module (shared)\n')
+        audit = apache.DisabledModuleAudit('bar')
+        result = audit._get_loaded_modules()
+        self.assertEqual(['foo', 'bar', 'ssl'], result)
+        self.assertTrue(audit.is_ssl_enabled())


### PR DESCRIPTION
 Add 'is_ssl_enable' for bug 1851610 to check if SSL module is enabled or not

The gerrit review link:  https://review.opendev.org/c/openstack/charm-neutron-api/+/766883