### PR TITLE
fix broken link to charm install

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -9,7 +9,7 @@ page.
 Installing Charm Tools
 ----------------------
 
-First, follow `these instructions <https://jujucharms.com/docs/stable/tools-charm-tools.html>`_
+First, follow `these instructions <https://juju.is/docs/t/charm-tools/1180>`_
 to install the ``charm-tools`` package for your platform.
 
 Creating a New Charm


### PR DESCRIPTION
The link was giving me a http 404 not found error. I hope the one I found is correct.