### PR TITLE
Fix error log notification of openstack-release pkg

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -483,9 +483,27 @@ def get_swift_codename(version):
     return None
 
 
-@deprecate("moved to charmhelpers.contrib.openstack.utils.get_installed_os_version()", "2021-01", log=juju_log)
 def get_os_codename_package(package, fatal=True):
-    '''Derive OpenStack release codename from an installed package.'''
+    """Derive OpenStack release codename from an installed package.
+
+    Initially, see of the openstack-release pkg is available (by trying to
+    install it) and use it instead.
+
+    If it isn't then it falls back to the existing method of checking the
+    version of the package passed and then resolving the version from that
+    using lookup tables.
+
+    Note: if possible, charms should use get_installed_os_version() to
+    determine the version of the "openstack-release" pkg.
+
+    :param package: the package to test for version information.
+    :type package: str
+    :param fatal: If True (default), then die via error_out()
+        be determined.
+    :type fatal: bool
+    :returns: the OpenStack release codename (e.g. ussuri)
+    :rtype: str
+    """
 
     codename = get_installed_os_version()
     if codename:
@@ -578,9 +596,20 @@ def get_os_version_package(pkg, fatal=True):
     # error_out(e)
 
 
+@cached
 def get_installed_os_version():
-    apt_install(filter_installed_packages(['openstack-release']), fatal=False)
-    print("OpenStack Release: {}".format(openstack_release()))
+    """Determine the OpenStack release code name from openstack-release pkg.
+
+    This uses the "openstack-release" pkg (if it exists) to return the
+    OpenStack release codename (e.g. usurri, mitaka, ocata, etc.)
+
+    Note, it caches the result so that it is only done once per hook.
+
+    :returns: the OpenStack release codename, if available
+    :rtype: Optional[str]
+    """
+    apt_install(filter_installed_packages(['openstack-release']),
+                fatal=False, quiet=True)
     return openstack_release().get('OPENSTACK_CODENAME')
 
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -596,7 +596,6 @@ def get_os_version_package(pkg, fatal=True):
     # error_out(e)
 
 
-@cached
 def get_installed_os_version():
     """Determine the OpenStack release code name from openstack-release pkg.
 
@@ -608,8 +607,12 @@ def get_installed_os_version():
     :returns: the OpenStack release codename, if available
     :rtype: Optional[str]
     """
-    apt_install(filter_installed_packages(['openstack-release']),
-                fatal=False, quiet=True)
+    @cached
+    def _do_install():
+        apt_install(filter_installed_packages(['openstack-release']),
+                    fatal=False, quiet=True)
+
+    _do_install()
     return openstack_release().get('OPENSTACK_CODENAME')
 
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -486,7 +486,7 @@ def get_swift_codename(version):
 def get_os_codename_package(package, fatal=True):
     """Derive OpenStack release codename from an installed package.
 
-    Initially, see of the openstack-release pkg is available (by trying to
+    Initially, see if the openstack-release pkg is available (by trying to
     install it) and use it instead.
 
     If it isn't then it falls back to the existing method of checking the
@@ -499,7 +499,6 @@ def get_os_codename_package(package, fatal=True):
     :param package: the package to test for version information.
     :type package: str
     :param fatal: If True (default), then die via error_out()
-        be determined.
     :type fatal: bool
     :returns: the OpenStack release codename (e.g. ussuri)
     :rtype: str

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
+import os
 import platform
 import re
 import six
@@ -274,7 +275,7 @@ def apt_install(packages, options=None, fatal=False, quiet=False):
     :param fatal: Whether the command's output should be checked and
                   retried.
     :type fatal: bool
-    :param quiet: if True (default), supress log message
+    :param quiet: if True (default), supress log message to stdout/stderr
     :type quiet: bool
     :raises: subprocess.CalledProcessError
     """
@@ -291,7 +292,7 @@ def apt_install(packages, options=None, fatal=False, quiet=False):
     if not quiet:
         log("Installing {} with options: {}"
             .format(packages, options))
-    _run_apt_command(cmd, fatal)
+    _run_apt_command(cmd, fatal, quiet=quiet)
 
 
 def apt_upgrade(options=None, fatal=False, dist=False):
@@ -733,7 +734,7 @@ def _verify_is_ubuntu_rel(release, os_release):
 
 
 def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
