### PR TITLE
Stop getting {public,private}-address from unit-get

### DIFF
--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -30,7 +30,6 @@ from charmhelpers.core.hookenv import (
     relation_get,
     relation_ids,
     remote_service_name,
-    unit_get,
     NoNetworkBinding,
     log,
     WARNING,
@@ -41,6 +40,7 @@ from charmhelpers.contrib.openstack.ip import (
     get_vip_in_network,
     ADDRESS_MAP,
     get_default_api_bindings,
+    local_address,
 )
 from charmhelpers.contrib.network.ip import (
     get_relation_ip,
@@ -81,7 +81,7 @@ class CertRequest(object):
 
     def add_hostname_cn(self):
         """Add a request for the hostname of the machine"""
-        ip = unit_get('private-address')
+        ip = local_address(unit_get_fallback='private-address')
         addresses = [ip]
         # If a vip is being used without os-hostname config or
         # network spaces then we need to ensure the local units
@@ -194,7 +194,7 @@ def get_certificate_sans(bindings=None):
     :returns: List of binding string names
     :rtype: List[str]
     """
-    _sans = [unit_get('private-address')]
+    _sans = [local_address(unit_get_fallback='private-address')]
     if bindings:
         # Add default API bindings to bindings list
         bindings = list(bindings + get_default_api_bindings())
@@ -260,7 +260,7 @@ def create_ip_cert_links(ssl_dir, custom_hostname_link=None, bindings=None):
                 os.symlink(requested_key, key)
 
     # Handle custom hostnames
-    hostname = get_hostname(unit_get('private-address'))
+    hostname = get_hostname(local_address(unit_get_fallback='private-address'))
     hostname_cert = os.path.join(
         ssl_dir,
         'cert_{}'.format(hostname))

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -49,7 +49,6 @@ from charmhelpers.core.hookenv import (
     relation_ids,
     related_units,
     relation_set,
-    unit_get,
     unit_private_ip,
     charm_name,
     DEBUG,
@@ -98,6 +97,7 @@ from charmhelpers.contrib.openstack.ip import (
     ADMIN,
     PUBLIC,
     ADDRESS_MAP,
+    local_address,
 )
 from charmhelpers.contrib.network.ip import (
     get_address_in_network,
@@ -247,7 +247,7 @@ class SharedDBContext(OSContextGenerator):
                 hostname_key = "hostname"
             access_hostname = get_address_in_network(
                 access_network,
-                unit_get('private-address'))
+                local_address(unit_get_fallback='private-address'))
             set_hostname = relation_get(attribute=hostname_key,
                                         unit=local_unit())
             if set_hostname != access_hostname:
@@ -1088,7 +1088,7 @@ class ApacheSSLContext(OSContextGenerator):
             # NOTE(jamespage): Fallback must always be private address
             #                  as this is used to bind services on the
             #                  local unit.
-            fallback = unit_get("private-address")
+            fallback = local_address(unit_get_fallback="private-address")
             if net_config:
                 addr = get_address_in_network(net_config,
                                               fallback)
@@ -1260,7 +1260,7 @@ class NeutronContext(OSContextGenerator):
         if is_clustered():
             host = config('vip')
         else:
-            host = unit_get('private-address')
+            host = local_address(unit_get_fallback='private-address')
 
         ctxt = {'network_manager': self.network_manager,
                 'neutron_url': '%s://%s:%s' % (proto, host, '9696')}

--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -123,6 +123,25 @@ def _get_address_override(endpoint_type=PUBLIC):
         return addr_override.format(service_name=service_name())
 
 
+def local_address(unit_get_fallback='public-address'):
+    """Return a network address for this unit.
+
+    Attempt to retrieve a 'default' IP address for this unit
+    from network-get. If this is running with an old version of Juju then
+    fallback to unit_get.
+
+    :param unit_get_fallback: Either 'public-address' or 'private-address'.
+                              Only used with old versions of Juju.
+    :type unit_get_fallback: str
+    :returns: IP Address
+    :rtype: str
+    """
+    try:
+        return network_get_primary_address('juju-info')
+    except NotImplementedError:
+        return unit_get(unit_get_fallback)
+
+
 def resolve_address(endpoint_type=PUBLIC, override=True):
     """Return unit address depending on net config.
 
@@ -176,7 +195,7 @@ def resolve_address(endpoint_type=PUBLIC, override=True):
         if config('prefer-ipv6'):
             fallback_addr = get_ipv6_addr(exc_list=vips)[0]
         else:
-            fallback_addr = unit_get(net_fallback)
+            fallback_addr = local_address(unit_get_fallback=net_fallback)
 
         if net_addr:
             resolved_address = get_address_in_network(net_addr, fallback_addr)

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -26,13 +26,13 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
-    def test_CertRequest_add_hostname_cn(self, unit_get, get_hostname,
+    @mock.patch.object(cert_utils, 'local_address')
+    def test_CertRequest_add_hostname_cn(self, local_address, get_hostname,
                                          get_vip_in_network,
                                          resolve_network_cidr, local_unit):
         resolve_network_cidr.side_effect = lambda x: x
         get_vip_in_network.return_value = '10.1.2.100'
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         cr = cert_utils.CertRequest()
         cr.add_hostname_cn()
@@ -46,13 +46,13 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_network_cidr')
     @mock.patch.object(cert_utils, 'get_vip_in_network')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
-    def test_CertRequest_add_hostname_cn_ip(self, unit_get, get_hostname,
+    @mock.patch.object(cert_utils, 'local_address')
+    def test_CertRequest_add_hostname_cn_ip(self, local_address, get_hostname,
                                             get_vip_in_network,
                                             resolve_network_cidr, local_unit):
         resolve_network_cidr.side_effect = lambda x: x
         get_vip_in_network.return_value = '10.1.2.100'
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         cr = cert_utils.CertRequest()
         cr.add_hostname_cn()
@@ -72,13 +72,13 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_address')
     @mock.patch.object(cert_utils, 'config')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
-    def test_get_certificate_request(self, unit_get, get_hostname,
+    @mock.patch.object(cert_utils, 'local_address')
+    def test_get_certificate_request(self, local_address, get_hostname,
                                      config, resolve_address,
                                      network_get_primary_address,
                                      get_vip_in_network, resolve_network_cidr,
                                      local_unit, get_certificate_sans):
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {
             'os-internal-hostname': 'internal.openstack.local',
@@ -141,12 +141,12 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_address')
     @mock.patch.object(cert_utils, 'config')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
+    @mock.patch.object(cert_utils, 'local_address')
     def test_get_certificate_request_no_hostnames(
-            self, unit_get, get_hostname, config, resolve_address,
+            self, local_address, get_hostname, config, resolve_address,
             network_get_primary_address, get_vip_in_network,
             resolve_network_cidr, local_unit, get_certificate_sans):
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {
             'os-admin-hostname': 'admin.openstack.local',
@@ -202,12 +202,12 @@ class CertUtilsTests(unittest.TestCase):
             bindings=['mybinding', 'internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'get_certificate_request')
-    @mock.patch.object(cert_utils, 'unit_get')
+    @mock.patch.object(cert_utils, 'local_address')
     @mock.patch.object(cert_utils.os, 'symlink')
     @mock.patch.object(cert_utils.os.path, 'isfile')
     @mock.patch.object(cert_utils, 'get_hostname')
     def test_create_ip_cert_links(self, get_hostname, isfile,
-                                  symlink, unit_get, get_cert_request):
+                                  symlink, local_address, get_cert_request):
         cert_request = {'cert_requests': {
             'admin.openstack.local': {
                 'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
@@ -273,12 +273,12 @@ class CertUtilsTests(unittest.TestCase):
             json_encode=False, bindings=['internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'get_certificate_request')
-    @mock.patch.object(cert_utils, 'unit_get')
+    @mock.patch.object(cert_utils, 'local_address')
     @mock.patch.object(cert_utils.os, 'symlink')
     @mock.patch.object(cert_utils.os.path, 'isfile')
     @mock.patch.object(cert_utils, 'get_hostname')
     def test_create_ip_cert_links_bindings(
-            self, get_hostname, isfile, symlink, unit_get, get_cert_request):
+            self, get_hostname, isfile, symlink, local_address, get_cert_request):
         cert_request = {'cert_requests': {
             'admin.openstack.local': {
                 'sans': ['10.10.0.100', '10.10.0.2', '10.10.0.3']},
@@ -583,13 +583,13 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_address')
     @mock.patch.object(cert_utils, 'config')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
-    def test_get_certificate_sans(self, unit_get, get_hostname,
+    @mock.patch.object(cert_utils, 'local_address')
+    def test_get_certificate_sans(self, local_address, get_hostname,
                                   config, resolve_address,
                                   get_relation_ip,
                                   get_vip_in_network, resolve_network_cidr,
                                   local_unit):
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {
             'os-internal-hostname': 'internal.openstack.local',
@@ -645,11 +645,11 @@ class CertUtilsTests(unittest.TestCase):
     @mock.patch.object(cert_utils, 'resolve_address')
     @mock.patch.object(cert_utils, 'config')
     @mock.patch.object(cert_utils, 'get_hostname')
-    @mock.patch.object(cert_utils, 'unit_get')
+    @mock.patch.object(cert_utils, 'local_address')
     def test_get_certificate_sans_bindings(
-            self, unit_get, get_hostname, config, resolve_address,
+            self, local_address, get_hostname, config, resolve_address,
             get_relation_ip, get_vip_in_network, resolve_network_cidr, local_unit):
-        unit_get.return_value = '10.1.2.3'
+        local_address.return_value = '10.1.2.3'
         get_hostname.return_value = 'juju-unit-2'
         _config = {
             'os-internal-hostname': 'internal.openstack.local',

--- a/tests/contrib/openstack/test_ip.py
+++ b/tests/contrib/openstack/test_ip.py
@@ -148,13 +148,15 @@ class IPTestCase(TestCase):
         resolve_address.return_value = 'unit1'
         self.assertTrue(ip.canonical_url(None), 'http://[unit1]')
 
-    def test_resolve_address_network_get(self):
+    @patch.object(ip, 'local_address')
+    def test_resolve_address_network_get(self, local_address):
         self.is_clustered.return_value = False
         self.unit_get.return_value = 'unit1'
         self.network_get_primary_address.side_effect = None
         self.network_get_primary_address.return_value = '10.5.60.1'
         self.assertEqual(ip.resolve_address(), '10.5.60.1')
-        self.unit_get.assert_called_with('public-address')
+        local_address.assert_called_once_with(
+            unit_get_fallback='public-address')
         calls = [call('os-public-network'),
                  call('prefer-ipv6')]
         self.config.assert_has_calls(calls)

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -666,7 +666,7 @@ TO_PATCH = [
     'related_units',
     'is_relation_made',
     'relation_set',
-    'unit_get',
+    'local_address',
     'https',
     'determine_api_port',
     'determine_apache_port',
@@ -2064,9 +2064,9 @@ class ContextTests(unittest.TestCase):
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_data(self, local_unit, unit_get):
+    def test_haproxy_context_with_data(self, local_unit, local_address):
         '''Test haproxy context with all relation data'''
         cluster_relation = {
             'cluster:0': {
@@ -2122,9 +2122,9 @@ class ContextTests(unittest.TestCase):
                                                call('public', False),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_data_timeout(self, local_unit, unit_get):
+    def test_haproxy_context_with_data_timeout(self, local_unit, local_address):
         '''Test haproxy context with all relation data and timeout'''
         cluster_relation = {
             'cluster:0': {
@@ -2185,9 +2185,9 @@ class ContextTests(unittest.TestCase):
                                                call('public', None),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_data_multinet(self, local_unit, unit_get):
+    def test_haproxy_context_with_data_multinet(self, local_unit, local_address):
         '''Test haproxy context with all relation data for network splits'''
         cluster_relation = {
             'cluster:0': {
@@ -2276,9 +2276,9 @@ class ContextTests(unittest.TestCase):
                                                call('public', False),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_data_public_only(self, local_unit, unit_get):
+    def test_haproxy_context_with_data_public_only(self, local_unit, local_address):
         '''Test haproxy context with with openstack-dashboard public only binding'''
         cluster_relation = {
             'cluster:0': {
@@ -2349,9 +2349,9 @@ class ContextTests(unittest.TestCase):
         self.get_relation_ip.assert_has_calls([call('public', None),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_data_ipv6(self, local_unit, unit_get):
+    def test_haproxy_context_with_data_ipv6(self, local_unit, local_address):
         '''Test haproxy context with all relation data ipv6'''
         cluster_relation = {
             'cluster:0': {
@@ -2422,9 +2422,9 @@ class ContextTests(unittest.TestCase):
         haproxy = context.HAProxyContext()
         self.assertEquals({}, haproxy())
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_no_peers(self, local_unit, unit_get):
+    def test_haproxy_context_with_no_peers(self, local_unit, local_address):
         '''Test haproxy context with single unit'''
         # peer relations always show at least one peer relation, even
         # if unit is alone. should be an incomplete context.
@@ -2451,9 +2451,9 @@ class ContextTests(unittest.TestCase):
                                                call('public', False),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_net_override(self, local_unit, unit_get):
+    def test_haproxy_context_with_net_override(self, local_unit, local_address):
         '''Test haproxy context with single unit'''
         # peer relations always show at least one peer relation, even
         # if unit is alone. should be an incomplete context.
@@ -2485,9 +2485,9 @@ class ContextTests(unittest.TestCase):
                                                call('public', '192.168.30.0/24'),
                                                call('cluster')])
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
-    def test_haproxy_context_with_no_peers_singlemode(self, local_unit, unit_get):
+    def test_haproxy_context_with_no_peers_singlemode(self, local_unit, local_address):
         '''Test haproxy context with single unit'''
         # peer relations always show at least one peer relation, even
         # if unit is alone. should be an incomplete context.
@@ -2853,13 +2853,13 @@ class ContextTests(unittest.TestCase):
             'neutron_security_groups': True,
             'local_ip': '10.0.0.1'}, neutron.midonet_ctxt())
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch.object(context.NeutronContext, 'network_manager')
     def test_neutron_neutron_ctxt(self, mock_network_manager,
-                                  mock_unit_get):
+                                  mock_local_address):
         vip = '88.11.22.33'
         priv_addr = '10.0.0.1'
-        mock_unit_get.return_value = priv_addr
+        mock_local_address.return_value = priv_addr
         neutron = context.NeutronContext()
 
         config = {'vip': vip}
@@ -2880,13 +2880,13 @@ class ContextTests(unittest.TestCase):
             neutron.neutron_ctxt()
         )
 
-    @patch('charmhelpers.contrib.openstack.context.unit_get')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch.object(context.NeutronContext, 'network_manager')
     def test_neutron_neutron_ctxt_http(self, mock_network_manager,
-                                       mock_unit_get):
+                                       mock_local_address):
         vip = '88.11.22.33'
         priv_addr = '10.0.0.1'
-        mock_unit_get.return_value = priv_addr
+        mock_local_address.return_value = priv_addr
         neutron = context.NeutronContext()
 
         config = {'vip': vip}
@@ -3389,7 +3389,7 @@ class ContextTests(unittest.TestCase):
             'os-public-network': None
         })
         self.resolve_address.return_value = '10.5.1.50'
-        self.unit_get.return_value = '10.5.1.50'
+        self.local_address.return_value = '10.5.1.50'
 
         apache = context.ApacheSSLContext()
         apache.external_ports = '8776'
@@ -3417,7 +3417,7 @@ class ContextTests(unittest.TestCase):
                            '10.5.3.100']
         self.get_address_in_network.side_effect = _base_addresses
         self.resolve_address.side_effect = _base_addresses
-        self.unit_get.return_value = '10.5.1.50'
+        self.local_address.return_value = '10.5.1.50'
 
         apache = context.ApacheSSLContext()
 
@@ -3446,7 +3446,7 @@ class ContextTests(unittest.TestCase):
         self.network_get_primary_address.side_effect = None
         self.network_get_primary_address.return_value = '10.5.2.50'
         self.resolve_address.return_value = '10.5.2.100'
-        self.unit_get.return_value = '10.5.1.50'
+        self.local_address.return_value = '10.5.1.50'
 
         apache = context.ApacheSSLContext()
         apache.external_ports = '8776'


### PR DESCRIPTION
In Juju 2.8rc3 `unit-get public-address` became unreliable
(Bug #1910973). Since getting an address this was is deprecated
switch the OpenStack functions to prefer network-get. However,
fallback to the old method to support old versions of Juju for
the time being.