### PR TITLE
Escape special chars in nrpe command arguments

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -174,7 +174,8 @@ define service {{
             if os.path.exists(os.path.join(path, parts[0])):
                 command = os.path.join(path, parts[0])
                 if len(parts) > 1:
-                    command += " " + " ".join(parts[1:])
+                    safe_args = [shlex.quote(arg) for arg in parts[1:]]
+                    command += " " + " ".join(safe_args)
                 return command
         log('Check command not found: {}'.format(parts[0]))
         return ''

--- a/tests/contrib/charmsupport/test_nrpe.py
+++ b/tests/contrib/charmsupport/test_nrpe.py
@@ -337,6 +337,21 @@ class NRPECheckTestCase(NRPEBaseTestCase):
         expected = 'Check command not found: check_http'
         self.assertEqual(expected, self.patched['log'].call_args[0][0])
 
+    def test_locate_cmd_argument_escape(self):
+        """Test that `_locate_cmd` properly escapes arguments.
+
+        If arguments contain symbols that have special meaning in shell, like
+        '*',';' or '`', they should be properly quoted to prevent unexpected
+        behavior.
+        """
+        self.patched['exists'].return_value = True
+        raw_cmd = "check_test -a * -b ; -c `/bin/bash` -d foo -e 1"
+        prefix = "/usr/lib/nagios/plugins/"
+        safe_cmd = "check_test -a '*' -b ';' -c '`/bin/bash`' -d foo -e 1"
+        check = nrpe.Check('shortname', 'description', raw_cmd)
+
+        self.assertEqual(check.check_cmd, prefix + safe_cmd)
+
     def test_run(self):
         self.patched['exists'].return_value = True
         command = '/usr/bin/wget foo'


### PR DESCRIPTION
Properly escaping arguments for NRPE checks will prevent possible command injection. It will also remove burden of properly escaping such characters on users part. This need to properly escape special characters is also often not apparent to the user. For example, when currently [configuring queue_thresholds](https://github.com/openstack/charm-rabbitmq-server/blob/bfcc4693b94e671f2287c140ce87190f30afec0b/config.yaml#L114) for rabbitmq-server, if user wants to use wildcards, they must be double-escaped like this:
```
juju config rabbitmq-server queue_threshold="[['\\*', '\\*', 100, 200]]"
```

If charmhelpers would automatically take care of escaping these characters when creating NRPE check commands, the above could be simplified to:
```
juju config rabbitmq-server queue_thresholds="[['*', '*', 100, 200]]"
```