### PR TITLE
contrib/openstack: Add helpers for principal subordinate package information exchange

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -1622,3 +1622,12 @@ def _contains_range(addresses):
         addresses.startswith(".") or
         ",." in addresses or
         " ." in addresses)
+
+
+def is_subordinate():
+    """Check whether charm is subordinate in unit metadata.
+
+    :returns: True if unit is subordniate, False otherwise.
+    :rtype: bool
+    """
+    return metadata().get('subordinate') is True

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -1670,6 +1670,15 @@ class HelpersTest(TestCase):
                                  any_order=True)
         self.assertEqual(expected_settings, proxy_settings)
 
+    @patch.object(hookenv, 'metadata')
+    def test_is_subordinate(self, mock_metadata):
+        mock_metadata.return_value = {}
+        self.assertFalse(hookenv.is_subordinate())
+        mock_metadata.return_value = {'subordinate': False}
+        self.assertFalse(hookenv.is_subordinate())
+        mock_metadata.return_value = {'subordinate': True}
+        self.assertTrue(hookenv.is_subordinate())
+
 
 class HooksTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
For principal - subordinate plugin type relations where the
principal Python payload imports code from packages managed by a
subordinate, upgrades can be problematic.

This change will allow a subordinate charm that have opted into the
feature to inform its principal about all implemented release -
packages combinations ahead of time. With this information in place
the principal can do the upgrade in one operation without risk of
charm relation RPC type processing at a critical moment.

Related-Bug: #1806111