### PR TITLE
Add support to customize ssl-min-ver value for haproxy

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -945,6 +945,9 @@ class HAProxyContext(OSContextGenerator):
             ctxt['local_host'] = '127.0.0.1'
             ctxt['haproxy_host'] = '0.0.0.0'
 
+        if config('ssl-min-ver'):
+            ctxt['ssl_min_ver'] = config('ssl-min-ver')
+
         ctxt['ipv6_enabled'] = not is_ipv6_disabled()
 
         ctxt['stat_port'] = '8888'

--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -7,6 +7,11 @@ global
     spread-checks 0
     stats socket /var/run/haproxy/admin.sock mode 600 level admin
     stats timeout 2m
+{%- if ssl_min_ver %}
+    ssl-default-bind-options ssl-min-ver {{ ssl_min_ver }}
+    ssl-default-server-options ssl-min-ver {{ ssl_min_ver }}
+{%- endif %}
+
 
 defaults
     log global


### PR DESCRIPTION
This option enforces use of a version when SSL is used.
(e.g. SSLv3, TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3)

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>