### PR TITLE
Revert "Set cmd_env for trusty and xenial only (#573)"

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -658,17 +658,11 @@ def _add_apt_repository(spec):
     :param spec: the parameter to pass to add_apt_repository
     :type spec: str
     """
-    series = get_distrib_codename()
     if '{series}' in spec:
+        series = get_distrib_codename()
         spec = spec.replace('{series}', series)
-    # software-properties package for bionic properly reacts to proxy settings
-    # set via apt.conf (see lp:1433761), however this is not the case for LTS
-    # and non-LTS releases before bionic.
-    if series in ('trusty', 'xenial'):
-        _run_with_retries(['add-apt-repository', '--yes', spec],
-                          cmd_env=env_proxy_settings(['https', 'http']))
-    else:
-        _run_with_retries(['add-apt-repository', '--yes', spec])
+    _run_with_retries(['add-apt-repository', '--yes', spec],
+                      cmd_env=env_proxy_settings(['https', 'http']))
 
 
 def _add_cloud_pocket(pocket):


### PR DESCRIPTION
This reverts commit 29c9c2c04cff4f4739caa27cd43da3bf80e40646.

This change also removes the comment regarding software-properties
as it was adding confusion. add-apt-repository is provided by the
software-properties package. While http_proxy and https_proxy env
vars appear to work with add-apt-repository, apt.conf settings
Acquire::http::Proxy and Acquire::https::Proxy do not appear to
work with add-apt-repository.

Fixes #602

(cherry picked from commit ba4dae4e7bba607f3e5b855d58f1594b39bf3466)