### PR TITLE
Update the build status badge for github actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 CharmHelpers |badge|
 --------------------
 
-.. |badge| image:: https://travis-ci.org/juju/charm-helpers.svg?branch=master
-    :target: https://travis-ci.org/juju/charm-helpers
+.. |badge| image:: https://github.com/juju/charm-helpers/actions/workflows/build.yml/badge.svg?branch=master
+    :target: https://github.com/juju/charm-helpers/actions/workflows/build.yml
 
 Overview
 ========


### PR DESCRIPTION
The CI bits were migrated from travis to github actions, but the
status badge still points at travis-ci. Update the badge links to
point to the github actions badges and status.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>