### PR TITLE
Allow rbd mirroring mode to be set to none

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -268,7 +268,7 @@ class BasePool(object):
         'compression-max-blob-size': (int, None),
         'compression-max-blob-size-hdd': (int, None),
         'compression-max-blob-size-ssd': (int, None),
-        'rbd-mirroring-mode': (str, ('image', 'pool'))
+        'rbd-mirroring-mode': (str, ('image', 'pool', 'none'))
     }
 
     def __init__(self, service, name=None, percent_data=None, app_name=None,


### PR DESCRIPTION
Allow the rbd-mirroring-mode for a Ceph pool to be specified as
'none'. This allows a charm to be able to explicitly disable rbd
mirroring when it knows it will be creating a pool type which is
not supported.

The example for this, is when erasure coded pools are being created
for RBD use. Two pools are created, one for erasure coded data and
one for RBD metadata. Neither pool should be mirrored, so the charm
can explicitly specify this.

Closes-Bug: #1898504
(cherry picked from commit c3bd490b67a53d86a40382ef644e41acf67d0b6a)