### PR TITLE
ceph.conf: enable logging for ceph clients

### DIFF
--- a/charmhelpers/contrib/openstack/templates/ceph.conf
+++ b/charmhelpers/contrib/openstack/templates/ceph.conf
@@ -17,6 +17,8 @@ rbd default features = {{ rbd_features }}
 {% endif %}
 
 [client]
+log to syslog = true
+err to stderr = true
 {% if rbd_client_cache_settings -%}
 {% for key, value in rbd_client_cache_settings.items() -%}
 {{ key }} = {{ value }}


### PR DESCRIPTION
Enable 'log to syslog' and 'err to stderr' for ceph clients.

Currently the default configuration disables "log to syslog" for ceph
primarily targeting the ceph OSD units which log to files in
/var/log/ceph instead. However this value is also used by ceph clients
and as a result even with an error a ceph client such as libvirt/qemu
will not log errors *anywhere* making issues such as failure to connect
to a ceph cluster or invalid keyrings difficult to diagnose. Hence we
always enable 'log to syslog' for ceph clients.

We could alternatively enable log to a file, however, there are apparmor
and permissions issues that mean access to /var/log/ceph is not
guaranteed and in some cases multiple PIDs may write to this file
creating many different files so syslog seems like the best choice.
(Reference: https://github.com/juju/charm-helpers/pull/204)

Also enable 'err to stderr' which it makes it more likely the error is
surfaced in other important locations such as
/var/log/libvirt/qemu/instance-*.log and on the command line.

Partial-Bug: #1786874