### PR TITLE
Add hirsute and wallaby identifiers for OpenStack

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -151,6 +151,7 @@ OPENSTACK_RELEASES = (
     'train',
     'ussuri',
     'victoria',
+    'wallaby',
 )
 
 UBUNTU_OPENSTACK_RELEASE = OrderedDict([
@@ -173,6 +174,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
     ('eoan', 'train'),
     ('focal', 'ussuri'),
     ('groovy', 'victoria'),
+    ('hirsute', 'wallaby'),
 ])
 
 
@@ -196,6 +198,7 @@ OPENSTACK_CODENAMES = OrderedDict([
     ('2019.2', 'train'),
     ('2020.1', 'ussuri'),
     ('2020.2', 'victoria'),
+    ('2021.1', 'wallaby'),
 ])
 
 # The ugly duckling - must list releases oldest to newest
@@ -238,6 +241,8 @@ SWIFT_CODENAMES = OrderedDict([
         ['2.24.0', '2.25.0']),
     ('victoria',
         ['2.25.0', '2.26.0']),
+    ('wallaby',
+        ['2.26.0']),
 ])
 
 # >= Liberty version->codename mapping
@@ -254,6 +259,7 @@ PACKAGE_CODENAMES = {
         ('20', 'train'),
         ('21', 'ussuri'),
         ('22', 'victoria'),
+        ('23', 'wallaby'),
     ]),
     'neutron-common': OrderedDict([
         ('7', 'liberty'),
@@ -267,6 +273,7 @@ PACKAGE_CODENAMES = {
         ('15', 'train'),
         ('16', 'ussuri'),
         ('17', 'victoria'),
+        ('18', 'wallaby'),
     ]),
     'cinder-common': OrderedDict([
         ('7', 'liberty'),
@@ -280,6 +287,7 @@ PACKAGE_CODENAMES = {
         ('15', 'train'),
         ('16', 'ussuri'),
         ('17', 'victoria'),
+        ('18', 'cinder'),
     ]),
     'keystone': OrderedDict([
         ('8', 'liberty'),
@@ -293,6 +301,7 @@ PACKAGE_CODENAMES = {
         ('16', 'train'),
         ('17', 'ussuri'),
         ('18', 'victoria'),
+        ('19', 'wallaby'),
     ]),
     'horizon-common': OrderedDict([
         ('8', 'liberty'),
@@ -304,8 +313,9 @@ PACKAGE_CODENAMES = {
         ('14', 'rocky'),
         ('15', 'stein'),
         ('16', 'train'),
-        ('18', 'ussuri'),
-        ('19', 'victoria'),
+        ('18', 'ussuri'),  # Note this was actually 17.0 - 18.3
+        ('19', 'victoria'),  # Note this is really 18.6
+        ('19', 'wallaby'),
     ]),
     'ceilometer-common': OrderedDict([
         ('5', 'liberty'),
@@ -319,6 +329,7 @@ PACKAGE_CODENAMES = {
         ('13', 'train'),
         ('14', 'ussuri'),
         ('15', 'victoria'),
+        ('16', 'wallaby'),  # estimated
     ]),
     'heat-common': OrderedDict([
         ('5', 'liberty'),
@@ -332,6 +343,7 @@ PACKAGE_CODENAMES = {
         ('13', 'train'),
         ('14', 'ussuri'),
         ('15', 'victoria'),
+        ('16', 'wallaby'),  # estimated
     ]),
     'glance-common': OrderedDict([
         ('11', 'liberty'),
@@ -345,6 +357,7 @@ PACKAGE_CODENAMES = {
         ('19', 'train'),
         ('20', 'ussuri'),
         ('21', 'victoria'),
+        ('22', 'wallaby'),
     ]),
     'openstack-dashboard': OrderedDict([
         ('8', 'liberty'),
@@ -358,6 +371,7 @@ PACKAGE_CODENAMES = {
         ('16', 'train'),
         ('18', 'ussuri'),
         ('19', 'victoria'),
+        ('19', 'wallaby'),
     ]),
 }
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -241,8 +241,6 @@ SWIFT_CODENAMES = OrderedDict([
         ['2.24.0', '2.25.0']),
     ('victoria',
         ['2.25.0', '2.26.0']),
-    ('wallaby',
-        ['2.26.0']),
 ])
 
 # >= Liberty version->codename mapping
@@ -259,7 +257,6 @@ PACKAGE_CODENAMES = {
         ('20', 'train'),
         ('21', 'ussuri'),
         ('22', 'victoria'),
-        ('23', 'wallaby'),
     ]),
     'neutron-common': OrderedDict([
         ('7', 'liberty'),
@@ -273,7 +270,6 @@ PACKAGE_CODENAMES = {
         ('15', 'train'),
         ('16', 'ussuri'),
         ('17', 'victoria'),
-        ('18', 'wallaby'),
     ]),
     'cinder-common': OrderedDict([
         ('7', 'liberty'),
@@ -287,7 +283,6 @@ PACKAGE_CODENAMES = {
         ('15', 'train'),
         ('16', 'ussuri'),
         ('17', 'victoria'),
-        ('18', 'wallaby'),
     ]),
     'keystone': OrderedDict([
         ('8', 'liberty'),
@@ -301,7 +296,6 @@ PACKAGE_CODENAMES = {
         ('16', 'train'),
         ('17', 'ussuri'),
         ('18', 'victoria'),
-        ('19', 'wallaby'),
     ]),
     'horizon-common': OrderedDict([
         ('8', 'liberty'),
@@ -315,7 +309,6 @@ PACKAGE_CODENAMES = {
         ('16', 'train'),
         ('18', 'ussuri'),  # Note this was actually 17.0 - 18.3
         ('19', 'victoria'),  # Note this is really 18.6
-        ('19', 'wallaby'),
     ]),
     'ceilometer-common': OrderedDict([
         ('5', 'liberty'),
@@ -329,7 +322,6 @@ PACKAGE_CODENAMES = {
         ('13', 'train'),
         ('14', 'ussuri'),
         ('15', 'victoria'),
-        ('16', 'wallaby'),  # estimated
     ]),
     'heat-common': OrderedDict([
         ('5', 'liberty'),
@@ -343,7 +335,6 @@ PACKAGE_CODENAMES = {
         ('13', 'train'),
         ('14', 'ussuri'),
         ('15', 'victoria'),
-        ('16', 'wallaby'),  # estimated
     ]),
     'glance-common': OrderedDict([
         ('11', 'liberty'),
@@ -357,7 +348,6 @@ PACKAGE_CODENAMES = {
         ('19', 'train'),
         ('20', 'ussuri'),
         ('21', 'victoria'),
-        ('22', 'wallaby'),
     ]),
     'openstack-dashboard': OrderedDict([
         ('8', 'liberty'),
@@ -371,7 +361,6 @@ PACKAGE_CODENAMES = {
         ('16', 'train'),
         ('18', 'ussuri'),
         ('19', 'victoria'),
-        ('19', 'wallaby'),
     ]),
 }
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -287,7 +287,7 @@ PACKAGE_CODENAMES = {
         ('15', 'train'),
         ('16', 'ussuri'),
         ('17', 'victoria'),
-        ('18', 'cinder'),
+        ('18', 'wallaby'),
     ]),
     'keystone': OrderedDict([
         ('8', 'liberty'),

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -200,6 +200,14 @@ CLOUD_ARCHIVE_POCKETS = {
     'victoria/proposed': 'focal-proposed/victoria',
     'focal-victoria/proposed': 'focal-proposed/victoria',
     'focal-proposed/victoria': 'focal-proposed/victoria',
+    # Wallaby
+    'wallaby': 'focal-updates/wallaby',
+    'focal-wallaby': 'focal-updates/wallaby',
+    'focal-wallaby/updates': 'focal-updates/wallaby',
+    'focal-updates/wallaby': 'focal-updates/wallaby',
+    'wallaby/proposed': 'focal-proposed/wallaby',
+    'focal-wallaby/proposed': 'focal-proposed/wallaby',
+    'focal-proposed/wallaby': 'focal-proposed/wallaby',
 }
 
 


### PR DESCRIPTION
This patch adds the hirsute to wallaby mapping for 'distro' for hirsute
and the wallaby version numbers for the core packages.