### PR TITLE
Adds context switch for neutron-dhcp-agent

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2379,6 +2379,12 @@ class DHCPAgentContext(OSContextGenerator):
             ctxt['enable_metadata_network'] = True
             ctxt['enable_isolated_metadata'] = True
 
+        ctxt['append_ovs_config'] = False
+        cmp_release = CompareOpenStackReleases(
+            os_release('neutron-common', base='icehouse'))
+        if cmp_release >= 'queens' and config('enable-dpdk'):
+            ctxt['append_ovs_config'] = True
+
         return ctxt
 
     @staticmethod


### PR DESCRIPTION
The neutron-dhcp-agent might rely on options defined in
openvswitch_agent.ini. By default this config file is not passed to
neutron-dhcp-agent daemon, and therefore those options are not
loaded and fall back for the default values and by that inhibits
the desired behavior. This behavior should happen only if
the release if greater than queens.

Please check: lp:#1832021 and gerrit:I134c8077ee52ccdb4e383109ecbea27ed1633fb8
for more context.