### PR TITLE
Allow passing additional jinja2.Environment variables to `render` function

### DIFF
--- a/charmhelpers/contrib/templating/jinja.py
+++ b/charmhelpers/contrib/templating/jinja.py
@@ -31,8 +31,21 @@ except ImportError:
 DEFAULT_TEMPLATES_DIR = 'templates'
 
 
-def render(template_name, context, template_dir=DEFAULT_TEMPLATES_DIR):
+def render(template_name, context, template_dir=DEFAULT_TEMPLATES_DIR,
+           jinja_env_args=None):
+    """
+    Render jinja2 template with provided context.
+
+    :param template_name: name of the jinja template file
+    :param context: template context
+    :param template_dir: directory in which the template file is located
+    :param jinja_env_args: additional arguments passed to the
+                           jinja2.Environment. Expected dict with format
+                           {'arg_name': 'arg_value'}
+    :return: Rendered template as a string
+    """
+    env_kwargs = jinja_env_args or {}
     templates = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(template_dir))
+        loader=jinja2.FileSystemLoader(template_dir), **env_kwargs)
     template = templates.get_template(template_name)
     return template.render(context)

--- a/tests/contrib/templating/test_jinja.py
+++ b/tests/contrib/templating/test_jinja.py
@@ -12,6 +12,8 @@ SIMPLE_TEMPLATE = "{{ somevar }}"
 
 LOOP_TEMPLATE = "{% for i in somevar %}{{ i }}{% endfor %}"
 
+CUSTOM_DELIM_TEMPLATE = "{{ not_var }} << template_var >>"
+
 
 class Jinja2Test(TestCase):
 
@@ -45,4 +47,17 @@ class Jinja2Test(TestCase):
         result = render(
             name, {"somevar": ["1", "2", "3", "4", "5"]},
             template_dir=self.templates_dir)
+        self.assertEqual(expected, result)
+
+    def test_custom_delimiters(self):
+        name = "custom_delimiters"
+        template_var = "foo"
+        jinja_env_args = {"variable_start_string": "<<",
+                          "variable_end_string": ">>"}
+        expected = "{{ not_var }} %s" % template_var
+        self._write_template_to_file(name, CUSTOM_DELIM_TEMPLATE)
+
+        result = render(name, {'template_var': template_var},
+                        template_dir=self.templates_dir,
+                        jinja_env_args=jinja_env_args)
         self.assertEqual(expected, result)


### PR DESCRIPTION
This should solve #367