### PR TITLE
Pin pip to < 20.3 as requirements.txt is broken for 20.3.1 - temporary fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ CharmHelpers |badge|
 Overview
 ========
 
+TODO: remove this change; just to trigger a build
+
 CharmHelpers provides an opinionated set of tools for building Juju charms.
 
 The full documentation is available online at: https://charm-helpers.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,6 @@ CharmHelpers |badge|
 Overview
 ========
 
-TODO: remove this change; just to trigger a build
-
 CharmHelpers provides an opinionated set of tools for building Juju charms.
 
 The full documentation is available online at: https://charm-helpers.readthedocs.io/

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,18 @@ sitepackages = false
 # NOTE(beisner): the 'py3' env is useful to "just give me whatever py3 is here."
 # NOTE(beisner): the 'py3x' envs are useful to use a distinct interpreter version (will fail if not found)
 ignore_basepython_conflict = true
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
1. Initially just reproduce the bug in #557 -- Done
2. Ultimately, use the tox fix (hopefully) to alleviate the problem:  -- Done

```tox.ini
# NOTES:
# * We avoid the new dependency resolver by pinning pip < 20.3, see
#   https://github.com/pypa/pip/issues/9187
# * Pinning dependencies requires tox >= 3.2.0, see
#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
# * It is also necessary to pin virtualenv as a newer virtualenv would still
#   lead to fetching the latest pip in the func* tox targets, see
#   https://stackoverflow.com/a/38133283
requires = pip < 20.3
           virtualenv < 20.0
# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
minversion = 3.2.0
```

3. Finally, work with the new resolver to sort out the dependencies so that it works.  TODO in another PR