### PR TITLE
contrib/openstack: Fix haproxy log socket path

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -1,10 +1,22 @@
 global
-    log /var/lib/haproxy/dev/log local0
-    log /var/lib/haproxy/dev/log local1 notice
+    # NOTE: on startup haproxy chroot's to /var/lib/haproxy.
+    #
+    # Unfortunately the program will open some files prior to the call to
+    # chroot never to reopen them, and some after. So looking at the on-disk
+    # layout of haproxy resources you will find some resources relative to /
+    # such as the admin socket, and some relative to /var/lib/haproxy such as
+    # the log socket.
+    #
+    # The logging socket is (re-)opened after the chroot and must be relative
+    # to /var/lib/haproxy.
+    log /dev/log local0
+    log /dev/log local1 notice
     maxconn 20000
     user haproxy
     group haproxy
     spread-checks 0
+    # The admin socket is opened prior to the chroot never to be reopened, so
+    # it lives outside the chroot directory in the filesystem.
     stats socket /var/run/haproxy/admin.sock mode 600 level admin
     stats timeout 2m
 


### PR DESCRIPTION
The HAproxy template file specifies an incorrect path to the log
socket. This is most likely due to confusion caused by the HAproxy
process opening some files prior to the call to chroot(8) and some
after.

Closes-Bug: #1940037