### PR TITLE
Update ubuntu_apt_pkg.py

### DIFF
--- a/charmhelpers/fetch/ubuntu_apt_pkg.py
+++ b/charmhelpers/fetch/ubuntu_apt_pkg.py
@@ -129,7 +129,7 @@ class Cache(object):
             else:
                 data = line.split(None, 4)
                 status = data.pop(0)
-                if status != 'ii':
+                if status not in ('ii', 'hi'):
                     continue
                 pkg = {}
                 pkg.update({k.lower(): v for k, v in zip(headings, data)})


### PR DESCRIPTION
The first part of dpkg-query's output is the "Desired" status of the package which can be one of "Unknown/Install/Remove/Purge/Hold". Where "Hold" means "A package marked to be on hold is kept on the same version" which is a variation of installed. Subsequently, a package with status of Hold should be considered as installed.