### PR TITLE
Base DPDK socket mem on sockets not NUMA nodes

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -25,7 +25,10 @@ import socket
 import time
 
 from base64 import b64decode
-from subprocess import check_call, CalledProcessError
+from subprocess import (
+    check_call,
+    check_output,
+    CalledProcessError)
 
 import six
 
@@ -2578,14 +2581,22 @@ class OVSDPDKDeviceContext(OSContextGenerator):
         return format(mask, '#04x')
 
     def socket_memory(self):
-        """Formatted list of socket memory configuration per NUMA node
+        """Formatted list of socket memory configuration per socket.
 
-        :returns: socket memory configuration per NUMA node
+        :returns: socket memory configuration per socket.
         :rtype: str
         """
+        lscpu_out = check_output(
+            ['lscpu', '-p=socket']).decode('UTF-8').strip()
+        sockets = set()
+        for line in lscpu_out.split('\n'):
+            try:
+                sockets.add(int(line))
+            except ValueError:
+                # lscpu output is headed by comments so ignore them.
+                pass
         sm_size = config('dpdk-socket-memory')
-        node_regex = '/sys/devices/system/node/node*'
-        mem_list = [str(sm_size) for _ in glob.glob(node_regex)]
+        mem_list = [str(sm_size) for _ in sockets]
         if mem_list:
             return ','.join(mem_list)
         else:

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4459,6 +4459,38 @@ NUMA_CORES_MULTI = {
     '1': [4, 5, 6, 7]
 }
 
+LSCPU_ONE_SOCKET = b"""
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# Socket
+0
+0
+0
+0
+"""
+
+LSCPU_TWO_SOCKET = b"""
+# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# Socket
+0
+1
+0
+1
+0
+1
+0
+1
+0
+1
+0
+1
+0
+1
+"""
+
 
 class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
 
@@ -4520,16 +4552,16 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
 
     def test_socket_memory(self):
         """Test socket memory configuration"""
-        self.patch_object(context, 'glob')
+        self.patch_object(context, 'check_output')
         self.patch_object(context, 'config')
         self.config.side_effect = lambda x: {
             'dpdk-socket-memory': 1024,
         }.get(x)
-        self.glob.glob.return_value = ['a']
+        self.check_output.return_value = LSCPU_ONE_SOCKET
         self.assertEqual(self.target.socket_memory(),
                          '1024')
 
-        self.glob.glob.return_value = ['a', 'b']
+        self.check_output.return_value = LSCPU_TWO_SOCKET
         self.assertEqual(self.target.socket_memory(),
                          '1024,1024')
 
@@ -4575,8 +4607,8 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
             '0000:00:1d.0': 'br-data',
         }.items()))
         self._numa_node_cores.return_value = NUMA_CORES_SINGLE
-        self.patch_object(context, 'glob')
-        self.glob.glob.return_value = ['a']
+        self.patch_object(context, 'check_output')
+        self.check_output.return_value = LSCPU_ONE_SOCKET
         self.config.side_effect = lambda x: {
             'dpdk-socket-cores': 1,
             'dpdk-socket-memory': 1024,


### PR DESCRIPTION
OVSDPDKDeviceContext().socket_memory() is currently using the
number of NUMA nodes to generate the memory option for
socket-mem/dpdk-socket-mem *1. However, this option should
be based on the number of sockets *2 & *3. Fwiw, looking at the
charms, socket_memory() only seems to be used to set
dpdk-socket-mem *4 *5. See bug report for more details *6

*1 https://github.com/juju/charm-helpers/blob/master/charmhelpers/contrib/openstack/context.py#L2587
*2 https://doc.dpdk.org/guides/linux_gsg/linux_eal_parameters.html#id3
*3 https://docs.openvswitch.org/en/latest/intro/install/dpdk/
*4 https://github.com/openstack-charmers/charm-layer-ovn/blob/master/lib/charms/ovn_charm.py#L664
*5 https://github.com/openstack/charm-neutron-openvswitch/blob/master/hooks/neutron_ovs_utils.py#L569
*6 https://bugs.launchpad.net/charm-ovn-chassis/+bug/1938557