### PR TITLE
contrib/ovs/ovsdb: Allow passing extra args to tool

### DIFF
--- a/tests/contrib/network/ovs/test_ovsdb.py
+++ b/tests/contrib/network/ovs/test_ovsdb.py
@@ -95,6 +95,14 @@ class TestSimpleOVSDB(test_utils.BaseTestCase):
             break
         self._run.assert_called_once_with(
             'ovs-vsctl', '-f', 'json', 'find', 'bridge', 'name=br-test')
+        # check the optional args paramenter
+        self._run.reset_mock()
+        self.target = ovsdb.SimpleOVSDB('ovs-vsctl', args=['extra', 'args'])
+        for el in self.target.bridge.find(condition='name=br-test'):
+            break
+        self._run.assert_called_once_with(
+            'ovs-vsctl', 'extra', 'args',
+            '-f', 'json', 'find', 'bridge', 'name=br-test')
 
     def test_clear(self):
         self.target = ovsdb.SimpleOVSDB('ovs-vsctl')


### PR DESCRIPTION
When using SimpleOVSDB with a non-local database it may be useful
to pass extra arguments to the tool.