### PR TITLE
Cap the number of workers always when multiplier is not set

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -74,7 +74,6 @@ from charmhelpers.core.host import (
     pwgen,
     lsb_release,
     CompareHostReleases,
-    is_container,
 )
 from charmhelpers.contrib.hahelpers.cluster import (
     determine_apache_port,
@@ -1581,8 +1580,7 @@ class BindHostContext(OSContextGenerator):
             return {'bind_host': '0.0.0.0'}
 
 
-MAX_DEFAULT_WORKERS = 16
-MAX_DEFAULT_WORKERS_CONTAINER = 4
+MAX_DEFAULT_WORKERS = 4
 DEFAULT_MULTIPLIER = 2
 
 
@@ -1611,13 +1609,9 @@ def _calculate_workers():
     if config('worker-multiplier') is None:
         # NOTE(jamespage): Limit unconfigured worker-multiplier
         #                  to MAX_DEFAULT_WORKERS to avoid insane
-        #                  worker configuration in LXD containers
-        #                  on large servers
+        #                  worker configuration on large servers
         # Reference: https://pad.lv/1665270
-        if is_container():
-            count = min(count, MAX_DEFAULT_WORKERS_CONTAINER)
-        else:
-            count = min(count, MAX_DEFAULT_WORKERS)
+        count = min(count, MAX_DEFAULT_WORKERS)
 
     return count
 

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1581,7 +1581,8 @@ class BindHostContext(OSContextGenerator):
             return {'bind_host': '0.0.0.0'}
 
 
-MAX_DEFAULT_WORKERS = 4
+MAX_DEFAULT_WORKERS = 16
+MAX_DEFAULT_WORKERS_CONTAINER = 4
 DEFAULT_MULTIPLIER = 2
 
 
@@ -1607,13 +1608,16 @@ def _calculate_workers():
         # assign at least one worker
         count = 1
 
-    if config('worker-multiplier') is None and is_container():
+    if config('worker-multiplier') is None:
         # NOTE(jamespage): Limit unconfigured worker-multiplier
         #                  to MAX_DEFAULT_WORKERS to avoid insane
         #                  worker configuration in LXD containers
         #                  on large servers
         # Reference: https://pad.lv/1665270
-        count = min(count, MAX_DEFAULT_WORKERS)
+        if is_container():
+            count = min(count, MAX_DEFAULT_WORKERS_CONTAINER)
+        else:
+            count = min(count, MAX_DEFAULT_WORKERS)
 
     return count
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3384,7 +3384,7 @@ class ContextTests(unittest.TestCase):
                                                                  _num_cpus):
         self.config.return_value = None
         _num_cpus.return_value = 32
-        self.assertEqual(context._calculate_workers(), 64)
+        self.assertEqual(context._calculate_workers(), 16)
 
     @patch.object(context, '_calculate_workers', return_value=256)
     def test_worker_context(self, calculate_workers):

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -685,7 +685,6 @@ TO_PATCH = [
     'kv',
     'pwgen',
     'lsb_release',
-    'is_container',
     'network_get_primary_address',
     'resolve_address',
     'is_ipv6_disabled',
@@ -740,7 +739,6 @@ class ContextTests(unittest.TestCase):
         self.kv.side_effect = TestDB
         self.pwgen.return_value = 'testpassword'
         self.lsb_release.return_value = {'DISTRIB_RELEASE': '16.04'}
-        self.is_container.return_value = False
         self.network_get_primary_address.side_effect = NotImplementedError()
         self.resolve_address.return_value = '10.5.1.50'
         self.maxDiff = None
@@ -3365,26 +3363,10 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(context._calculate_workers(), 2)
 
     @patch.object(context, '_num_cpus')
-    def test_calculate_workers_noconfig_container(self, _num_cpus):
+    def test_calculate_workers_noconfig_lotsa_cpus(self, _num_cpus):
         self.config.return_value = None
-        self.is_container.return_value = True
-        _num_cpus.return_value = 1
-        self.assertEqual(context._calculate_workers(), 2)
-
-    @patch.object(context, '_num_cpus')
-    def test_calculate_workers_noconfig_lotsa_cpus_container(self,
-                                                             _num_cpus):
-        self.config.return_value = None
-        self.is_container.return_value = True
         _num_cpus.return_value = 32
         self.assertEqual(context._calculate_workers(), 4)
-
-    @patch.object(context, '_num_cpus')
-    def test_calculate_workers_noconfig_lotsa_cpus_not_container(self,
-                                                                 _num_cpus):
-        self.config.return_value = None
-        _num_cpus.return_value = 32
-        self.assertEqual(context._calculate_workers(), 16)
 
     @patch.object(context, '_calculate_workers', return_value=256)
     def test_worker_context(self, calculate_workers):


### PR DESCRIPTION
**This pull request depends on #552.**

Previously the cap is only applied to the units in containers. However,
services in a bare metal also requires a sensible cap. Otherwise,
nova-compute, for example, will have 256 workers for nova-api-metadata
out of the box which is an overkill with the following system.

32 cores * 2 threads/core * 2 sockets * 2 (default multiplier) = 256

Let's cap the number of workers as 4 always, then let operators override
it with an explicit config to worker-multiplier.

Closes-Bug: [LP: #1843011](https://bugs.launchpad.net/charm-nova-compute/+bug/1843011)