### PR TITLE
Disable apache 'status' module 

### DIFF
--- a/charmhelpers/contrib/hardening/defaults/apache.yaml
+++ b/charmhelpers/contrib/hardening/defaults/apache.yaml
@@ -10,7 +10,7 @@ common:
 hardening:
     traceenable: 'off'
     allowed_http_methods: "GET POST"
-    modules_to_disable: [ cgi, cgid ]
+    modules_to_disable: [ cgi, cgid, status ]
     servertokens: 'Prod'
     honor_cipher_order: 'on'
     cipher_suite: 'ALL:+MEDIUM:+HIGH:!LOW:!MD5:!RC4:!eNULL:!aNULL:!3DES'


### PR DESCRIPTION
Apache 'status' module is enabled by default, 
which exposes some security risks as described
in bug 1836513. This PR added 'status' module
to modules_to_disable so that /server-status
endpoint would not expose

The gerrit review link: https://review.opendev.org/c/openstack/charm-openstack-dashboard/+/764602