### PR TITLE
Decorator/context manager version of restart_on_change

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -729,6 +729,63 @@ def restart_on_change(restart_map, stopstart=False, restart_functions=None):
     return wrap
 
 
+class restart_on_change1(object):
+    """Decorator AND context manager to handle restarts.
+
+    Usage:
+
+       @restart_on_change(restart_map, ...)
+       def function_that_might_trigger_a_restart(...)
+           ...
+
+    Or:
+
+       with restart_on_change(restart_map, ...):
+           do_stuff_that_might_trigger_a_restart()
+           ...
+    """
+
+    def __init__(self, restart_map, stopstart=False, restart_functions=None):
+        self.restart_map = restart_map
+        self.stopstart = stopstart
+        self.restart_functions = restart_functions
+
+    def __call__(self, f):
+        """Work like a decorator.
+
+        Returns a wrapped function that performs the restart if triggered.
+
+        :param f: The function that is being wrapped.
+        :type f: Callable[[Any], Any]
+        :returns: the wrapped function
+        :rtype: Callable[[Any], Any]
+        """
+        @functools.wraps(f)
+        def wrapped_f(*args, **kwargs):
+            return restart_on_change_helper(
+                (lambda: f(*args, **kwargs)),
+                self.restart_map,
+                self.stopstart,
+                self.restart_functions)
+        return wrapped_f
+
+    def __enter__(self):
+        self.checksums = _pre_restart_on_change_helper(self.restart_map)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        """
+        if exc_type is None:
+            _post_restart_on_change_helper(
+                self.checksums,
+                self.restart_map,
+                stopstart=self.stopstart,
+                restart_functions=self.restart_functions)
+        # All is good, so return False; any exceptions will propagate.
+        return False
+
+
+
 def restart_on_change_helper(lambda_f, restart_map, stopstart=False,
                              restart_functions=None,
                              can_restart_now_f=None,
@@ -779,10 +836,31 @@ def restart_on_change_helper(lambda_f, restart_map, stopstart=False,
     :returns: result of lambda_f()
     :rtype: ANY
     """
+    checksums = _pre_restart_on_change_helper(restart_map)
+    r = lambda_f()
+    _post_restart_on_change_helper(checksums,
+                                   restart_map,
+                                   stopstart,
+                                   restart_functions,
+                                   can_restart_now_f,
+                                   post_svc_restart_f,
+                                   pre_restarts_wait_f)
+    return r
+
+
+def _pre_restart_on_change_helper(restart_map):
+    return {path: path_hash(path) for path in restart_map}
+
+
+def _post_restart_on_change_helper(checksums,
+                                   restart_map,
+                                   stopstart=False,
+                                   restart_functions=None,
+                                   can_restart_now_f=None,
+                                   post_svc_restart_f=None,
+                                   pre_restarts_wait_f=None):
     if restart_functions is None:
         restart_functions = {}
-    checksums = {path: path_hash(path) for path in restart_map}
-    r = lambda_f()
     changed_files = defaultdict(list)
     restarts = []
     # create a list of lists of the services to restart
@@ -808,7 +886,6 @@ def restart_on_change_helper(lambda_f, restart_map, stopstart=False,
                     service(action, service_name)
             if post_svc_restart_f:
                 post_svc_restart_f(service_name)
-    return r
 
 
 def pwgen(length=None):

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -1431,6 +1431,53 @@ class HelpersTest(TestCase):
     @patch.object(host, 'service')
     @patch('os.path.exists')
     @patch('glob.iglob')
+    def test_restart_on_change1(self, iglob, exists, service):
+        file_name = '/etc/missing.conf'
+        restart_map = {
+            file_name: ['test-service']
+        }
+        iglob.side_effect = [[], [file_name]]
+        exists.return_value = True
+
+        @host.restart_on_change1(restart_map)
+        def make_some_changes(mock_file):
+            mock_file.read.return_value = b"newstuff"
+
+        with patch_open() as (mock_open, mock_file):
+            make_some_changes(mock_file)
+
+        for service_name in restart_map[file_name]:
+            service.assert_called_with('restart', service_name)
+
+        exists.assert_has_calls([
+            call(file_name),
+        ])
+
+    @patch.object(host, 'service')
+    @patch('os.path.exists')
+    @patch('glob.iglob')
+    def test_restart_on_change1_context_manager(self, iglob, exists, service):
+        file_name = '/etc/missing.conf'
+        restart_map = {
+            file_name: ['test-service']
+        }
+        iglob.side_effect = [[], [file_name]]
+        exists.return_value = True
+
+        with patch_open() as (mock_open, mock_file):
+            with host.restart_on_change1(restart_map):
+                mock_file.read.return_value = b"newstuff"
+
+        for service_name in restart_map[file_name]:
+            service.assert_called_with('restart', service_name)
+
+        exists.assert_has_calls([
+            call(file_name),
+        ])
+
+    @patch.object(host, 'service')
+    @patch('os.path.exists')
+    @patch('glob.iglob')
     def test_multiservice_restart_on_change(self, iglob, exists, service):
         file_name_one = '/etc/missing.conf'
         file_name_two = '/etc/exists.conf'


### PR DESCRIPTION
This is the start of an example of how to turn the restart_on_change
decorator into a context manager and decorator.