### PR TITLE
Add JUJU_DEPARTING_UNIT support

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -226,6 +226,17 @@ def relation_id(relation_name=None, service_or_unit=None):
         raise ValueError('Must specify neither or both of relation_name and service_or_unit')
 
 
+def departing_unit():
+    """The departing unit for the current relation hook.
+
+    Available since juju 2.8.
+
+    :returns: the departing unit, or None if the information isn't available.
+    :rtype: Optional[str]
+    """
+    return os.environ.get('JUJU_DEPARTING_UNIT', None)
+
+
 def local_unit():
     """Local unit ID"""
     return os.environ['JUJU_UNIT_NAME']

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -772,6 +772,19 @@ class HelpersTest(TestCase):
         has_juju_version.assertCalledOnceWith("2.4.4")
 
     @patch('charmhelpers.core.hookenv.os')
+    def test_gets_the_departing_unit(self, os_):
+        os_.environ = {
+            'JUJU_DEPARTING_UNIT': 'foo/0',
+        }
+
+        self.assertEqual(hookenv.departing_unit(), 'foo/0')
+
+    @patch('charmhelpers.core.hookenv.os')
+    def test_no_departing_unit(self, os_):
+        os_.environ = {}
+        self.assertEqual(hookenv.departing_unit(), None)
+
+    @patch('charmhelpers.core.hookenv.os')
     def test_gets_the_remote_unit(self, os_):
         os_.environ = {
             'JUJU_REMOTE_UNIT': 'foo',


### PR DESCRIPTION
Juju 2.8 introduced the new environment variable JUJU_DEPARTING_UNIT
which holds the name of the unit that's being removed, this allows
charm authors to remove the unit from the cluster during the execution
of the *-relation-departed hook.

https://discourse.charmhub.io/t/juju-2-8-0-release-notes/