-                      retry_message="", cmd_env=None):
+                      retry_message="", cmd_env=None, quiet=False):
     """Run a command and retry until success or max_retries is reached.
 
     :param cmd: The apt command to run.
@@ -748,10 +749,19 @@ def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
     :type retry_message: str
     :param: cmd_env: Environment variables to add to the command run.
     :type cmd_env: Option[None, Dict[str, str]]
+    :param quiet: if True, silence the output of the command from stdout and
+        stderr
+    :type quiet: bool
     """
     env = get_apt_dpkg_env()
     if cmd_env:
         env.update(cmd_env)
+
+    kwargs = {}
+    if quiet:
+        devnull = os.devnull if six.PY2 else subprocess.DEVNULL
+        kwargs['stdout'] = devnull
+        kwargs['stderr'] = devnull
 
     if not retry_message:
         retry_message = "Failed executing '{}'".format(" ".join(cmd))
@@ -763,7 +773,7 @@ def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
     retry_results = (None,) + retry_exitcodes
     while result in retry_results:
         try:
-            result = subprocess.check_call(cmd, env=env)
+            result = subprocess.check_call(cmd, env=env, **kwargs)
         except subprocess.CalledProcessError as e:
             retry_count = retry_count + 1
             if retry_count > max_retries:
@@ -773,7 +783,7 @@ def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
             time.sleep(CMD_RETRY_DELAY)
 
 
-def _run_apt_command(cmd, fatal=False):
+def _run_apt_command(cmd, fatal=False, quiet=False):
     """Run an apt command with optional retries.
 
     :param cmd: The apt command to run.
@@ -781,13 +791,22 @@ def _run_apt_command(cmd, fatal=False):
     :param fatal: Whether the command's output should be checked and
                   retried.
     :type fatal: bool
+    :param quiet: if True, silence the output of the command from stdout and
+        stderr
+    :type quiet: bool
     """
     if fatal:
         _run_with_retries(
             cmd, retry_exitcodes=(1, APT_NO_LOCK,),
-            retry_message="Couldn't acquire DPKG lock")
+            retry_message="Couldn't acquire DPKG lock",
+            quiet=quiet)
     else:
-        subprocess.call(cmd, env=get_apt_dpkg_env())
+        kwargs = {}
+        if quiet:
+            devnull = os.devnull if six.PY2 else subprocess.DEVNULL
+            kwargs['stdout'] = devnull
+            kwargs['stderr'] = devnull
+        subprocess.call(cmd, env=get_apt_dpkg_env(), **kwargs)
 
 
 def get_upstream_version(package):

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -306,6 +306,7 @@ class OpenStackHelpersTestCase(TestCase):
     def test_get_swift_codename_none(self):
         self.assertEquals(openstack.get_swift_codename('1.2.3'), None)
 
+    @patch("charmhelpers.core.hookenv.cache", new={})
     @patch.object(openstack, 'openstack_release')
     @patch.object(openstack, 'filter_installed_packages')
     @patch.object(openstack, 'apt_install')
@@ -313,10 +314,10 @@ class OpenStackHelpersTestCase(TestCase):
                                                  mock_filter_installed_packages,
                                                  mock_openstack_release):
         mock_openstack_release.return_value = {}
-        print("Checking when none")
         self.assertEquals(
             openstack.get_installed_os_version(), None)
 
+    @patch("charmhelpers.core.hookenv.cache", new={})
     @patch.object(openstack, 'openstack_release')
     @patch.object(openstack, 'filter_installed_packages')
     @patch.object(openstack, 'apt_install')
@@ -324,7 +325,6 @@ class OpenStackHelpersTestCase(TestCase):
                                                    mock_filter_installed_packages,
                                                    mock_openstack_release):
         mock_openstack_release.return_value = {'OPENSTACK_CODENAME': 'wallaby'}
-        print("Checking when wallaby")
         self.assertEquals(
             openstack.get_installed_os_version(), 'wallaby')
 


### PR DESCRIPTION
Basically, kill the error log messsage for the openstack-release pkg
being missing, which appears due to the attempt to install it.  However,
it's not actually a bug if it isn't there (yet).

Also, add some docstrings to the functions so that future travellers can
understand what is going on.