### PR TITLE
Retry on MySQL connection failures

### DIFF
--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -23,6 +23,9 @@ import six
 
 # from string import upper
 
+from charmhelpers.core.decorators import (
+    retry_on_exception,
+)
 from charmhelpers.core.host import (
     CompareHostReleases,
     lsb_release,
@@ -88,6 +91,8 @@ class MySQLHelper(object):
         self.delete_ondisk_passwd_file = delete_ondisk_passwd_file
         self.connection = None
 
+    @retry_on_exception(3, base_delay=10,
+                        exc_type=MySQLdb.OperationalError)
     def connect(self, user='root', password=None, host=None, port=None,
                 connect_timeout=None):
         _connection_info = {


### PR DESCRIPTION
While running [our OpenStack upgrade tests](https://github.com/openstack-charmers/zaza-openstack-tests/blob/master/zaza/openstack/charm_tests/openstack_upgrade/tests.py#L123) it sometimes happen that a `mysql-innodb-cluster` unit errors after having been paused:

```
[INFO] Performing upgrade of Database Services
[INFO] origin for mysql-innodb-cluster is source=distro
[INFO] Setting config for mysql-innodb-cluster to {'source': 'cloud:focal-victoria', 'action-managed-upgrade': 'True'}
[WARNING] get_subordinate_units from zaza.openstack.utilities.juju is deprecated. Please use the equivalent from zaza.utilities.juju
[INFO] Pausing
[INFO] Pausing mysql-innodb-cluster/0
```

```
[ERROR] Juju log for mysql-innodb-cluster/0
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py", line 181, in invoke
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     self._action(*args)
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/charm/reactive/mysql_innodb_cluster_handlers.py", line 302, in post_rolling_restart_update_clients
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     db_router_respond()
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/charm/reactive/mysql_innodb_cluster_handlers.py", line 340, in db_router_respond
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     if instance.create_databases_and_users(db_router):
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/charm/lib/charm/openstack/mysql_innodb_cluster.py", line 1265, in create_databases_and_users
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     allowed_units = self.get_allowed_units(
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/charm/lib/charm/openstack/mysql_innodb_cluster.py", line 1218, in get_allowed_units
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     allowed_units = db_helper.get_allowed_units(
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/.venv/lib/python3.8/site-packages/charmhelpers/contrib/database/mysql.py", line 441, in get_allowed_units
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     self.connect(password=self.get_mysql_root_password())
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/.venv/lib/python3.8/site-packages/charmhelpers/contrib/database/mysql.py", line 111, in connect
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     self.connection = MySQLdb.connect(**_connection_info)
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/.venv/lib/python3.8/site-packages/MySQLdb/__init__.py", line 130, in Connect
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     return Connection(*args, **kwargs)
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed   File "/var/lib/juju/agents/unit-mysql-innodb-cluster-0/.venv/lib/python3.8/site-packages/MySQLdb/connections.py", line 185, in __init__
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed     super().__init__(*args, **kwargs2)
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 WARNING coordinator-relation-changed MySQLdb._exceptions.OperationalError: (2002, "Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)")
[ERROR] unit-mysql-innodb-cluster-0.log: 2021-09-17 10:27:38 ERROR juju.worker.uniter.operation runhook.go:139 hook "coordinator-relation-changed" (via explicit, bespoke hook script) failed:
```

This will hopefully help.