### PR TITLE
Use bindings for certificate requests

### DIFF
--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -106,10 +106,10 @@ class CertUtilsTests(unittest.TestCase):
             '10.10.0.3': '10.10.0.0/16',
             '10.20.0.3': '10.20.0.0/16',
         }
-        get_certificate_sans.return_value = set(
+        get_certificate_sans.return_value = list(set(
             list(_resolve_address.values()) +
             list(_npa.values()) +
-            list(_vips.values()))
+            list(_vips.values())))
         expect = {
             'admin.openstack.local': {
                 'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
@@ -130,6 +130,76 @@ class CertUtilsTests(unittest.TestCase):
         self.assertEqual(
             output,
             expect)
+        get_certificate_sans.assert_called_once_with(
+            bindings=['internal', 'admin', 'public'])
+
+    @mock.patch.object(cert_utils, 'get_certificate_sans')
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
+    @mock.patch.object(cert_utils, 'resolve_network_cidr')
+    @mock.patch.object(cert_utils, 'get_vip_in_network')
+    @mock.patch.object(cert_utils, 'network_get_primary_address')
+    @mock.patch.object(cert_utils, 'resolve_address')
+    @mock.patch.object(cert_utils, 'config')
+    @mock.patch.object(cert_utils, 'get_hostname')
+    @mock.patch.object(cert_utils, 'unit_get')
+    def test_get_certificate_request_no_hostnames(
+            self, unit_get, get_hostname, config, resolve_address,
+            network_get_primary_address, get_vip_in_network,
+            resolve_network_cidr, local_unit, get_certificate_sans):
+        unit_get.return_value = '10.1.2.3'
+        get_hostname.return_value = 'juju-unit-2'
+        _config = {
+            'os-admin-hostname': 'admin.openstack.local',
+            'os-public-hostname': 'public.openstack.local',
+        }
+        _resolve_address = {
+            'int': '10.0.0.2',
+            'internal': '10.0.0.2',
+            'admin': '10.10.0.2',
+            'public': '10.20.0.2',
+        }
+        _npa = {
+            'internal': '10.0.0.3',
+            'admin': '10.10.0.3',
+            'public': '10.20.0.3',
+            'mybinding': '10.30.0.3',
+        }
+        _vips = {
+            '10.0.0.0/16': '10.0.0.100',
+            '10.10.0.0/16': '10.10.0.100',
+            '10.20.0.0/16': '10.20.0.100',
+        }
+        _resolve_nets = {
+            '10.0.0.3': '10.0.0.0/16',
+            '10.10.0.3': '10.10.0.0/16',
+            '10.20.0.3': '10.20.0.0/16',
+        }
+        get_certificate_sans.return_value = list(set(
+            list(_resolve_address.values()) +
+            list(_npa.values()) +
+            list(_vips.values())))
+        expect = {
+            'admin.openstack.local': {
+                'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
+            'juju-unit-2': {'sans': [
+                '10.0.0.100', '10.0.0.2', '10.0.0.3', '10.1.2.3', '10.30.0.3']},
+            'public.openstack.local': {
+                'sans': ['10.20.0.100', '10.20.0.2', '10.20.0.3']}}
+        self.maxDiff = None
+        config.side_effect = lambda x: _config.get(x)
+        get_vip_in_network.side_effect = lambda x: _vips.get(x)
+        resolve_network_cidr.side_effect = lambda x: _resolve_nets.get(x)
+        network_get_primary_address.side_effect = lambda x: _npa.get(x)
+        resolve_address.side_effect = \
+            lambda endpoint_type: _resolve_address[endpoint_type]
+        output = json.loads(
+            cert_utils.get_certificate_request(
+                bindings=['mybinding'])['cert_requests'])
+        self.assertEqual(
+            output,
+            expect)
+        get_certificate_sans.assert_called_once_with(
+            bindings=['mybinding', 'internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'get_certificate_request')
     @mock.patch.object(cert_utils, 'unit_get')
@@ -199,6 +269,79 @@ class CertUtilsTests(unittest.TestCase):
             mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_funky-name'),
         ])
         symlink.assert_has_calls(expected, any_order=True)
+        get_cert_request.assert_called_with(
+            json_encode=False, bindings=['internal', 'admin', 'public'])
+
+    @mock.patch.object(cert_utils, 'get_certificate_request')
+    @mock.patch.object(cert_utils, 'unit_get')
+    @mock.patch.object(cert_utils.os, 'symlink')
+    @mock.patch.object(cert_utils.os.path, 'isfile')
+    @mock.patch.object(cert_utils, 'get_hostname')
+    def test_create_ip_cert_links_bindings(
+            self, get_hostname, isfile, symlink, unit_get, get_cert_request):
+        cert_request = {'cert_requests': {
+            'admin.openstack.local': {
+                'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
+            'internal.openstack.local': {
+                'sans': ['10.0.0.100', '10.0.0.2', '10.0.0.3']},
+            'juju-unit-2': {'sans': ['10.1.2.3']},
+            'public.openstack.local': {
+                'sans': ['10.20.0.100', '10.20.0.2', '10.20.0.3']}}}
+        get_cert_request.return_value = cert_request
+        _files = {
+            '/etc/ssl/cert_juju-unit-2': True,
+            '/etc/ssl/cert_10.1.2.3': False,
+            '/etc/ssl/cert_admin.openstack.local': True,
+            '/etc/ssl/cert_10.10.0.100': False,
+            '/etc/ssl/cert_10.10.0.2': False,
+            '/etc/ssl/cert_10.10.0.3': False,
+            '/etc/ssl/cert_internal.openstack.local': True,
+            '/etc/ssl/cert_10.0.0.100': False,
+            '/etc/ssl/cert_10.0.0.2': False,
+            '/etc/ssl/cert_10.0.0.3': False,
+            '/etc/ssl/cert_public.openstack.local': True,
+            '/etc/ssl/cert_10.20.0.100': False,
+            '/etc/ssl/cert_10.20.0.2': False,
+            '/etc/ssl/cert_10.20.0.3': False,
+            '/etc/ssl/cert_funky-name': False,
+        }
+        isfile.side_effect = lambda x: _files[x]
+        expected = [
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.100'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.100'),
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.2'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.2'),
+            mock.call('/etc/ssl/cert_admin.openstack.local', '/etc/ssl/cert_10.10.0.3'),
+            mock.call('/etc/ssl/key_admin.openstack.local', '/etc/ssl/key_10.10.0.3'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.100'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.100'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.2'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.2'),
+            mock.call('/etc/ssl/cert_internal.openstack.local', '/etc/ssl/cert_10.0.0.3'),
+            mock.call('/etc/ssl/key_internal.openstack.local', '/etc/ssl/key_10.0.0.3'),
+            mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_10.1.2.3'),
+            mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_10.1.2.3'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.100'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.100'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.2'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.2'),
+            mock.call('/etc/ssl/cert_public.openstack.local', '/etc/ssl/cert_10.20.0.3'),
+            mock.call('/etc/ssl/key_public.openstack.local', '/etc/ssl/key_10.20.0.3')]
+        cert_utils.create_ip_cert_links('/etc/ssl', bindings=['mybindings'])
+        symlink.assert_has_calls(expected, any_order=True)
+        # Customer hostname
+        symlink.reset_mock()
+        get_hostname.return_value = 'juju-unit-2'
+        cert_utils.create_ip_cert_links(
+            '/etc/ssl',
+            custom_hostname_link='funky-name', bindings=['mybinding'])
+        expected.extend([
+            mock.call('/etc/ssl/cert_juju-unit-2', '/etc/ssl/cert_funky-name'),
+            mock.call('/etc/ssl/key_juju-unit-2', '/etc/ssl/key_funky-name'),
+        ])
+        symlink.assert_has_calls(expected, any_order=True)
+        get_cert_request.assert_called_with(
+            json_encode=False, bindings=['mybinding', 'internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'write_file')
     def test_install_certs(self, write_file):
@@ -287,7 +430,56 @@ class CertUtilsTests(unittest.TestCase):
             'MYCHAIN', user='root', group='root')
         create_ip_cert_links.assert_called_once_with(
             '/etc/apache2/ssl/myservice',
-            custom_hostname_link='funky-name')
+            custom_hostname_link='funky-name',
+            bindings=['internal', 'admin', 'public'])
+
+    @mock.patch.object(cert_utils, '_manage_ca_certs')
+    @mock.patch.object(cert_utils, 'remote_service_name')
+    @mock.patch.object(cert_utils, 'local_unit')
+    @mock.patch.object(cert_utils, 'create_ip_cert_links')
+    @mock.patch.object(cert_utils, 'install_certs')
+    @mock.patch.object(cert_utils, 'install_ca_cert')
+    @mock.patch.object(cert_utils, 'mkdir')
+    @mock.patch.object(cert_utils, 'relation_get')
+    def test_process_certificates_bindings(
+            self, relation_get, mkdir, install_ca_cert,
+            install_certs, create_ip_cert_links,
+            local_unit, remote_service_name, _manage_ca_certs):
+        remote_service_name.return_value = 'vault'
+        local_unit.return_value = 'devnull/2'
+        certs = {
+            'admin.openstack.local': {
+                'cert': 'ADMINCERT',
+                'key': 'ADMINKEY'}}
+        _relation_info = {
+            'keystone_2.processed_requests': json.dumps(certs),
+            'chain': 'MYCHAIN',
+            'ca': 'ROOTCA',
+        }
+        relation_get.return_value = _relation_info
+        self.assertFalse(cert_utils.process_certificates(
+            'myservice',
+            'certificates:2',
+            'vault/0',
+            custom_hostname_link='funky-name'))
+        local_unit.return_value = 'keystone/2'
+        self.assertTrue(cert_utils.process_certificates(
+            'myservice',
+            'certificates:2',
+            'vault/0',
+            custom_hostname_link='funky-name',
+            bindings=['mybinding']))
+        _manage_ca_certs.assert_called_once_with(
+            'ROOTCA', 'certificates:2')
+        install_certs.assert_called_once_with(
+            '/etc/apache2/ssl/myservice',
+            {'admin.openstack.local': {
+                'key': 'ADMINKEY', 'cert': 'ADMINCERT'}},
+            'MYCHAIN', user='root', group='root')
+        create_ip_cert_links.assert_called_once_with(
+            '/etc/apache2/ssl/myservice',
+            custom_hostname_link='funky-name',
+            bindings=['mybinding', 'internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'remote_service_name')
     @mock.patch.object(cert_utils.os, 'remove')
@@ -425,11 +617,11 @@ class CertUtilsTests(unittest.TestCase):
             '10.10.0.3': '10.10.0.0/16',
             '10.20.0.3': '10.20.0.0/16',
         }
-        expect = set([
+        expect = list(set([
             '10.10.0.100', '10.10.0.2', '10.10.0.3',
             '10.0.0.100', '10.0.0.2', '10.0.0.3',
             '10.1.2.3',
-            '10.20.0.100', '10.20.0.2', '10.20.0.3'])
+            '10.20.0.100', '10.20.0.2', '10.20.0.3']))
         self.maxDiff = None
         config.side_effect = lambda x: _config.get(x)
         get_vip_in_network.side_effect = lambda x: _vips.get(x)
@@ -437,4 +629,73 @@ class CertUtilsTests(unittest.TestCase):
         get_relation_ip.side_effect = lambda x, cidr_network: _npa.get(x)
         resolve_address.side_effect = \
             lambda endpoint_type: _resolve_address[endpoint_type]
-        self.assertEqual(cert_utils.get_certificate_sans(), expect)
+        expected_get_relation_ip_calls = [
+            mock.call('internal', cidr_network=None),
+            mock.call('admin', cidr_network=None),
+            mock.call('public', cidr_network=None)]
+        self.assertEqual(cert_utils.get_certificate_sans().sort(),
+                         expect.sort())
+        get_relation_ip.assert_has_calls(
+            expected_get_relation_ip_calls, any_order=True)
+
+    @mock.patch.object(cert_utils, 'local_unit', return_value='unit/2')
+    @mock.patch.object(cert_utils, 'resolve_network_cidr')
+    @mock.patch.object(cert_utils, 'get_vip_in_network')
+    @mock.patch.object(cert_utils, 'get_relation_ip')
+    @mock.patch.object(cert_utils, 'resolve_address')
+    @mock.patch.object(cert_utils, 'config')
+    @mock.patch.object(cert_utils, 'get_hostname')
+    @mock.patch.object(cert_utils, 'unit_get')
+    def test_get_certificate_sans_bindings(
+            self, unit_get, get_hostname, config, resolve_address,
+            get_relation_ip, get_vip_in_network, resolve_network_cidr, local_unit):
+        unit_get.return_value = '10.1.2.3'
+        get_hostname.return_value = 'juju-unit-2'
+        _config = {
+            'os-internal-hostname': 'internal.openstack.local',
+            'os-admin-hostname': 'admin.openstack.local',
+            'os-public-hostname': 'public.openstack.local',
+        }
+        _resolve_address = {
+            'int': '10.0.0.2',
+            'internal': '10.0.0.2',
+            'admin': '10.10.0.2',
+            'public': '10.20.0.2',
+        }
+        _npa = {
+            'internal': '10.0.0.3',
+            'admin': '10.10.0.3',
+            'public': '10.20.0.3',
+        }
+        _vips = {
+            '10.0.0.0/16': '10.0.0.100',
+            '10.10.0.0/16': '10.10.0.100',
+            '10.20.0.0/16': '10.20.0.100',
+        }
+        _resolve_nets = {
+            '10.0.0.3': '10.0.0.0/16',
+            '10.10.0.3': '10.10.0.0/16',
+            '10.20.0.3': '10.20.0.0/16',
+        }
+        expect = list(set([
+            '10.10.0.100', '10.10.0.2', '10.10.0.3',
+            '10.0.0.100', '10.0.0.2', '10.0.0.3',
+            '10.1.2.3',
+            '10.20.0.100', '10.20.0.2', '10.20.0.3']))
+        self.maxDiff = None
+        config.side_effect = lambda x: _config.get(x)
+        get_vip_in_network.side_effect = lambda x: _vips.get(x)
+        resolve_network_cidr.side_effect = lambda x: _resolve_nets.get(x)
+        get_relation_ip.side_effect = lambda x, cidr_network: _npa.get(x)
+        resolve_address.side_effect = \
+            lambda endpoint_type: _resolve_address[endpoint_type]
+        expected_get_relation_ip_calls = [
+            mock.call('internal', cidr_network=None),
+            mock.call('admin', cidr_network=None),
+            mock.call('public', cidr_network=None),
+            mock.call('mybinding', cidr_network=None)]
+        self.assertEqual(
+            cert_utils.get_certificate_sans(bindings=['mybinding']).sort(),
+            expect.sort())
+        get_relation_ip.assert_has_calls(
+            expected_get_relation_ip_calls, any_order=True)


### PR DESCRIPTION
Ignore ADDRESS_MAP KeyErrors

Just for a reference.

With a couple of changes to the charm and one to charms.openstack.charm.classes.get_certificate_requests, this works using the centralized helpers.