### PR TITLE
Add a base openstack code name as a source for add_source()

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -106,6 +106,8 @@ from charmhelpers.fetch import (
     filter_installed_packages,
     filter_missing_packages,
     ubuntu_apt_pkg as apt,
+    OPENSTACK_RELEASES,
+    UBUNTU_OPENSTACK_RELEASE,
 )
 
 from charmhelpers.fetch.snap import (
@@ -131,53 +133,6 @@ CLOUD_ARCHIVE_KEY_ID = '5EDB1B62EC4926EA'
 
 DISTRO_PROPOSED = ('deb http://archive.ubuntu.com/ubuntu/ %s-proposed '
                    'restricted main multiverse universe')
-
-OPENSTACK_RELEASES = (
-    'diablo',
-    'essex',
-    'folsom',
-    'grizzly',
-    'havana',
-    'icehouse',
-    'juno',
-    'kilo',
-    'liberty',
-    'mitaka',
-    'newton',
-    'ocata',
-    'pike',
-    'queens',
-    'rocky',
-    'stein',
-    'train',
-    'ussuri',
-    'victoria',
-    'wallaby',
-)
-
-UBUNTU_OPENSTACK_RELEASE = OrderedDict([
-    ('oneiric', 'diablo'),
-    ('precise', 'essex'),
-    ('quantal', 'folsom'),
-    ('raring', 'grizzly'),
-    ('saucy', 'havana'),
-    ('trusty', 'icehouse'),
-    ('utopic', 'juno'),
-    ('vivid', 'kilo'),
-    ('wily', 'liberty'),
-    ('xenial', 'mitaka'),
-    ('yakkety', 'newton'),
-    ('zesty', 'ocata'),
-    ('artful', 'pike'),
-    ('bionic', 'queens'),
-    ('cosmic', 'rocky'),
-    ('disco', 'stein'),
-    ('eoan', 'train'),
-    ('focal', 'ussuri'),
-    ('groovy', 'victoria'),
-    ('hirsute', 'wallaby'),
-])
-
 
 OPENSTACK_CODENAMES = OrderedDict([
     ('2011.2', 'diablo'),

--- a/charmhelpers/fetch/__init__.py
+++ b/charmhelpers/fetch/__init__.py
@@ -106,6 +106,8 @@ if __platform__ == "ubuntu":
     apt_pkg = fetch.ubuntu_apt_pkg
     get_apt_dpkg_env = fetch.get_apt_dpkg_env
     get_installed_version = fetch.get_installed_version
+    OPENSTACK_RELEASES = fetch.OPENSTACK_RELEASES
+    UBUNTU_OPENSTACK_RELEASE = fetch.UBUNTU_OPENSTACK_RELEASE
 elif __platform__ == "centos":
     yum_search = fetch.yum_search
 

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -625,7 +625,7 @@ def add_source(source, key=None, fail_invalid=False):
     '<openstack-version>': translate to cloud:<release> based on the current
       distro version (i.e. for 'ussuri' this will either be 'bionic-ussuri' or
       'distro'.
-    '<openstack-version/proposed': as above, but for proposed.
+    '<openstack-version>/proposed': as above, but for proposed.
 
     Otherwise the source is not recognised and this is logged to the juju log.
     However, no error is raised, unless sys_error_on_exit is True.

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -810,7 +810,6 @@ def _add_bare_openstack(openstack_release):
     :type openstack_release: str
     :raises: SourceConfigError
     """
-    # So it's distro, which means it's a no-op so end here.
     # TODO(ajkavanagh) - surely this means we should be removing cloud archives
     # if they exist?
     __add_bare_helper(openstack_release, "{}-{}", lambda: None)

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -730,6 +730,98 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
         # distro is a noop but test validate no exception is thrown
         fetch.add_source(source=source)
 
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_is_distro(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket):
+        mock_get_distrib_codename.return_value = 'focal'
+        fetch.add_source('ussuri')
+        mock_add_cloud_pocket.assert_not_called()
+
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_is_cloud_pocket(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket):
+        mock_get_distrib_codename.return_value = 'bionic'
+        fetch.add_source('ussuri')
+        mock_add_cloud_pocket.assert_called_once_with("bionic-ussuri")
+
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_impossible_version(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket):
+        mock_get_distrib_codename.return_value = 'xenial'
+        try:
+            fetch.add_source('ussuri')
+            self.fail("add_source('ussuri') on xenial should fail")
+        except fetch.SourceConfigError:
+            pass
+        mock_add_cloud_pocket.assert_not_called()
+
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_impossible_ubuntu(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket):
+        mock_get_distrib_codename.return_value = 'bambam'
+        try:
+            fetch.add_source('ussuri')
+            self.fail("add_source('ussuri') on bambam should fail")
+        except fetch.SourceConfigError:
+            pass
+        mock_add_cloud_pocket.assert_not_called()
+
+    @patch('charmhelpers.fetch.ubuntu._add_proposed')
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_proposed_is_distro_proposed(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket,
+            mock_add_proposed):
+        mock_get_distrib_codename.return_value = 'focal'
+        fetch.add_source('ussuri/proposed')
+        mock_add_cloud_pocket.assert_not_called()
+        mock_add_proposed.assert_called_once_with()
+
+    @patch('charmhelpers.fetch.ubuntu._add_proposed')
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_proposed_is_cloud_pocket(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket,
+            mock_add_proposed):
+        mock_get_distrib_codename.return_value = 'bionic'
+        fetch.add_source('ussuri/proposed')
+        mock_add_cloud_pocket.assert_called_once_with("bionic-ussuri/proposed")
+        mock_add_proposed.assert_not_called()
+
+    @patch('charmhelpers.fetch.ubuntu._add_proposed')
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_proposed_impossible_version(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket,
+            mock_add_proposed):
+        mock_get_distrib_codename.return_value = 'xenial'
+        try:
+            fetch.add_source('ussuri/proposed')
+            self.fail("add_source('ussuri/proposed') on xenial should fail")
+        except fetch.SourceConfigError:
+            pass
+        mock_add_cloud_pocket.assert_not_called()
+        mock_add_proposed.assert_not_called()
+
+    @patch('charmhelpers.fetch.ubuntu._add_proposed')
+    @patch('charmhelpers.fetch.ubuntu._add_cloud_pocket')
+    @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
+    def test_add_bare_openstack_proposed_impossible_ubuntu(
+            self, mock_get_distrib_codename, mock_add_cloud_pocket,
+            mock_add_proposed):
+        mock_get_distrib_codename.return_value = 'bambam'
+        try:
+            fetch.add_source('ussuri/proposed')
+            self.fail("add_source('ussuri/proposed') on bambam should fail")
+        except fetch.SourceConfigError:
+            pass
+        mock_add_cloud_pocket.assert_not_called()
+        mock_add_proposed.assert_not_called()
+
 
 class AptTests(TestCase):
 


### PR DESCRIPTION
This is a 'smart' option, where the openstack-origin=ussuri, for
example, passing 'ussuri' to the add_source() function.  This, on focal,
will be the equivalent of 'distro' and on bionic, will be
'cloud:bionic-ussuri'.  On groovy, victoria is distro, etc.

Also support a 'ussuri/proposed' to allow proposed to be carried between
distro versions.  This is to simplify the logic for setting openstack
versions so that the version wanted is the name rather than 'distro'.