### PR TITLE
Set WSGI env with lang=C.UTF-8

### DIFF
--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -15,7 +15,7 @@ Listen {{ public_port }}
 {% if port -%}
 <VirtualHost *:{{ port }}>
     WSGIDaemonProcess {{ service_name }} processes={{ processes }} threads={{ threads }} user={{ user }} group={{ group }} \
-                      display-name=%{GROUP}
+                      display-name=%{GROUP} lang=C.UTF-8 locale=C.UTF-8
     WSGIProcessGroup {{ service_name }}
     WSGIScriptAlias / {{ script }}
     WSGIApplicationGroup %{GLOBAL}
@@ -41,7 +41,7 @@ Listen {{ public_port }}
 {% if admin_port -%}
 <VirtualHost *:{{ admin_port }}>
     WSGIDaemonProcess {{ service_name }}-admin processes={{ admin_processes }} threads={{ threads }} user={{ user }} group={{ group }} \
-                      display-name=%{GROUP}
+                      display-name=%{GROUP} lang=C.UTF-8 locale=C.UTF-8
     WSGIProcessGroup {{ service_name }}-admin
     WSGIScriptAlias / {{ admin_script }}
     WSGIApplicationGroup %{GLOBAL}
@@ -67,7 +67,7 @@ Listen {{ public_port }}
 {% if public_port -%}
 <VirtualHost *:{{ public_port }}>
     WSGIDaemonProcess {{ service_name }}-public processes={{ public_processes }} threads={{ threads }} user={{ user }} group={{ group }} \
-                      display-name=%{GROUP}
+                      display-name=%{GROUP} lang=C.UTF-8 locale=C.UTF-8
     WSGIProcessGroup {{ service_name }}-public
     WSGIScriptAlias / {{ public_script }}
     WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
The default apache2 environment, and therefore the default WSGI
environment, sets LANG=C. For languages beyond the scope of ASCII
this can create problems.

Explicitly set the lang and locale to C.UTF-8 which will support all
UTF-8 language sets.

Related-Bug: #1933109