### PR TITLE
Fix issues around py38 (groovy) and amulet module

### DIFF
--- a/charmhelpers/contrib/openstack/amulet/utils.py
+++ b/charmhelpers/contrib/openstack/amulet/utils.py
@@ -42,6 +42,7 @@ import pika
 import swiftclient
 
 from charmhelpers.core.decorators import retry_on_exception
+
 from charmhelpers.contrib.amulet.utils import (
     AmuletUtils
 )

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1912,7 +1912,10 @@ class HelpersTest(TestCase):
         self.assertEqual(host.updatedb(updatedb_text, '/srv/node'),
                          updatedb_text)
 
-    def test_write_updatedb(self):
+    @patch('os.path')
+    def test_write_updatedb(self, mock_path):
+        mock_path.exists.return_value = True
+        mock_path.isdir.return_value = False
         _open = mock_open(read_data='PRUNEPATHS="/tmp /srv/node"')
         with patch('charmhelpers.core.host.open', _open, create=True):
             host.add_to_updatedb_prunepath("/tmp/test")


### PR DESCRIPTION
* py38 seems to require additional mocking in test_write_updatedb()
* mock the amulet module as it goes looking for the juju command, and
  that's a violation of the unit tests.

Closes-Bug: #575