### PR TITLE
Issue564: add None check for max_check_attempts in nrpe check

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -337,10 +337,8 @@ class NRPE(object):
                 "command": nrpecheck.command,
             }
             # If we were passed max_check_attempts, add that to the relation data
-            try:
+            if nrpecheck.max_check_attempts is not None:
                 nrpe_monitors[nrpecheck.shortname]['max_check_attempts'] = nrpecheck.max_check_attempts
-            except AttributeError:
-                pass
 
         # update-status hooks are configured to firing every 5 minutes by
         # default. When nagios-nrpe-server is restarted, the nagios server

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -180,7 +180,6 @@ define service {
 
         nrpe_monitors = {'myservice':
                          {'command': 'check_myservice',
-                          'max_check_attempts': None,
                           }}
         monitors = yaml.dump(
             {"monitors": {"remote": {"nrpe": nrpe_monitors}}})


### PR DESCRIPTION
In commit 198c0e3, a new kwarg max_check_attempts=None was introduced to nrpe.Check class.
However, it doesn't check the None condition, which will always render max_check_attempts: null
in check cfg and cause nagios to break with latest charmhelpers.

This patch add None check to ensure max_check_attempts only be rendered when it's not None.

Closes #564 

Signed-off-by: Joe Guo <joe.guo@canonical.com>