### PR TITLE
Add hirsute to the list of known UBUNTU_RELEASES

### DIFF
--- a/charmhelpers/core/host_factory/ubuntu.py
+++ b/charmhelpers/core/host_factory/ubuntu.py
@@ -26,7 +26,8 @@ UBUNTU_RELEASES = (
     'disco',
     'eoan',
     'focal',
-    'groovy'
+    'groovy',
+    'hirsute',
 )
 
 


### PR DESCRIPTION
It got missed out in a recent update to charmhelpers, but is needed for
the CompareHostReleases() function to operate correctly.