### PR TITLE
Fix duplicating other charms deferred event messages

### DIFF
--- a/charmhelpers/contrib/openstack/deferred_events.py
+++ b/charmhelpers/contrib/openstack/deferred_events.py
@@ -46,9 +46,13 @@ class ServiceEvent():
         self.service = service
         self.reason = reason
         self.action = action
-        if not policy_requestor_name:
+        if policy_requestor_name:
+            self.policy_requestor_name = policy_requestor_name
+        else:
             self.policy_requestor_name = hookenv.service_name()
-        if not policy_requestor_type:
+        if policy_requestor_type:
+            self.policy_requestor_type = policy_requestor_type
+        else:
             self.policy_requestor_type = 'charm'
 
     def __eq__(self, other):
@@ -99,7 +103,9 @@ def read_event_file(file_name):
         contents['timestamp'],
         contents['service'],
         contents['reason'],
-        contents['action'])
+        contents['action'],
+        policy_requestor_name=contents.get('policy_requestor_name'),
+        policy_requestor_type=contents.get('policy_requestor_type'))
     return event
 
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1090,7 +1090,7 @@ def _determine_os_workload_status(
     try:
         if config(POLICYD_CONFIG_NAME):
             message = "{} {}".format(policyd_status_message_prefix(), message)
-        # Get deferred restarts events that were triggered by a policy writtena
+        # Get deferred restarts events that were triggered by a policy written
         # by this charm.
         deferred_restarts = list(set(
             [e.service

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1090,8 +1090,8 @@ def _determine_os_workload_status(
     try:
         if config(POLICYD_CONFIG_NAME):
             message = "{} {}".format(policyd_status_message_prefix(), message)
-        # Get deferred restarts events that were triggered by a policy written
-        # by this charm.
+        # Get deferred restarts events that have been triggered by a policy
+        # written by this charm.
         deferred_restarts = list(set(
             [e.service
              for e in deferred_events.get_deferred_restarts()

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -56,6 +56,7 @@ from charmhelpers.core.hookenv import (
     relation_id,
     relation_ids,
     relation_set,
+    service_name as ch_service_name,
     status_set,
     hook_name,
     application_version_set,
@@ -1089,8 +1090,12 @@ def _determine_os_workload_status(
     try:
         if config(POLICYD_CONFIG_NAME):
             message = "{} {}".format(policyd_status_message_prefix(), message)
+        # Get deferred restarts events that were triggered by a policy writtena
+        # by this charm.
         deferred_restarts = list(set(
-            [e.service for e in deferred_events.get_deferred_restarts()]))
+            [e.service
+             for e in deferred_events.get_deferred_restarts()
+             if e.policy_requestor_name == ch_service_name()]))
         if deferred_restarts:
             svc_msg = "Services queued for restart: {}".format(
                 ', '.join(sorted(deferred_restarts)))

--- a/tests/contrib/openstack/test_deferred_events.py
+++ b/tests/contrib/openstack/test_deferred_events.py
@@ -57,7 +57,9 @@ class DeferredCharmServiceEventsTestCase(tests.utils.BaseTestCase):
             timestamp=123,
             service='svcA',
             reason='ReasonA',
-            action='restart')
+            action='restart',
+            policy_requestor_name='myapp',
+            policy_requestor_type='charm')
         self.exp_event_b = deferred_events.ServiceEvent(
             timestamp=223,
             service='svcB',


### PR DESCRIPTION
Stop charms from duplicating each others deferred event messages when
they are deployed on the same unit.

This includes a fix to ensure the policy_requestor_name and
policy_requestor_type are read properly from the event file.

Closes bug https://bugs.launchpad.net/charm-nova-compute/+bug/1923739