### PR TITLE
Refactoring around _manage_ca_certs() (#570)

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -1068,6 +1068,17 @@ def modulo_distribution(modulo=3, wait=30, non_zero_wait=False):
         return calculated_wait_time
 
 
+def ca_cert_absolute_path(basename_without_extension):
+    """Returns absolute path to CA certificate.
+
+    :param basename_without_extension: Filename without extension
+    :type basename_without_extension: str
+    :returns: Absolute full path
+    :rtype: str
+    """
+    return '{}/{}.crt'.format(CA_CERT_DIR, basename_without_extension)
+
+
 def install_ca_cert(ca_cert, name=None):
     """
     Install the given cert as a trusted CA.
@@ -1083,7 +1094,7 @@ def install_ca_cert(ca_cert, name=None):
         ca_cert = ca_cert.encode('utf8')
     if not name:
         name = 'juju-{}'.format(charm_name())
-    cert_file = '{}/{}.crt'.format(CA_CERT_DIR, name)
+    cert_file = ca_cert_absolute_path(name)
     new_hash = hashlib.md5(ca_cert).hexdigest()
     if file_hash(cert_file) == new_hash:
         return

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -482,6 +482,29 @@ class CertUtilsTests(unittest.TestCase):
             bindings=['mybinding', 'internal', 'admin', 'public'])
 
     @mock.patch.object(cert_utils, 'remote_service_name')
+    @mock.patch.object(cert_utils, 'relation_ids')
+    def test_get_cert_relation_ca_name(self, relation_ids, remote_service_name):
+        remote_service_name.return_value = 'vault'
+
+        # Test with argument:
+        self.assertEqual(cert_utils.get_cert_relation_ca_name('certificates:1'),
+                         'vault_juju_ca_cert')
+        remote_service_name.assert_called_once_with(relid='certificates:1')
+        remote_service_name.reset_mock()
+
+        # Test without argument:
+        relation_ids.return_value = ['certificates:2']
+        self.assertEqual(cert_utils.get_cert_relation_ca_name(),
+                         'vault_juju_ca_cert')
+        remote_service_name.assert_called_once_with(relid='certificates:2')
+        remote_service_name.reset_mock()
+
+        # Test without argument nor 'certificates' relation:
+        relation_ids.return_value = []
+        self.assertEqual(cert_utils.get_cert_relation_ca_name(), '')
+        remote_service_name.assert_not_called()
+
+    @mock.patch.object(cert_utils, 'remote_service_name')
     @mock.patch.object(cert_utils.os, 'remove')
     @mock.patch.object(cert_utils.os.path, 'exists')
     @mock.patch.object(cert_utils, 'config')


### PR DESCRIPTION
* Refactoring around _manage_ca_certs()

Needed for https://launchpad.net/bugs/1915504

(cherry picked from commit 5523f95943995734c943a9db1734c58dd71c4acb)