### PR TITLE
Set no_proxy in the command environment for add-apt-repository

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -742,7 +742,8 @@ def _add_apt_repository(spec):
         series = get_distrib_codename()
         spec = spec.replace('{series}', series)
     _run_with_retries(['add-apt-repository', '--yes', spec],
-                      cmd_env=env_proxy_settings(['https', 'http']))
+                      cmd_env=env_proxy_settings(['https', 'http', 'no_proxy'])
+                      )
 
 
 def _add_cloud_pocket(pocket):


### PR DESCRIPTION
When setting up the command environment for calling add-apt-repository the no_proxy environment variable should also be set so that if you have a restrictive proxy server you can add ppa.launchpad.net to the no proxy list and add apt repositories.

I specifically encountered this when deploying cassandra on bionic with http_proxy and https_proxy set to squid.internal and ppa.launchpad.net in no_proxy.

Here you can see the output of os.environ which was obtained by modifying software-properties ppa.py:

`Cannot add PPA: 'ppa:~cassandra-charmers/ubuntu/stable'.                                                                                    ERROR: '~cassandra-charmers' user or team does not exist.environ({'DEBIAN_FRONTEND': 'noninteractive', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin', 'HTTP_PROXY': 'http://squid.internal:3128', 'http_proxy': 'http://squid.internal:3128', 'HTTPS_PROXY': 'http://squid.internal:3128', 'https_proxy': 'http://squid.internal:3128', 'APT_CONFIG': '/tmp/tmpspydfz8k/apt.conf'})`

After modifying ubuntu.py to set no_proxy:

`Cannot add PPA: 'ppa:~cassandra-charmers/ubuntu/stable'.
ERROR: '~cassandra-charmers' user or team does not exist.environ({'DEBIAN_FRONTEND': 'noninteractive', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin', 'HTTP_PROXY': 'http://squid.internal:3128', 'http_proxy': 'http://squid.internal:3128', 'HTTPS_PROXY': 'http://squid.internal:3128', 'https_proxy': 'http://squid.internal:3128', 'NO_PROXY': '127.0.0.1,localhost,::1', 'no_proxy': '127.0.0.1,localhost,::1', 'APT_CONFIG': '/tmp/tmplgdd__1h/apt.conf'})
`
The above only failed because the juju-no-proxy model-config setting had not been updated to include ppa.launchpad.net.