### PR TITLE
More retries on 'apt-get install'

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -280,7 +280,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
 
 APT_NO_LOCK = 100  # The return code for "couldn't acquire lock" in APT.
 CMD_RETRY_DELAY = 10  # Wait 10 seconds between command retries.
-CMD_RETRY_COUNT = 3  # Retry a failing fatal command X times.
+CMD_RETRY_COUNT = 10  # Retry a failing fatal command X times.
 
 
 def filter_installed_packages(packages):


### PR DESCRIPTION
Experience shows that only 3 attempts with 10 seconds
in between is still too likely to fail when deploying
large models.