### PR TITLE
Run actual tests of _calculate_workers and _num_cpus

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1596,9 +1596,15 @@ def _calculate_workers():
 
     @returns int: number of worker processes to use
     '''
-    multiplier = config('worker-multiplier') or DEFAULT_MULTIPLIER
+    multiplier = config('worker-multiplier')
+
+    # distinguish an empty config and an explicit config as 0.0
+    if multiplier is None:
+        multiplier = DEFAULT_MULTIPLIER
+
     count = int(_num_cpus() * multiplier)
-    if multiplier > 0 and count == 0:
+    if count <= 0:
+        # assign at least one worker
         count = 1
 
     if config('worker-multiplier') is None and is_container():

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3315,20 +3315,29 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, 'psutil')
     def test_num_cpus_xenial(self, _psutil):
         _psutil.cpu_count.return_value = 4
-        self.assertTrue(context._num_cpus(), 4)
+        self.assertEqual(context._num_cpus(), 4)
 
     @patch.object(context, 'psutil')
     def test_num_cpus_trusty(self, _psutil):
+        _psutil.cpu_count.side_effect = AttributeError
         _psutil.NUM_CPUS = 4
-        self.assertTrue(context._num_cpus(), 4)
+        self.assertEqual(context._num_cpus(), 4)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_float(self, _num_cpus):
         self.config.side_effect = fake_config({
             'worker-multiplier': 0.3
         })
-        _num_cpus.return_value = 4
-        self.assertTrue(context._calculate_workers(), 4)
+        _num_cpus.return_value = 8
+        self.assertEqual(context._calculate_workers(), 2)
+
+    @patch.object(context, '_num_cpus')
+    def test_calculate_workers_float_negative(self, _num_cpus):
+        self.config.side_effect = fake_config({
+            'worker-multiplier': -4.0
+        })
+        _num_cpus.return_value = 8
+        self.assertEqual(context._calculate_workers(), 1)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_not_quite_0(self, _num_cpus):
@@ -3339,28 +3348,28 @@ class ContextTests(unittest.TestCase):
             'worker-multiplier': 0.001
         })
         _num_cpus.return_value = 100
-        self.assertTrue(context._calculate_workers(), 1)
+        self.assertEqual(context._calculate_workers(), 1)
 
-    @patch.object(context, 'psutil')
-    def test_calculate_workers_0(self, _psutil):
+    @patch.object(context, '_num_cpus')
+    def test_calculate_workers_0(self, _num_cpus):
         self.config.side_effect = fake_config({
             'worker-multiplier': 0
         })
-        _psutil.cpu_count.return_value = 2
-        self.assertTrue(context._calculate_workers(), 0)
+        _num_cpus.return_value = 2
+        self.assertEqual(context._calculate_workers(), 1)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_noconfig(self, _num_cpus):
         self.config.return_value = None
         _num_cpus.return_value = 1
-        self.assertTrue(context._calculate_workers(), 2)
+        self.assertEqual(context._calculate_workers(), 2)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_noconfig_container(self, _num_cpus):
         self.config.return_value = None
         self.is_container.return_value = True
         _num_cpus.return_value = 1
-        self.assertTrue(context._calculate_workers(), 2)
+        self.assertEqual(context._calculate_workers(), 2)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_noconfig_lotsa_cpus_container(self,
@@ -3368,14 +3377,14 @@ class ContextTests(unittest.TestCase):
         self.config.return_value = None
         self.is_container.return_value = True
         _num_cpus.return_value = 32
-        self.assertTrue(context._calculate_workers(), 4)
+        self.assertEqual(context._calculate_workers(), 4)
 
     @patch.object(context, '_num_cpus')
     def test_calculate_workers_noconfig_lotsa_cpus_not_container(self,
                                                                  _num_cpus):
         self.config.return_value = None
         _num_cpus.return_value = 32
-        self.assertTrue(context._calculate_workers(), 64)
+        self.assertEqual(context._calculate_workers(), 64)
 
     @patch.object(context, '_calculate_workers', return_value=256)
     def test_worker_context(self, calculate_workers):


### PR DESCRIPTION
Previously it succeeded always regardless of any values set. Also,
handle corner cases properly such as worker-multiplier=0.0 because the
number of workers cannot be zero.