### PR TITLE
 Add force_upgrade parm to openstack-upgrade action

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1414,7 +1414,7 @@ def incomplete_relation_data(configs, required_interfaces):
 
 
 def do_action_openstack_upgrade(package, upgrade_callback, configs,
-                                dist_upgrade=False):
+                                force_upgrade=False):
     """Perform action-managed OpenStack upgrade.
 
     Upgrades packages to the configured openstack-origin version and sets
@@ -1428,13 +1428,13 @@ def do_action_openstack_upgrade(package, upgrade_callback, configs,
     @param package: package name for determining if upgrade available
     @param upgrade_callback: function callback to charm's upgrade function
     @param configs: templating object derived from OSConfigRenderer class
-    @param dist_upgrade: perform dist-upgrade regardless of new openstack
+    @param force_upgrade: perform dist-upgrade regardless of new openstack
 
     @return: True if upgrade successful; False if upgrade failed or skipped
     """
     ret = False
 
-    if openstack_upgrade_available(package) or dist_upgrade:
+    if openstack_upgrade_available(package) or force_upgrade:
         if config('action-managed-upgrade'):
             juju_log('Upgrading OpenStack release')
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -1841,13 +1841,13 @@ class OpenStackHelpersTestCase(TestCase):
         action_set.assert_called_with({'outcome': msg})
         self.assertFalse(action_fail.called)
 
-        # test dist_upgrade
+        # test force_upgrade
         openstack_upgrade_available.return_value = False
 
         openstack.do_action_openstack_upgrade('package-xyz',
                                               do_openstack_upgrade,
                                               None,
-                                              dist_upgrade=True)
+                                              force_upgrade=True)
 
         self.assertTrue(openstack_upgrade_available.called)
         msg = ('success, upgrade completed.')


### PR DESCRIPTION
If force_upgrade is set to true, the upgrade will be performed
regardless of whether a new OpenStack release is available. This
can be useful for upgrading to the latest stable packages, or for
testing upgrades to a proposed pocket or PPA of the same release.