### PR TITLE
Check bridges keys format and set charm to blocked state if wrong

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -139,6 +139,13 @@ HAPROXY_RUN_DIR = '/var/run/haproxy/'
 DEFAULT_OSLO_MESSAGING_DRIVER = "messagingv2"
 
 
+class BridgesKeyException(Exception):
+    """Raised when an error occurs setting up bridges keys
+    """
+
+    pass
+
+
 def ensure_packages(packages):
     """Install but do not upgrade required plugin packages."""
     required = filter_installed_packages(packages)
@@ -2798,44 +2805,57 @@ class BridgePortInterfaceMap(object):
                 self._mac_pci_address_map[bond_mac.mac] = pci_address
 
         config_bridges = config(bridges_key) or ''
-        for bridge, ifname_or_mac in (
-                pair.split(':', 1)
-                for pair in config_bridges.split()):
-            if ':' in ifname_or_mac:
-                try:
-                    ifname = self.ifname_from_mac(ifname_or_mac)
-                except KeyError:
-                    # The interface is destined for a different unit in the
-                    # deployment.
-                    continue
-                macs = [ifname_or_mac]
-            else:
-                ifname = ifname_or_mac
-                macs = self.macs_from_ifname(ifname_or_mac)
+        # check config_bridges pattern "<str>:<str>","<str>:<str> <str>:<str>" or ""
+        config_bridges_pattern = re.match(
+            r'^((\S+:\S+)( \S+:\S+)*|^$)$',
+            config_bridges
+        )
+        if config_bridges_pattern:
+            for bridge, ifname_or_mac in (
+                    pair.split(':', 1)
+                    for pair in config_bridges.split()):
+                if ':' in ifname_or_mac:
+                    try:
+                        ifname = self.ifname_from_mac(ifname_or_mac)
+                    except KeyError:
+                        # The interface is destined for a different unit in the
+                        # deployment.
+                        continue
+                    macs = [ifname_or_mac]
+                else:
+                    ifname = ifname_or_mac
+                    macs = self.macs_from_ifname(ifname_or_mac)
 
-            portname = ifname
-            for mac in macs:
-                try:
-                    pci_address = self.pci_address_from_mac(mac)
-                    iftype = self.interface_type.dpdk
-                    ifname = self.ifname_from_mac(mac)
-                except KeyError:
-                    pci_address = None
-                    iftype = self.interface_type.system
+                portname = ifname
+                for mac in macs:
+                    try:
+                        pci_address = self.pci_address_from_mac(mac)
+                        iftype = self.interface_type.dpdk
+                        ifname = self.ifname_from_mac(mac)
+                    except KeyError:
+                        pci_address = None
+                        iftype = self.interface_type.system
 
-                self.add_interface(
-                    bridge, portname, ifname, iftype, pci_address, global_mtu)
+                    self.add_interface(
+                        bridge, portname, ifname, iftype, pci_address, global_mtu)
 
-            if not macs:
-                # We have not mapped the interface and it is probably some sort
-                # of virtual interface. Our user have put it in the config with
-                # a purpose so let's carry out their wish. LP: #1884743
-                log('Add unmapped interface from config: name "{}" bridge "{}"'
-                    .format(ifname, bridge),
-                    level=DEBUG)
-                self.add_interface(
-                    bridge, ifname, ifname, self.interface_type.system, None,
-                    global_mtu)
+                if not macs:
+                    # We have not mapped the interface and it is probably some sort
+                    # of virtual interface. Our user have put it in the config with
+                    # a purpose so let's carry out their wish. LP: #1884743
+                    log('Add unmapped interface from config: name "{}" bridge "{}"'
+                        .format(ifname, bridge),
+                        level=DEBUG)
+                    self.add_interface(
+                        bridge, ifname, ifname, self.interface_type.system, None,
+                        global_mtu)
+
+        else:
+            msg = ('Wrong format. '
+                   'Expected format is space-delimited list of key-value pairs.'
+                   'Ex: "br-internet:00:00:5e:00:00:42 br-provider:enp3s0f0"')
+            status_set('blocked', msg)
+            raise BridgesKeyException(msg)
 
     def __getitem__(self, key):
         """Provide a Dict-like interface, get value of item.

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4776,6 +4776,57 @@ class TestBridgePortInterfaceMap(tests.utils.BaseTestCase):
             },
         })
 
+    def test_wrong_bridges_keys_pattern(self):
+        self.patch_object(context, 'config')
+        # check "<str>" pattern
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'incorrect_pattern'),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        with self.assertRaises(context.BridgesKeyException):
+            context.BridgePortInterfaceMap()
+
+        # check "<str>:<str> " pattern
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'br-ex:eth2 '
+                'br-provider1:bond0 '),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        with self.assertRaises(context.BridgesKeyException):
+            context.BridgePortInterfaceMap()
+
+        # check "<str>:<str> <str>" pattern
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'br-ex:eth2 '
+                'br-provider1'),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        with self.assertRaises(context.BridgesKeyException):
+            context.BridgePortInterfaceMap()
+
+        # check "<str>:<str> <str>:" pattern
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'br-ex:eth2 '
+                'br-provider1:'),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        with self.assertRaises(context.BridgesKeyException):
+            context.BridgePortInterfaceMap()
+
+        # check double spaces "<str>:<str>  <str>:<str>" pattern
+        self.config.side_effect = lambda x: {
+            'data-port': (
+                'br-ex:eth2  '
+                'br-provider1:bond0'),
+            'dpdk-bond-mappings': '',
+        }.get(x)
+        with self.assertRaises(context.BridgesKeyException):
+            context.BridgePortInterfaceMap()
+
     def test_add_interface(self):
         self.patch_object(context, 'config')
         self.config.return_value = ''


### PR DESCRIPTION
The expected format for the bridges key is space-delimited list of key-value pairs.
Ex: "br-internet:00:00:5e:00:00:42 br-provider:enp3s0f0". If user sets a wrong format,
the config-changed hook fails.

In order to fix this, a regex was set to check if is in the correct format including
empty strings. If the format is wrong, it sets the juju status to "blocked" and
raises an exception.

The regex ` ^((\S+:\S+)( \S+:\S+)*|^$)$ ` means that the string should start and
end with content inside that can be empty or that have one or more non-space
character followed by ":" and one or more non-space character. In case of more
than one key-value, the expression searches for exactly one space and then
 one or more non-space character followed by ":" and one or more non-space
character. The expression accepts any number of pairs of key-value.

The following examples of key-value pairs are accepted:
"<str>:<str>" Ex: "br-provider:enp3s0f0"
"<str>:<str> <str>:<str>" Ex: "br-provider:enp3s0f0 br-internet:00:00:5e:00:00:42"
"" (empty string)

The following examples of key-value pairs are not accepted:
"<str>"
"<str>:"
"<str>:<str>  <str>:<str>" (Double spaces between key-values)
"<str>:<str> <str>:"

The bug was filled  on charm-ovn-chassis  located at
https://bugs.launchpad.net/charm-ovn-chassis/+bug/1919481

Closes-Bug: #1919481