### PR TITLE
Add force flag to openstack-upgrade action

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1413,7 +1413,8 @@ def incomplete_relation_data(configs, required_interfaces):
         for i in incomplete_relations}
 
 
-def do_action_openstack_upgrade(package, upgrade_callback, configs):
+def do_action_openstack_upgrade(package, upgrade_callback, configs,
+                                force_upgrade=False):
     """Perform action-managed OpenStack upgrade.
 
     Upgrades packages to the configured openstack-origin version and sets
@@ -1427,12 +1428,13 @@ def do_action_openstack_upgrade(package, upgrade_callback, configs):
     @param package: package name for determining if upgrade available
     @param upgrade_callback: function callback to charm's upgrade function
     @param configs: templating object derived from OSConfigRenderer class
+    @param force_upgrade: force the upgrade to be performed
 
     @return: True if upgrade successful; False if upgrade failed or skipped
     """
     ret = False
 
-    if openstack_upgrade_available(package):
+    if openstack_upgrade_available(package) or force_upgrade:
         if config('action-managed-upgrade'):
             juju_log('Upgrading OpenStack release')
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1841,6 +1841,19 @@ class OpenStackHelpersTestCase(TestCase):
         action_set.assert_called_with({'outcome': msg})
         self.assertFalse(action_fail.called)
 
+        # test force_upgrade
+        openstack_upgrade_available.return_value = False
+
+        openstack.do_action_openstack_upgrade('package-xyz',
+                                              do_openstack_upgrade,
+                                              None,
+                                              force_upgrade=True)
+
+        self.assertTrue(openstack_upgrade_available.called)
+        msg = ('success, upgrade completed.')
+        action_set.assert_called_with({'outcome': msg})
+        self.assertFalse(action_fail.called)
+
     @patch.object(openstack, 'juju_log')
     @patch.object(openstack, 'action_set')
     @patch.object(openstack, 'action_fail')


### PR DESCRIPTION
This flag allows upgrading to new package versions regardless of
whether there is a new release of OpenStack available. This can be
useful to dist-upgrade to a proposed pocket or PPA for testing, or
to upgrade packages to new stable versions.