### PR TITLE
Remove py27 and pre py35 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 2.7
-            env: pep8,py27
-          - python-version: 3.4
-            env: pep8,py34
           - python-version: 3.5
             env: pep8,py35
           - python-version: 3.6

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,28 +7,19 @@ such as making real, unmocked calls out to sudo foo, juju binaries, and perhaps
 other things.  This is not ideal for a number of reasons.  One of those reasons
 is that it pollutes the test runner (your) system.
 
-The current recommendation for testing locally is to do so in a fresh Xenial
-(16.04) lxc container.  16.04 is selected for consistency with what is available
-in the Travis CI test gates.  As of this writing, 18.04 is not available there.
+The current recommendation for testing locally is to do so in a fresh bionic
+(18.04) lxc container.  This is because charmhelpers supports at least bionic
+and later Ubuntu distros.
 
-The fresh Xenial lxc system container will need to have the following packages
+The fresh Bionic lxc system container will need to have the following packages
 installed in order to satisfy test runner dependencies:
 
-    sudo apt install git bzr tox libapt-pkg-dev python-dev python3-dev build-essential juju -y
+    sudo apt install git bzr tox libapt-pkg-dev python3-dev build-essential juju -y
 
 The tests can be executed as follows:
 
     tox -e pep8
     tox -e py3
-    tox -e py2
-
-See also:  .travis.yaml for what is happening in the test gate.
-
-## Run testsuite (legacy Makefile method)
-
-    make test
-
-Run `make` without arguments for more options.
 
 ## Test it in a charm
 
@@ -66,9 +57,9 @@ charm, get the path of the installed charmhelpers by running following command.*
 Install html doc dependencies:
 
 ```bash
-sudo apt-get install python-flake8 python-shelltoolbox python-tempita \
-python-nose python-mock python-testtools python-jinja2 python-coverage \
-python-git python-netifaces python-netaddr python-pip zip
+sudo apt-get install python3-flake8 python3-shelltoolbox python3-tempita \
+python3-nose python3-mock python3-testtools python3-jinja2 python3-coverage \
+python3-git python3-netifaces python3-netaddr python3-pip zip
 ```
 
 To build the html documentation:
@@ -82,7 +73,7 @@ To browse the html documentation locally:
 ```bash
 make docs
 cd docs/_build/html
-python -m SimpleHTTPServer 8765
+python3 -m SimpleHTTPServer 8765
 # point web browser to http://localhost:8765
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT=charmhelpers
-PYTHON := /usr/bin/env python
+PYTHON := /usr/bin/env python3
 SUITE=unstable
 TESTS=tests/
 
@@ -21,29 +21,21 @@ deb: source
 
 source: setup.py
 	scripts/update-revno
-	python setup.py sdist
+	python3 setup.py sdist
 
 clean:
-	-python setup.py clean
+	-python3 setup.py clean
 	rm -rf build/ MANIFEST
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
 	rm -rf dist/*
-	rm -rf .venv
 	rm -rf .venv3
 	(which dh_clean && dh_clean) || true
 
 userinstall:
 	scripts/update-revno
-	python setup.py install --user
+	python3 setup.py install --user
 
-
-.venv:
-	dpkg-query -W -f='$${status}' gcc python-dev python-virtualenv 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python-dev python-virtualenv
-	virtualenv .venv --system-site-packages
-	.venv/bin/pip install -U pip
-	.venv/bin/pip install -I -r test-requirements.txt
-	.venv/bin/pip install bzr
 
 .venv3:
 	dpkg-query -W -f='$${status}' gcc python3-dev python-virtualenv python3-apt 2>/dev/null | grep --invert-match "not-installed" || sudo apt-get install -y python3-dev python-virtualenv python3-apt
@@ -52,12 +44,8 @@ userinstall:
 	.venv3/bin/pip install -I -r test-requirements.txt
 
 # Note we don't even attempt to run tests if lint isn't passing.
-test: lint test2 test3
+test: lint test3
 	@echo OK
-
-test2:
-	@echo Starting Py2 tests...
-	.venv/bin/nosetests -s --nologcapture tests/
 
 test3:
 	@echo Starting Py3 tests...
@@ -65,19 +53,16 @@ test3:
 
 ftest: lint
 	@echo Starting fast tests...
-	.venv/bin/nosetests --attr '!slow' --nologcapture tests/
 	.venv3/bin/nosetests --attr '!slow' --nologcapture tests/
 
-lint: .venv .venv3
+lint: .venv3
 	@echo Checking for Python syntax...
-	@.venv/bin/flake8 --ignore=E402,E501,W504 $(PROJECT) $(TESTS) tools/ \
-	    && echo Py2 OK
 	@.venv3/bin/flake8 --ignore=E402,E501,W504 $(PROJECT) $(TESTS) tools/ \
 	    && echo Py3 OK
 
 docs:
-	- [ -z "`dpkg -l | grep python-sphinx`" ] && sudo apt-get install python-sphinx -y
-	- [ -z "`dpkg -l | grep python-pip`" ] && sudo apt-get install python-pip -y
+	- [ -z "`dpkg -l | grep python3-sphinx`" ] && sudo apt-get install python-sphinx -y
+	- [ -z "`dpkg -l | grep python3-pip`" ] && sudo apt-get install python-pip -y
 	- [ -z "`pip list | grep -i sphinx-pypi-upload`" ] && sudo pip install sphinx-pypi-upload
 	- [ -z "`pip list | grep -i sphinx_rtd_theme`" ] && sudo pip install sphinx_rtd_theme
 	cd docs && make html && cd -

--- a/charmhelpers/__init__.py
+++ b/charmhelpers/__init__.py
@@ -20,24 +20,12 @@ from __future__ import absolute_import
 import functools
 import inspect
 import subprocess
-import sys
 
-try:
-    import six  # NOQA:F401
-except ImportError:
-    if sys.version_info.major == 2:
-        subprocess.check_call(['apt-get', 'install', '-y', 'python-six'])
-    else:
-        subprocess.check_call(['apt-get', 'install', '-y', 'python3-six'])
-    import six  # NOQA:F401
 
 try:
     import yaml  # NOQA:F401
 except ImportError:
-    if sys.version_info.major == 2:
-        subprocess.check_call(['apt-get', 'install', '-y', 'python-yaml'])
-    else:
-        subprocess.check_call(['apt-get', 'install', '-y', 'python3-yaml'])
+    subprocess.check_call(['apt-get', 'install', '-y', 'python3-yaml'])
     import yaml  # NOQA:F401
 
 

--- a/charmhelpers/cli/__init__.py
+++ b/charmhelpers/cli/__init__.py
@@ -16,9 +16,6 @@ import inspect
 import argparse
 import sys
 
-import six
-from six.moves import zip
-
 import charmhelpers.core.unitdata
 
 
@@ -149,10 +146,7 @@ class CommandLine(object):
     def run(self):
         "Run cli, processing arguments and executing subcommands."
         arguments = self.argument_parser.parse_args()
-        if six.PY2:
-            argspec = inspect.getargspec(arguments.func)
-        else:
-            argspec = inspect.getfullargspec(arguments.func)
+        argspec = inspect.getfullargspec(arguments.func)
         vargs = []
         for arg in argspec.args:
             vargs.append(getattr(arguments, arg))
@@ -177,10 +171,7 @@ def describe_arguments(func):
     Analyze a function's signature and return a data structure suitable for
     passing in as arguments to an argparse parser's add_argument() method."""
 
-    if six.PY2:
-        argspec = inspect.getargspec(func)
-    else:
-        argspec = inspect.getfullargspec(func)
+    argspec = inspect.getfullargspec(func)
     # we should probably raise an exception somewhere if func includes **kwargs
     if argspec.defaults:
         positional_args = argspec.args[:-len(argspec.defaults)]

--- a/charmhelpers/context.py
+++ b/charmhelpers/context.py
@@ -18,15 +18,9 @@ A Pythonic API to interact with the charm hook environment.
 :author: Stuart Bishop <stuart.bishop@canonical.com>
 '''
 
-import six
-
 from charmhelpers.core import hookenv
 
-from collections import OrderedDict
-if six.PY3:
-    from collections import UserDict  # pragma: nocover
-else:
-    from UserDict import IterableUserDict as UserDict  # pragma: nocover
+from collections import OrderedDict, UserDict
 
 
 class Relations(OrderedDict):
@@ -166,7 +160,7 @@ class RelationInfo(UserDict):
         if self.unit != hookenv.local_unit():
             raise TypeError('Attempting to set {} on remote unit {}'
                             ''.format(key, self.unit))
-        if value is not None and not isinstance(value, six.string_types):
+        if value is not None and not isinstance(value, str):
             # We don't do implicit casting. This would cause simple
             # types like integers to be read back as strings in subsequent
             # hooks, and mutable types would require a lot of wrapping
@@ -191,7 +185,7 @@ class Leader(UserDict):
     def __setitem__(self, key, value):
         if not hookenv.is_leader():
             raise TypeError('Not the leader. Cannot change leader settings.')
-        if value is not None and not isinstance(value, six.string_types):
+        if value is not None and not isinstance(value, str):
             # We don't do implicit casting. This would cause simple
             # types like integers to be read back as strings in subsequent
             # hooks, and mutable types would require a lot of wrapping

--- a/charmhelpers/contrib/charmhelpers/__init__.py
+++ b/charmhelpers/contrib/charmhelpers/__init__.py
@@ -21,12 +21,9 @@ import time
 import yaml
 import subprocess
 
-import six
-if six.PY3:
-    from urllib.request import urlopen
-    from urllib.error import (HTTPError, URLError)
-else:
-    from urllib2 import (urlopen, HTTPError, URLError)
+from urllib.request import urlopen
+from urllib.error import (HTTPError, URLError)
+
 
 """Helper functions for writing Juju charms in Python."""
 

--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -19,7 +19,6 @@ import sys
 import platform
 import os
 import glob
-import six
 
 # from string import upper
 
@@ -55,10 +54,7 @@ try:
     import MySQLdb
 except ImportError:
     apt_update(fatal=True)
-    if six.PY2:
-        apt_install(filter_installed_packages(['python-mysqldb']), fatal=True)
-    else:
-        apt_install(filter_installed_packages(['python3-mysqldb']), fatal=True)
+    apt_install(filter_installed_packages(['python3-mysqldb']), fatal=True)
     import MySQLdb
 
 

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -32,8 +32,6 @@ import time
 
 from socket import gethostname as get_unit_hostname
 
-import six
-
 from charmhelpers.core.hookenv import (
     log,
     relation_ids,
@@ -125,16 +123,16 @@ def is_crm_dc():
     """
     cmd = ['crm', 'status']
     try:
-        status = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        if not isinstance(status, six.text_type):
-            status = six.text_type(status, "utf-8")
+        status = subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT).decode('utf-8')
     except subprocess.CalledProcessError as ex:
         raise CRMDCNotFound(str(ex))
 
     current_dc = ''
     for line in status.split('\n'):
         if line.startswith('Current DC'):
-            # Current DC: juju-lytrusty-machine-2 (168108163) - partition with quorum
+            # Current DC: juju-lytrusty-machine-2 (168108163)
+            #  - partition with quorum
             current_dc = line.split(':')[1].split()[0]
     if current_dc == get_unit_hostname():
         return True
@@ -158,9 +156,8 @@ def is_crm_leader(resource, retry=False):
         return is_crm_dc()
     cmd = ['crm', 'resource', 'show', resource]
     try:
-        status = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        if not isinstance(status, six.text_type):
-            status = six.text_type(status, "utf-8")
+        status = subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT).decode('utf-8')
     except subprocess.CalledProcessError:
         status = None
 

--- a/charmhelpers/contrib/hardening/apache/checks/config.py
+++ b/charmhelpers/contrib/hardening/apache/checks/config.py
@@ -14,7 +14,6 @@
 
 import os
 import re
-import six
 import subprocess
 
 
@@ -95,9 +94,7 @@ class ApacheConfContext(object):
         settings = utils.get_settings('apache')
         ctxt = settings['hardening']
 
-        out = subprocess.check_output(['apache2', '-v'])
-        if six.PY3:
-            out = out.decode('utf-8')
+        out = subprocess.check_output(['apache2', '-v']).decode('utf-8')
         ctxt['apache_version'] = re.search(r'.+version: Apache/(.+?)\s.+',
                                            out).group(1)
         ctxt['apache_icondir'] = '/usr/share/apache2/icons/'

--- a/charmhelpers/contrib/hardening/audits/apache.py
+++ b/charmhelpers/contrib/hardening/audits/apache.py
@@ -15,8 +15,6 @@
 import re
 import subprocess
 
-import six
-
 from charmhelpers.core.hookenv import (
     log,
     INFO,
@@ -35,7 +33,7 @@ class DisabledModuleAudit(BaseAudit):
     def __init__(self, modules):
         if modules is None:
             self.modules = []
-        elif isinstance(modules, six.string_types):
+        elif isinstance(modules, str):
             self.modules = [modules]
         else:
             self.modules = modules
@@ -68,9 +66,7 @@ class DisabledModuleAudit(BaseAudit):
     @staticmethod
     def _get_loaded_modules():
         """Returns the modules which are enabled in Apache."""
-        output = subprocess.check_output(['apache2ctl', '-M'])
-        if six.PY3:
-            output = output.decode('utf-8')
+        output = subprocess.check_output(['apache2ctl', '-M']).decode('utf-8')
         modules = []
         for line in output.splitlines():
             # Each line of the enabled module output looks like:

--- a/charmhelpers/contrib/hardening/audits/apt.py
+++ b/charmhelpers/contrib/hardening/audits/apt.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import  # required for external apt import
-from six import string_types
 
 from charmhelpers.fetch import (
     apt_cache,
@@ -51,7 +50,7 @@ class RestrictedPackages(BaseAudit):
 
     def __init__(self, pkgs, **kwargs):
         super(RestrictedPackages, self).__init__(**kwargs)
-        if isinstance(pkgs, string_types) or not hasattr(pkgs, '__iter__'):
+        if isinstance(pkgs, str) or not hasattr(pkgs, '__iter__'):
             self.pkgs = pkgs.split()
         else:
             self.pkgs = pkgs

--- a/charmhelpers/contrib/hardening/audits/file.py
+++ b/charmhelpers/contrib/hardening/audits/file.py
@@ -23,7 +23,6 @@ from subprocess import (
     check_call,
 )
 from traceback import format_exc
-from six import string_types
 from stat import (
     S_ISGID,
     S_ISUID
@@ -63,7 +62,7 @@ class BaseFileAudit(BaseAudit):
         """
         super(BaseFileAudit, self).__init__(*args, **kwargs)
         self.always_comply = always_comply
-        if isinstance(paths, string_types) or not hasattr(paths, '__iter__'):
+        if isinstance(paths, str) or not hasattr(paths, '__iter__'):
             self.paths = [paths]
         else:
             self.paths = paths

--- a/charmhelpers/contrib/hardening/harden.py
+++ b/charmhelpers/contrib/hardening/harden.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
-
 from collections import OrderedDict
 
 from charmhelpers.core.hookenv import (
@@ -53,18 +51,17 @@ def harden(overrides=None):
         overrides = []
 
     def _harden_inner1(f):
-        # As this has to be py2.7 compat, we can't use nonlocal.  Use a trick
-        # to capture the dictionary that can then be updated.
-        _logged = {'done': False}
+        _logged = False
 
         def _harden_inner2(*args, **kwargs):
             # knock out hardening via a config var; normally it won't get
             # disabled.
+            nonlocal _logged
             if _DISABLE_HARDENING_FOR_UNIT_TEST:
                 return f(*args, **kwargs)
-            if not _logged['done']:
+            if not _logged:
                 log("Hardening function '%s'" % (f.__name__), level=DEBUG)
-                _logged['done'] = True
+                _logged = True
             RUN_CATALOG = OrderedDict([('os', run_os_checks),
                                        ('ssh', run_ssh_checks),
                                        ('mysql', run_mysql_checks),
@@ -74,7 +71,7 @@ def harden(overrides=None):
             if enabled:
                 modules_to_run = []
                 # modules will always be performed in the following order
-                for module, func in six.iteritems(RUN_CATALOG):
+                for module, func in RUN_CATALOG.items():
                     if module in enabled:
                         enabled.remove(module)
                         modules_to_run.append(func)

--- a/charmhelpers/contrib/hardening/host/checks/login.py
+++ b/charmhelpers/contrib/hardening/host/checks/login.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from six import string_types
-
 from charmhelpers.contrib.hardening.audits.file import TemplatedFile
 from charmhelpers.contrib.hardening.host import TEMPLATES_DIR
 from charmhelpers.contrib.hardening import utils
@@ -41,7 +39,7 @@ class LoginContext(object):
         # a string assume it to be octal and turn it into an octal
         # string.
         umask = settings['environment']['umask']
-        if not isinstance(umask, string_types):
+        if not isinstance(umask, str):
             umask = '%s' % oct(umask)
 
         ctxt = {

--- a/charmhelpers/contrib/hardening/host/checks/sysctl.py
+++ b/charmhelpers/contrib/hardening/host/checks/sysctl.py
@@ -15,7 +15,6 @@
 import os
 import platform
 import re
-import six
 import subprocess
 
 from charmhelpers.core.hookenv import (
@@ -183,9 +182,9 @@ class SysCtlHardeningContext(object):
 
             ctxt['sysctl'][key] = d[2] or None
 
-        # Translate for python3
-        return {'sysctl_settings':
-                [(k, v) for k, v in six.iteritems(ctxt['sysctl'])]}
+        return {
+            'sysctl_settings': [(k, v) for k, v in ctxt['sysctl'].items()]
+        }
 
 
 class SysctlConf(TemplatedFile):

--- a/charmhelpers/contrib/hardening/mysql/checks/config.py
+++ b/charmhelpers/contrib/hardening/mysql/checks/config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import subprocess
 
 from charmhelpers.core.hookenv import (
@@ -82,6 +81,6 @@ class MySQLConfContext(object):
     """
     def __call__(self):
         settings = utils.get_settings('mysql')
-        # Translate for python3
-        return {'mysql_settings':
-                [(k, v) for k, v in six.iteritems(settings['security'])]}
+        return {
+            'mysql_settings': [(k, v) for k, v in settings['security'].items()]
+        }

--- a/charmhelpers/contrib/hardening/templating.py
+++ b/charmhelpers/contrib/hardening/templating.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import six
 
 from charmhelpers.core.hookenv import (
     log,
@@ -27,10 +26,7 @@ except ImportError:
     from charmhelpers.fetch import apt_install
     from charmhelpers.fetch import apt_update
     apt_update(fatal=True)
-    if six.PY2:
-        apt_install('python-jinja2', fatal=True)
-    else:
-        apt_install('python3-jinja2', fatal=True)
+    apt_install('python3-jinja2', fatal=True)
     from jinja2 import FileSystemLoader, Environment
 
 

--- a/charmhelpers/contrib/hardening/utils.py
+++ b/charmhelpers/contrib/hardening/utils.py
@@ -16,7 +16,6 @@ import glob
 import grp
 import os
 import pwd
-import six
 import yaml
 
 from charmhelpers.core.hookenv import (
@@ -91,7 +90,7 @@ def _apply_overrides(settings, overrides, schema):
     :returns: dictionary of modules config with user overrides applied.
     """
     if overrides:
-        for k, v in six.iteritems(overrides):
+        for k, v in overrides.items():
             if k in schema:
                 if schema[k] is None:
                     settings[k] = v

--- a/charmhelpers/contrib/mellanox/infiniband.py
+++ b/charmhelpers/contrib/mellanox/infiniband.py
@@ -17,8 +17,6 @@
 
 __author__ = "Jorge Niedbalski <jorge.niedbalski@canonical.com>"
 
-import six
-
 from charmhelpers.fetch import (
     apt_install,
     apt_update,
@@ -32,10 +30,7 @@ from charmhelpers.core.hookenv import (
 try:
     from netifaces import interfaces as network_interfaces
 except ImportError:
-    if six.PY2:
-        apt_install('python-netifaces')
-    else:
-        apt_install('python3-netifaces')
+    apt_install('python3-netifaces')
     from netifaces import interfaces as network_interfaces
 
 import os

--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -15,7 +15,6 @@
 import glob
 import re
 import subprocess
-import six
 import socket
 
 from functools import partial
@@ -39,20 +38,14 @@ try:
     import netifaces
 except ImportError:
     apt_update(fatal=True)
-    if six.PY2:
-        apt_install('python-netifaces', fatal=True)
-    else:
-        apt_install('python3-netifaces', fatal=True)
+    apt_install('python3-netifaces', fatal=True)
     import netifaces
 
 try:
     import netaddr
 except ImportError:
     apt_update(fatal=True)
-    if six.PY2:
-        apt_install('python-netaddr', fatal=True)
-    else:
-        apt_install('python3-netaddr', fatal=True)
+    apt_install('python3-netaddr', fatal=True)
     import netaddr
 
 
@@ -462,15 +455,12 @@ def ns_query(address):
     try:
         import dns.resolver
     except ImportError:
-        if six.PY2:
-            apt_install('python-dnspython', fatal=True)
-        else:
-            apt_install('python3-dnspython', fatal=True)
+        apt_install('python3-dnspython', fatal=True)
         import dns.resolver
 
     if isinstance(address, dns.name.Name):
         rtype = 'PTR'
-    elif isinstance(address, six.string_types):
+    elif isinstance(address, str):
         rtype = 'A'
     else:
         return None
@@ -513,10 +503,7 @@ def get_hostname(address, fqdn=True):
         try:
             import dns.reversename
         except ImportError:
-            if six.PY2:
-                apt_install("python-dnspython", fatal=True)
-            else:
-                apt_install("python3-dnspython", fatal=True)
+            apt_install("python3-dnspython", fatal=True)
             import dns.reversename
 
         rev = dns.reversename.from_address(address)

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -17,7 +17,6 @@ import collections
 import hashlib
 import os
 import re
-import six
 import subprocess
 
 from charmhelpers import deprecate
@@ -367,10 +366,7 @@ def add_ovsbridge_linuxbridge(name, bridge, ifdata=None, portdata=None):
     try:
         import netifaces
     except ImportError:
-        if six.PY2:
-            apt_install('python-netifaces', fatal=True)
-        else:
-            apt_install('python3-netifaces', fatal=True)
+        apt_install('python3-netifaces', fatal=True)
         import netifaces
 
     # NOTE(jamespage):

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -30,8 +30,6 @@ from subprocess import (
     check_output,
     CalledProcessError)
 
-import six
-
 import charmhelpers.contrib.storage.linux.ceph as ch_ceph
 
 from charmhelpers.contrib.openstack.audits.openstack_security_guide import (
@@ -130,10 +128,7 @@ except ImportError:
 try:
     import psutil
 except ImportError:
-    if six.PY2:
-        apt_install('python-psutil', fatal=True)
-    else:
-        apt_install('python3-psutil', fatal=True)
+    apt_install('python3-psutil', fatal=True)
     import psutil
 
 CA_CERT_PATH = '/usr/local/share/ca-certificates/keystone_juju_ca_cert.crt'
@@ -150,10 +145,7 @@ def ensure_packages(packages):
 
 
 def context_complete(ctxt):
-    _missing = []
-    for k, v in six.iteritems(ctxt):
-        if v is None or v == '':
-            _missing.append(k)
+    _missing = [k for k, v in ctxt.items() if v is None or v == '']
 
     if _missing:
         log('Missing required data: %s' % ' '.join(_missing), level=INFO)
@@ -180,7 +172,7 @@ class OSContextGenerator(object):
         # Fresh start
         self.complete = False
         self.missing_data = []
-        for k, v in six.iteritems(ctxt):
+        for k, v in ctxt.items():
             if v is None or v == '':
                 if k not in self.missing_data:
                     self.missing_data.append(k)
@@ -1118,7 +1110,7 @@ class ApacheSSLContext(OSContextGenerator):
         return sorted_addresses
 
     def __call__(self):
-        if isinstance(self.external_ports, six.string_types):
+        if isinstance(self.external_ports, str):
             self.external_ports = [self.external_ports]
 
         if not self.external_ports or not https():
@@ -1535,9 +1527,9 @@ class SubordinateConfigContext(OSContextGenerator):
                             continue
 
                         sub_config = sub_config[self.config_file]
-                        for k, v in six.iteritems(sub_config):
+                        for k, v in sub_config.items():
                             if k == 'sections':
-                                for section, config_list in six.iteritems(v):
+                                for section, config_list in v.items():
                                     log("adding section '%s'" % (section),
                                         level=DEBUG)
                                     if ctxt[k].get(section):
@@ -1891,8 +1883,11 @@ class DataPortContext(NeutronPortContext):
             normalized.update({port: port for port in resolved
                                if port in ports})
             if resolved:
-                return {normalized[port]: bridge for port, bridge in
-                        six.iteritems(portmap) if port in normalized.keys()}
+                return {
+                    normalized[port]: bridge
+                    for port, bridge in portmap.items()
+                    if port in normalized.keys()
+                }
 
         return None
 
@@ -2295,15 +2290,10 @@ class HostInfoContext(OSContextGenerator):
         name = name or socket.gethostname()
         fqdn = ''
 
-        if six.PY2:
-            exc = socket.error
-        else:
-            exc = OSError
-
         try:
             addrs = socket.getaddrinfo(
                 name, None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME)
-        except exc:
+        except OSError:
             pass
         else:
             for addr in addrs:
@@ -2420,12 +2410,12 @@ class DHCPAgentContext(OSContextGenerator):
         existing_ovs_use_veth = None
         # If there is a dhcp_agent.ini file read the current setting
         if os.path.isfile(DHCP_AGENT_INI):
-            # config_ini does the right thing and returns None if the setting is
-            # commented.
+            # config_ini does the right thing and returns None if the setting
+            # is commented.
             existing_ovs_use_veth = (
                 config_ini(DHCP_AGENT_INI)["DEFAULT"].get("ovs_use_veth"))
         # Convert to Bool if necessary
-        if isinstance(existing_ovs_use_veth, six.string_types):
+        if isinstance(existing_ovs_use_veth, str):
             return bool_from_string(existing_ovs_use_veth)
         return existing_ovs_use_veth
 

--- a/charmhelpers/contrib/openstack/keystone.py
+++ b/charmhelpers/contrib/openstack/keystone.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 #
 # Copyright 2017 Canonical Ltd
 #
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 from charmhelpers.fetch import apt_install
 from charmhelpers.contrib.openstack.context import IdentityServiceContext
 from charmhelpers.core.hookenv import (
@@ -117,10 +115,7 @@ class KeystoneManager2(KeystoneManager):
             from keystoneclient.auth.identity import v2
             from keystoneclient import session
         except ImportError:
-            if six.PY2:
-                apt_install(["python-keystoneclient"], fatal=True)
-            else:
-                apt_install(["python3-keystoneclient"], fatal=True)
+            apt_install(["python3-keystoneclient"], fatal=True)
 
             from keystoneclient.v2_0 import client
             from keystoneclient.auth.identity import v2
@@ -151,10 +146,7 @@ class KeystoneManager3(KeystoneManager):
             from keystoneclient import session
             from keystoneclient.auth.identity import v3
         except ImportError:
-            if six.PY2:
-                apt_install(["python-keystoneclient"], fatal=True)
-            else:
-                apt_install(["python3-keystoneclient"], fatal=True)
+            apt_install(["python3-keystoneclient"], fatal=True)
 
             from keystoneclient.v3 import client
             from keystoneclient.auth import token_endpoint

--- a/charmhelpers/contrib/openstack/neutron.py
+++ b/charmhelpers/contrib/openstack/neutron.py
@@ -14,7 +14,6 @@
 
 # Various utilities for dealing with Neutron and the renaming from Quantum.
 
-import six
 from subprocess import check_output
 
 from charmhelpers.core.hookenv import (
@@ -349,11 +348,4 @@ def parse_vlan_range_mappings(mappings):
     Returns dict of the form {provider: (start, end)}.
     """
     _mappings = parse_mappings(mappings)
-    if not _mappings:
-        return {}
-
-    mappings = {}
-    for p, r in six.iteritems(_mappings):
-        mappings[p] = tuple(r.split(':'))
-
-    return mappings
+    return {p: tuple(r.split(':')) for p, r in _mappings.items()}

--- a/charmhelpers/contrib/openstack/policyd.py
+++ b/charmhelpers/contrib/openstack/policyd.py
@@ -15,7 +15,6 @@
 import collections
 import contextlib
 import os
-import six
 import shutil
 import yaml
 import zipfile
@@ -202,12 +201,6 @@ class BadPolicyYamlFile(Exception):
 
     def __str__(self):
         return self.log_message
-
-
-if six.PY2:
-    BadZipFile = zipfile.BadZipfile
-else:
-    BadZipFile = zipfile.BadZipFile
 
 
 def is_policyd_override_valid_on_this_release(openstack_release):
@@ -487,10 +480,10 @@ def read_and_validate_yaml(stream_or_doc, blacklist_keys=None):
     if blacklisted_keys_present:
         raise BadPolicyYamlFile("blacklisted keys {} present."
                                 .format(", ".join(blacklisted_keys_present)))
-    if not all(isinstance(k, six.string_types) for k in keys):
+    if not all(isinstance(k, str) for k in keys):
         raise BadPolicyYamlFile("keys in yaml aren't all strings?")
     # check that the dictionary looks like a mapping of str to str
-    if not all(isinstance(v, six.string_types) for v in doc.values()):
+    if not all(isinstance(v, str) for v in doc.values()):
         raise BadPolicyYamlFile("values in yaml aren't all strings?")
     return doc
 
@@ -530,8 +523,7 @@ def clean_policyd_dir_for(service, keep_paths=None, user=None, group=None):
     hookenv.log("Cleaning path: {}".format(path), level=hookenv.DEBUG)
     if not os.path.exists(path):
         ch_host.mkdir(path, owner=_user, group=_group, perms=0o775)
-    _scanner = os.scandir if hasattr(os, 'scandir') else _fallback_scandir
-    for direntry in _scanner(path):
+    for direntry in os.scandir(path):
         # see if the path should be kept.
         if direntry.path in keep_paths:
             continue
@@ -556,36 +548,6 @@ def maybe_create_directory_for(path, user, group):
     _dir, _ = os.path.split(path)
     if not os.path.exists(_dir):
         ch_host.mkdir(_dir, owner=user, group=group, perms=0o775)
-
-
-@contextlib.contextmanager
-def _fallback_scandir(path):
-    """Fallback os.scandir implementation.
-
-    provide a fallback implementation of os.scandir if this module ever gets
-    used in a py2 or py34 charm. Uses os.listdir() to get the names in the path,
-    and then mocks the is_dir() function using os.path.isdir() to check for
-    directory.
-
-    :param path: the path to list the directories for
-    :type path: str
-    :returns: Generator that provides _FBDirectory objects
-    :rtype: ContextManager[_FBDirectory]
-    """
-    for f in os.listdir(path):
-        yield _FBDirectory(f)
-
-
-class _FBDirectory(object):
-    """Mock a scandir Directory object with enough to use in
-    clean_policyd_dir_for
-    """
-
-    def __init__(self, path):
-        self.path = path
-
-    def is_dir(self):
-        return os.path.isdir(self.path)
 
 
 def path_for_policy_file(service, name):
@@ -768,7 +730,7 @@ def process_policy_resource_file(resource_file,
                                    _group)
         # Every thing worked, so we mark up a success.
         completed = True
-    except (BadZipFile, BadPolicyZipFile, BadPolicyYamlFile) as e:
+    except (zipfile.BadZipFile, BadPolicyZipFile, BadPolicyYamlFile) as e:
         hookenv.log("Processing {} failed: {}".format(resource_file, str(e)),
                     level=POLICYD_LOG_LEVEL_DEFAULT)
     except IOError as e:

--- a/charmhelpers/contrib/openstack/templating.py
+++ b/charmhelpers/contrib/openstack/templating.py
@@ -14,8 +14,6 @@
 
 import os
 
-import six
-
 from charmhelpers.fetch import apt_install, apt_update
 from charmhelpers.core.hookenv import (
     log,
@@ -29,10 +27,7 @@ try:
     from jinja2 import FileSystemLoader, ChoiceLoader, Environment, exceptions
 except ImportError:
     apt_update(fatal=True)
-    if six.PY2:
-        apt_install('python-jinja2', fatal=True)
-    else:
-        apt_install('python3-jinja2', fatal=True)
+    apt_install('python3-jinja2', fatal=True)
     from jinja2 import FileSystemLoader, ChoiceLoader, Environment, exceptions
 
 
@@ -62,7 +57,7 @@ def get_loader(templates_dir, os_release):
         order by OpenStack release.
     """
     tmpl_dirs = [(rel, os.path.join(templates_dir, rel))
-                 for rel in six.itervalues(OPENSTACK_CODENAMES)]
+                 for rel in OPENSTACK_CODENAMES.values()]
 
     if not os.path.isdir(templates_dir):
         log('Templates directory not found @ %s.' % templates_dir,
@@ -225,10 +220,7 @@ class OSConfigRenderer(object):
             # if this code is running, the object is created pre-install hook.
             # jinja2 shouldn't get touched until the module is reloaded on next
             # hook execution, with proper jinja2 bits successfully imported.
-            if six.PY2:
-                apt_install('python-jinja2')
-            else:
-                apt_install('python3-jinja2')
+            apt_install('python3-jinja2')
 
     def register(self, config_file, contexts, config_template=None):
         """
@@ -318,9 +310,7 @@ class OSConfigRenderer(object):
             log('Config not registered: %s' % config_file, level=ERROR)
             raise OSConfigException
 
-        _out = self.render(config_file)
-        if six.PY3:
-            _out = _out.encode('UTF-8')
+        _out = self.render(config_file).encode('UTF-8')
 
         with open(config_file, 'wb') as out:
             out.write(_out)
@@ -331,7 +321,8 @@ class OSConfigRenderer(object):
         """
         Write out all registered config files.
         """
-        [self.write(k) for k in six.iterkeys(self.templates)]
+        for k in self.templates.keys():
+            self.write(k)
 
     def set_release(self, openstack_release):
         """
@@ -347,8 +338,8 @@ class OSConfigRenderer(object):
         Returns a list of context interfaces that yield a complete context.
         '''
         interfaces = []
-        [interfaces.extend(i.complete_contexts())
-         for i in six.itervalues(self.templates)]
+        for i in self.templates.values():
+            interfaces.extend(i.complete_contexts())
         return interfaces
 
     def get_incomplete_context_data(self, interfaces):
@@ -360,7 +351,7 @@ class OSConfigRenderer(object):
         '''
         incomplete_context_data = {}
 
-        for i in six.itervalues(self.templates):
+        for i in self.templates.values():
             for context in i.contexts:
                 for interface in interfaces:
                     related = False

--- a/charmhelpers/contrib/peerstorage/__init__.py
+++ b/charmhelpers/contrib/peerstorage/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import six
 
 from charmhelpers.core.hookenv import relation_id as current_relation_id
 from charmhelpers.core.hookenv import (
@@ -229,7 +228,7 @@ def peer_echo(includes=None, force=False):
             if ex in echo_data:
                 echo_data.pop(ex)
     else:
-        for attribute, value in six.iteritems(rdata):
+        for attribute, value in rdata.items():
             for include in includes:
                 if include in attribute:
                     echo_data[attribute] = value
@@ -255,8 +254,8 @@ def peer_store_and_set(relation_id=None, peer_relation_name='cluster',
                  relation_settings=relation_settings,
                  **kwargs)
     if is_relation_made(peer_relation_name):
-        for key, value in six.iteritems(dict(list(kwargs.items()) +
-                                             list(relation_settings.items()))):
+        items = dict(list(kwargs.items()) + list(relation_settings.items()))
+        for key, value in items.items():
             key_prefix = relation_id or current_relation_id()
             peer_store(key_prefix + delimiter + key,
                        value,

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -23,7 +23,6 @@ import collections
 import errno
 import hashlib
 import math
-import six
 
 import os
 import shutil
@@ -218,7 +217,7 @@ def validator(value, valid_type, valid_range=None):
                 "was given {} of type {}"
                 .format(valid_range, type(valid_range)))
         # If we're dealing with strings
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             assert value in valid_range, (
                 "{} is not in the list {}".format(value, valid_range))
         # Integer, float should have a min and max
@@ -434,9 +433,9 @@ class BasePool(object):
         :type mode: str
         """
         # Check the input types and values
-        validator(value=cache_pool, valid_type=six.string_types)
+        validator(value=cache_pool, valid_type=str)
         validator(
-            value=mode, valid_type=six.string_types,
+            value=mode, valid_type=str,
             valid_range=["readonly", "writeback"])
 
         check_call([
@@ -779,9 +778,7 @@ def enabled_manager_modules():
     """
     cmd = ['ceph', 'mgr', 'module', 'ls']
     try:
-        modules = check_output(cmd)
-        if six.PY3:
-            modules = modules.decode('UTF-8')
+        modules = check_output(cmd).decode('utf-8')
     except CalledProcessError as e:
         log("Failed to list ceph modules: {}".format(e), WARNING)
         return []
@@ -816,10 +813,8 @@ def get_mon_map(service):
     try:
         octopus_or_later = cmp_pkgrevno('ceph-common', '15.0.0') >= 0
         mon_status_cmd = 'quorum_status' if octopus_or_later else 'mon_status'
-        mon_status = check_output(['ceph', '--id', service,
-                                   mon_status_cmd, '--format=json'])
-        if six.PY3:
-            mon_status = mon_status.decode('UTF-8')
+        mon_status = (check_output(['ceph', '--id', service, mon_status_cmd,
+                                   '--format=json'])).decode('utf-8')
         try:
             return json.loads(mon_status)
         except ValueError as v:
@@ -961,9 +956,7 @@ def get_erasure_profile(service, name):
     try:
         out = check_output(['ceph', '--id', service,
                             'osd', 'erasure-code-profile', 'get',
-                            name, '--format=json'])
-        if six.PY3:
-            out = out.decode('UTF-8')
+                            name, '--format=json']).decode('utf-8')
         return json.loads(out)
     except (CalledProcessError, OSError, ValueError):
         return None
@@ -1166,8 +1159,7 @@ def create_erasure_profile(service, profile_name,
         'nvme'
     ]
 
-    validator(erasure_plugin_name, six.string_types,
-              list(plugin_techniques.keys()))
+    validator(erasure_plugin_name, str, list(plugin_techniques.keys()))
 
     cmd = [
         'ceph', '--id', service,
@@ -1178,7 +1170,7 @@ def create_erasure_profile(service, profile_name,
     ]
 
     if erasure_plugin_technique:
-        validator(erasure_plugin_technique, six.string_types,
+        validator(erasure_plugin_technique, str,
                   plugin_techniques[erasure_plugin_name])
         cmd.append('technique={}'.format(erasure_plugin_technique))
 
@@ -1191,7 +1183,7 @@ def create_erasure_profile(service, profile_name,
         failure_domain = 'rack'
 
     if failure_domain:
-        validator(failure_domain, six.string_types, failure_domains)
+        validator(failure_domain, str, failure_domains)
         # failure_domain changed in luminous
         if luminous_or_later:
             cmd.append('crush-failure-domain={}'.format(failure_domain))
@@ -1200,7 +1192,7 @@ def create_erasure_profile(service, profile_name,
 
     # device class new in luminous
     if luminous_or_later and device_class:
-        validator(device_class, six.string_types, device_classes)
+        validator(device_class, str, device_classes)
         cmd.append('crush-device-class={}'.format(device_class))
     else:
         log('Skipping device class configuration (ceph < 12.0.0)',
@@ -1215,7 +1207,7 @@ def create_erasure_profile(service, profile_name,
             raise ValueError("locality must be provided for lrc plugin")
         # LRC optional configuration
         if crush_locality:
-            validator(crush_locality, six.string_types, failure_domains)
+            validator(crush_locality, str, failure_domains)
             cmd.append('crush-locality={}'.format(crush_locality))
 
     if erasure_plugin_name == 'shec':
@@ -1243,8 +1235,8 @@ def rename_pool(service, old_name, new_name):
     :param new_name: Name to rename pool to.
     :type new_name: str
     """
-    validator(value=old_name, valid_type=six.string_types)
-    validator(value=new_name, valid_type=six.string_types)
+    validator(value=old_name, valid_type=str)
+    validator(value=new_name, valid_type=str)
 
     cmd = [
         'ceph', '--id', service,
@@ -1262,7 +1254,7 @@ def erasure_profile_exists(service, name):
     :returns: True if it exists, False otherwise.
     :rtype: bool
     """
-    validator(value=name, valid_type=six.string_types)
+    validator(value=name, valid_type=str)
     try:
         check_call(['ceph', '--id', service,
                     'osd', 'erasure-code-profile', 'get',
@@ -1282,12 +1274,10 @@ def get_cache_mode(service, pool_name):
     :returns: Current cache mode.
     :rtype: Optional[int]
     """
-    validator(value=service, valid_type=six.string_types)
-    validator(value=pool_name, valid_type=six.string_types)
+    validator(value=service, valid_type=str)
+    validator(value=pool_name, valid_type=str)
     out = check_output(['ceph', '--id', service,
-                        'osd', 'dump', '--format=json'])
-    if six.PY3:
-        out = out.decode('UTF-8')
+                        'osd', 'dump', '--format=json']).decode('utf-8')
     try:
         osd_json = json.loads(out)
         for pool in osd_json['pools']:
@@ -1301,9 +1291,8 @@ def get_cache_mode(service, pool_name):
 def pool_exists(service, name):
     """Check to see if a RADOS pool already exists."""
     try:
-        out = check_output(['rados', '--id', service, 'lspools'])
-        if six.PY3:
-            out = out.decode('UTF-8')
+        out = check_output(
+            ['rados', '--id', service, 'lspools']).decode('utf-8')
     except CalledProcessError:
         return False
 
@@ -1322,13 +1311,11 @@ def get_osds(service, device_class=None):
         out = check_output(['ceph', '--id', service,
                             'osd', 'crush', 'class',
                             'ls-osd', device_class,
-                            '--format=json'])
+                            '--format=json']).decode('utf-8')
     else:
         out = check_output(['ceph', '--id', service,
                             'osd', 'ls',
-                            '--format=json'])
-    if six.PY3:
-        out = out.decode('UTF-8')
+                            '--format=json']).decode('utf-8')
     return json.loads(out)
 
 
@@ -1345,9 +1332,7 @@ def rbd_exists(service, pool, rbd_img):
     """Check to see if a RADOS block device exists."""
     try:
         out = check_output(['rbd', 'list', '--id',
-                            service, '--pool', pool])
-        if six.PY3:
-            out = out.decode('UTF-8')
+                            service, '--pool', pool]).decode('utf-8')
     except CalledProcessError:
         return False
 
@@ -1373,7 +1358,7 @@ def update_pool(client, pool, settings):
     :raises: CalledProcessError
     """
     cmd = ['ceph', '--id', client, 'osd', 'pool', 'set', pool]
-    for k, v in six.iteritems(settings):
+    for k, v in settings.items():
         check_call(cmd + [k, v])
 
 
@@ -1511,9 +1496,7 @@ def configure(service, key, auth, use_syslog):
 def image_mapped(name):
     """Determine whether a RADOS block device is mapped locally."""
     try:
-        out = check_output(['rbd', 'showmapped'])
-        if six.PY3:
-            out = out.decode('UTF-8')
+        out = check_output(['rbd', 'showmapped']).decode('utf-8')
     except CalledProcessError:
         return False
 

--- a/charmhelpers/contrib/storage/linux/loopback.py
+++ b/charmhelpers/contrib/storage/linux/loopback.py
@@ -19,8 +19,6 @@ from subprocess import (
     check_output,
 )
 
-import six
-
 
 ##################################################
 # loopback device helpers.
@@ -40,9 +38,7 @@ def loopback_devices():
     '''
     loopbacks = {}
     cmd = ['losetup', '-a']
-    output = check_output(cmd)
-    if six.PY3:
-        output = output.decode('utf-8')
+    output = check_output(cmd).decode('utf-8')
     devs = [d.strip().split(' ', 2) for d in output.splitlines() if d != '']
     for dev, _, f in devs:
         loopbacks[dev.replace(':', '')] = re.search(r'\((.+)\)', f).groups()[0]
@@ -57,7 +53,7 @@ def create_loopback(file_path):
     '''
     file_path = os.path.abspath(file_path)
     check_call(['losetup', '--find', file_path])
-    for d, f in six.iteritems(loopback_devices()):
+    for d, f in loopback_devices().items():
         if f == file_path:
             return d
 
@@ -71,7 +67,7 @@ def ensure_loopback_device(path, size):
 
     :returns: str: Full path to the ensured loopback device (eg, /dev/loop0)
     '''
-    for d, f in six.iteritems(loopback_devices()):
+    for d, f in loopback_devices().items():
         if f == path:
             return d
 

--- a/charmhelpers/contrib/templating/contexts.py
+++ b/charmhelpers/contrib/templating/contexts.py
@@ -20,8 +20,6 @@
 import os
 import yaml
 
-import six
-
 import charmhelpers.core.hookenv
 
 
@@ -93,7 +91,8 @@ def juju_state_to_yaml(yaml_path, namespace_separator=':',
     By default, hyphens are allowed in keys as this is supported
     by yaml, but for tools like ansible, hyphens are not valid [1].
 
-    [1] http://www.ansibleworks.com/docs/playbooks_variables.html#what-makes-a-valid-variable-name
+    [1] http://www.ansibleworks.com/docs/playbooks_variables.html
+            #what-makes-a-valid-variable-name
     """
     config = charmhelpers.core.hookenv.config()
 
@@ -101,16 +100,17 @@ def juju_state_to_yaml(yaml_path, namespace_separator=':',
     # file resources etc.
     config['charm_dir'] = charm_dir
     config['local_unit'] = charmhelpers.core.hookenv.local_unit()
-    config['unit_private_address'] = charmhelpers.core.hookenv.unit_private_ip()
+    config['unit_private_address'] = (
+        charmhelpers.core.hookenv.unit_private_ip())
     config['unit_public_address'] = charmhelpers.core.hookenv.unit_get(
         'public-address'
     )
 
     # Don't use non-standard tags for unicode which will not
     # work when salt uses yaml.load_safe.
-    yaml.add_representer(six.text_type,
+    yaml.add_representer(str,
                          lambda dumper, value: dumper.represent_scalar(
-                             six.u('tag:yaml.org,2002:str'), value))
+                             'tag:yaml.org,2002:str', value))
 
     yaml_dir = os.path.dirname(yaml_path)
     if not os.path.exists(yaml_dir):

--- a/charmhelpers/contrib/templating/jinja.py
+++ b/charmhelpers/contrib/templating/jinja.py
@@ -13,18 +13,14 @@
 # limitations under the License.
 
 """
-Templating using the python-jinja2 package.
+Templating using the python3-jinja2 package.
 """
-import six
 from charmhelpers.fetch import apt_install, apt_update
 try:
     import jinja2
 except ImportError:
     apt_update(fatal=True)
-    if six.PY3:
-        apt_install(["python3-jinja2"], fatal=True)
-    else:
-        apt_install(["python-jinja2"], fatal=True)
+    apt_install(["python3-jinja2"], fatal=True)
     import jinja2
 
 

--- a/charmhelpers/coordinator.py
+++ b/charmhelpers/coordinator.py
@@ -226,8 +226,6 @@ from functools import wraps
 import json
 import os.path
 
-from six import with_metaclass
-
 from charmhelpers.core import hookenv
 
 
@@ -244,7 +242,8 @@ class Singleton(type):
         return cls._instances[cls]
 
 
-class BaseCoordinator(with_metaclass(Singleton, object)):
+# class BaseCoordinator(with_metaclass(Singleton, object)):
+class BaseCoordinator(metaclass=Singleton):
     relid = None  # Peer relation-id, set by __init__
     relname = None
 

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -31,7 +31,6 @@ import subprocess
 import hashlib
 import functools
 import itertools
-import six
 
 from contextlib import contextmanager
 from collections import OrderedDict, defaultdict
@@ -263,7 +262,7 @@ def service(action, service_name, **kwargs):
         cmd = ['systemctl', action, service_name]
     else:
         cmd = ['service', service_name, action]
-        for key, value in six.iteritems(kwargs):
+        for key, value in kwargs.items():
             parameter = '%s=%s' % (key, value)
             cmd.append(parameter)
     return subprocess.call(cmd) == 0
@@ -289,7 +288,7 @@ def service_running(service_name, **kwargs):
         if os.path.exists(_UPSTART_CONF.format(service_name)):
             try:
                 cmd = ['status', service_name]
-                for key, value in six.iteritems(kwargs):
+                for key, value in kwargs.items():
                     parameter = '%s=%s' % (key, value)
                     cmd.append(parameter)
                 output = subprocess.check_output(
@@ -564,7 +563,7 @@ def write_file(path, content, owner='root', group='root', perms=0o444):
         with open(path, 'wb') as target:
             os.fchown(target.fileno(), uid, gid)
             os.fchmod(target.fileno(), perms)
-            if six.PY3 and isinstance(content, six.string_types):
+            if isinstance(content, str):
                 content = content.encode('UTF-8')
             target.write(content)
         return
@@ -967,7 +966,7 @@ def get_bond_master(interface):
 
 def list_nics(nic_type=None):
     """Return a list of nics of given type(s)"""
-    if isinstance(nic_type, six.string_types):
+    if isinstance(nic_type, str):
         int_types = [nic_type]
     else:
         int_types = nic_type
@@ -1081,8 +1080,7 @@ def chownr(path, owner, group, follow_links=True, chowntopdir=False):
             try:
                 chown(full, uid, gid)
             except (IOError, OSError) as e:
-                # Intended to ignore "file not found". Catching both to be
-                # compatible with both Python 2.7 and 3.x.
+                # Intended to ignore "file not found".
                 if e.errno == errno.ENOENT:
                     pass
 

--- a/charmhelpers/core/services/base.py
+++ b/charmhelpers/core/services/base.py
@@ -17,8 +17,6 @@ import json
 import inspect
 from collections import Iterable, OrderedDict
 
-import six
-
 from charmhelpers.core import host
 from charmhelpers.core import hookenv
 
@@ -171,10 +169,7 @@ class ServiceManager(object):
                     if not units:
                         continue
                     remote_service = units[0].split('/')[0]
-                    if six.PY2:
-                        argspec = inspect.getargspec(provider.provide_data)
-                    else:
-                        argspec = inspect.getfullargspec(provider.provide_data)
+                    argspec = inspect.getfullargspec(provider.provide_data)
                     if len(argspec.args) > 1:
                         data = provider.provide_data(remote_service, service_ready)
                     else:

--- a/charmhelpers/core/strutils.py
+++ b/charmhelpers/core/strutils.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import re
 
 TRUTHY_STRINGS = {'y', 'yes', 'true', 't', 'on'}
@@ -27,8 +26,8 @@ def bool_from_string(value, truthy_strings=TRUTHY_STRINGS, falsey_strings=FALSEY
 
     Returns True if value translates to True otherwise False.
     """
-    if isinstance(value, six.string_types):
-        value = six.text_type(value)
+    if isinstance(value, str):
+        value = str(value)
     else:
         msg = "Unable to interpret non-string value '%s' as boolean" % (value)
         raise ValueError(msg)
@@ -61,8 +60,8 @@ def bytes_from_string(value):
         'P': 5,
         'PB': 5,
     }
-    if isinstance(value, six.string_types):
-        value = six.text_type(value)
+    if isinstance(value, str):
+        value = str(value)
     else:
         msg = "Unable to interpret non-string value '%s' as bytes" % (value)
         raise ValueError(msg)

--- a/charmhelpers/core/templating.py
+++ b/charmhelpers/core/templating.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from charmhelpers.core import host
 from charmhelpers.core import hookenv
@@ -43,9 +42,8 @@ def render(source, target, context, owner='root', group='root',
     The rendered template will be written to the file as well as being returned
     as a string.
 
-    Note: Using this requires python-jinja2 or python3-jinja2; if it is not
-    installed, calling this will attempt to use charmhelpers.fetch.apt_install
-    to install it.
+    Note: Using this requires python3-jinja2; if it is not installed, calling
+    this will attempt to use charmhelpers.fetch.apt_install to install it.
     """
     try:
         from jinja2 import FileSystemLoader, Environment, exceptions
@@ -57,10 +55,7 @@ def render(source, target, context, owner='root', group='root',
                         'charmhelpers.fetch to install it',
                         level=hookenv.ERROR)
             raise
-        if sys.version_info.major == 2:
-            apt_install('python-jinja2', fatal=True)
-        else:
-            apt_install('python3-jinja2', fatal=True)
+        apt_install('python3-jinja2', fatal=True)
         from jinja2 import FileSystemLoader, Environment, exceptions
 
     if template_loader:

--- a/charmhelpers/fetch/__init__.py
+++ b/charmhelpers/fetch/__init__.py
@@ -20,11 +20,7 @@ from charmhelpers.core.hookenv import (
     log,
 )
 
-import six
-if six.PY3:
-    from urllib.parse import urlparse, urlunparse
-else:
-    from urlparse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 
 # The order of this list is very important. Handlers should be listed in from
@@ -134,14 +130,14 @@ def configure_sources(update=False,
     sources = safe_load((config(sources_var) or '').strip()) or []
     keys = safe_load((config(keys_var) or '').strip()) or None
 
-    if isinstance(sources, six.string_types):
+    if isinstance(sources, str):
         sources = [sources]
 
     if keys is None:
         for source in sources:
             add_source(source, None)
     else:
-        if isinstance(keys, six.string_types):
+        if isinstance(keys, str):
             keys = [keys]
 
         if len(sources) != len(keys):

--- a/charmhelpers/fetch/archiveurl.py
+++ b/charmhelpers/fetch/archiveurl.py
@@ -26,26 +26,15 @@ from charmhelpers.payload.archive import (
 )
 from charmhelpers.core.host import mkdir, check_hash
 
-import six
-if six.PY3:
-    from urllib.request import (
-        build_opener, install_opener, urlopen, urlretrieve,
-        HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler,
-    )
-    from urllib.parse import urlparse, urlunparse, parse_qs
-    from urllib.error import URLError
-else:
-    from urllib import urlretrieve
-    from urllib2 import (
-        build_opener, install_opener, urlopen,
-        HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler,
-        URLError
-    )
-    from urlparse import urlparse, urlunparse, parse_qs
+from urllib.request import (
+    build_opener, install_opener, urlopen, urlretrieve,
+    HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler,
+)
+from urllib.parse import urlparse, urlunparse, parse_qs
+from urllib.error import URLError
 
 
 def splituser(host):
-    '''urllib.splituser(), but six's support of this seems broken'''
     _userprog = re.compile('^(.*)@(.*)$')
     match = _userprog.match(host)
     if match:
@@ -54,7 +43,6 @@ def splituser(host):
 
 
 def splitpasswd(user):
-    '''urllib.splitpasswd(), but six's support of this is missing'''
     _passwdprog = re.compile('^([^:]*):(.*)$', re.S)
     match = _passwdprog.match(user)
     if match:
@@ -150,10 +138,7 @@ class ArchiveUrlFetchHandler(BaseFetchHandler):
             raise UnhandledSource(e.strerror)
         options = parse_qs(url_parts.fragment)
         for key, value in options.items():
-            if not six.PY3:
-                algorithms = hashlib.algorithms
-            else:
-                algorithms = hashlib.algorithms_available
+            algorithms = hashlib.algorithms_available
             if key in algorithms:
                 if len(value) != 1:
                     raise TypeError(

--- a/charmhelpers/fetch/centos.py
+++ b/charmhelpers/fetch/centos.py
@@ -15,7 +15,6 @@
 import subprocess
 import os
 import time
-import six
 import yum
 
 from tempfile import NamedTemporaryFile
@@ -42,7 +41,7 @@ def install(packages, options=None, fatal=False):
     if options is not None:
         cmd.extend(options)
     cmd.append('install')
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)
@@ -71,7 +70,7 @@ def update(fatal=False):
 def purge(packages, fatal=False):
     """Purge one or more packages."""
     cmd = ['yum', '--assumeyes', 'remove']
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)
@@ -83,7 +82,7 @@ def yum_search(packages):
     """Search for a package."""
     output = {}
     cmd = ['yum', 'search']
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)

--- a/charmhelpers/fetch/python/packages.py
+++ b/charmhelpers/fetch/python/packages.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 import os
-import six
 import subprocess
 import sys
 
@@ -40,10 +39,7 @@ def pip_execute(*args, **kwargs):
             from pip import main as _pip_execute
         except ImportError:
             apt_update()
-            if six.PY2:
-                apt_install('python-pip')
-            else:
-                apt_install('python3-pip')
+            apt_install('python3-pip')
             from pip import main as _pip_execute
         _pip_execute(*args, **kwargs)
     finally:
@@ -140,12 +136,8 @@ def pip_list():
 
 def pip_create_virtualenv(path=None):
     """Create an isolated Python environment."""
-    if six.PY2:
-        apt_install('python-virtualenv')
-        extra_flags = []
-    else:
-        apt_install(['python3-virtualenv', 'virtualenv'])
-        extra_flags = ['--python=python3']
+    apt_install(['python3-virtualenv', 'virtualenv'])
+    extra_flags = ['--python=python3']
 
     if path:
         venv_path = path

--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 from collections import OrderedDict
-import os
 import platform
 import re
-import six
 import subprocess
 import sys
 import time
@@ -361,7 +359,7 @@ def apt_install(packages, options=None, fatal=False, quiet=False):
     cmd = ['apt-get', '--assume-yes']
     cmd.extend(options)
     cmd.append('install')
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)
@@ -413,7 +411,7 @@ def apt_purge(packages, fatal=False):
     :raises: subprocess.CalledProcessError
     """
     cmd = ['apt-get', '--assume-yes', 'purge']
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)
@@ -440,7 +438,7 @@ def apt_mark(packages, mark, fatal=False):
     """Flag one or more packages using apt-mark."""
     log("Marking {} as {}".format(packages, mark))
     cmd = ['apt-mark', mark]
-    if isinstance(packages, six.string_types):
+    if isinstance(packages, str):
         cmd.append(packages)
     else:
         cmd.extend(packages)
@@ -485,10 +483,7 @@ def import_key(key):
         if ('-----BEGIN PGP PUBLIC KEY BLOCK-----' in key and
                 '-----END PGP PUBLIC KEY BLOCK-----' in key):
             log("Writing provided PGP key in the binary format", level=DEBUG)
-            if six.PY3:
-                key_bytes = key.encode('utf-8')
-            else:
-                key_bytes = key
+            key_bytes = key.encode('utf-8')
             key_name = _get_keyid_by_gpg_key(key_bytes)
             key_gpg = _dearmor_gpg_key(key_bytes)
             _write_apt_gpg_keyfile(key_name=key_name, key_material=key_gpg)
@@ -528,9 +523,8 @@ def _get_keyid_by_gpg_key(key_material):
                           stderr=subprocess.PIPE,
                           stdin=subprocess.PIPE)
     out, err = ps.communicate(input=key_material)
-    if six.PY3:
-        out = out.decode('utf-8')
-        err = err.decode('utf-8')
+    out = out.decode('utf-8')
+    err = err.decode('utf-8')
     if 'gpg: no valid OpenPGP data found.' in err:
         raise GPGKeyError('Invalid GPG key material provided')
     # from gnupg2 docs: fpr :: Fingerprint (fingerprint is in field 10)
@@ -588,8 +582,7 @@ def _dearmor_gpg_key(key_asc):
                           stdin=subprocess.PIPE)
     out, err = ps.communicate(input=key_asc)
     # no need to decode output as it is binary (invalid utf-8), only error
-    if six.PY3:
-        err = err.decode('utf-8')
+    err = err.decode('utf-8')
     if 'gpg: no valid OpenPGP data found.' in err:
         raise GPGKeyError('Invalid GPG key material. Check your network setup'
                           ' (MTU, routing, DNS) and/or proxy server settings'
@@ -693,7 +686,7 @@ def add_source(source, key=None, fail_invalid=False):
     ])
     if source is None:
         source = ''
-    for r, fn in six.iteritems(_mapping):
+    for r, fn in _mapping.items():
         m = re.match(r, source)
         if m:
             if key:
@@ -726,7 +719,7 @@ def _add_proposed():
     """
     release = get_distrib_codename()
     arch = platform.machine()
-    if arch not in six.iterkeys(ARCH_TO_PROPOSED_POCKET):
+    if arch not in ARCH_TO_PROPOSED_POCKET.keys():
         raise SourceConfigError("Arch {} not supported for (distro-)proposed"
                                 .format(arch))
     with open('/etc/apt/sources.list.d/proposed.list', 'w') as apt:
@@ -913,9 +906,8 @@ def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
 
     kwargs = {}
     if quiet:
-        devnull = os.devnull if six.PY2 else subprocess.DEVNULL
-        kwargs['stdout'] = devnull
-        kwargs['stderr'] = devnull
+        kwargs['stdout'] = subprocess.DEVNULL
+        kwargs['stderr'] = subprocess.DEVNULL
 
     if not retry_message:
         retry_message = "Failed executing '{}'".format(" ".join(cmd))
@@ -957,9 +949,8 @@ def _run_apt_command(cmd, fatal=False, quiet=False):
     else:
         kwargs = {}
         if quiet:
-            devnull = os.devnull if six.PY2 else subprocess.DEVNULL
-            kwargs['stdout'] = devnull
-            kwargs['stderr'] = devnull
+            kwargs['stdout'] = subprocess.DEVNULL
+            kwargs['stderr'] = subprocess.DEVNULL
         subprocess.call(cmd, env=get_apt_dpkg_env(), **kwargs)
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,6 @@
 # Fri, 04 Jan 2013 15:14:11 -0600
 
 %:
-	dh $@ --with python2 --buildsystem=python_distutils
+	dh $@ --with python3 --buildsystem=python_distutils
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ PyYAML
 # Jinja2==2.11 is last supported for py27 & py35 (xenial)
 Jinja2
 
-six
 netaddr
 Tempita
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,26 +1,25 @@
 [metadata]
 name = charmhelpers
 summary = Helpers for Juju Charm development
-description-file = 
+description-file =
     README.rst
 author = Charmers
 author-email = juju@lists.ubuntu.com
 home-page = https://github.com/juju/charm-helpers
-classifier = 
+classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [files]
-packages = 
+packages =
     charmhelpers
 scripts =
     bin/chlp

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@
 
 import setuptools
 
-# In python < 2.7.4, a lazy loading of package `pbr` will break
-# setuptools if some other modules registered functions in `atexit`.
-# solution from: http://bugs.python.org/issue15881#msg170215
 try:
     import multiprocessing  # noqa
 except ImportError:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,9 +6,9 @@ coverage>=3.6
 mock>=1.0.1,<1.1.0
 nose>=1.3.1
 flake8
-testtools==0.9.14  # Before dependent on modern 'six'
+# testtools==0.9.14  # Before dependent on modern 'six'
+testtools
 sphinx_rtd_theme
-ipaddress;python_version<'3.0'  # Py27 unit test requirement
 
 
 ##########################################################
@@ -16,20 +16,14 @@ ipaddress;python_version<'3.0'  # Py27 unit test requirement
 # The requirements.txt file cannot be so specific
 
 # https://pyyaml.org/wiki/PyYAML#history
-# PyYAML==5.2 is last supported for py34
-PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-PyYAML;     python_version == '2.7' or python_version >= '3.5'  # all else
+PyYAML
 
 # https://jinja.palletsprojects.com/en/2.11.x/changelog/
-# Jinja2==2.10 is last supported for py34
-# Jinja2==2.11.3 is last supported for py27 & py35
-Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-Jinja2==2.11.3;python_version == '2.7' or python_version == '3.5'  # py27, py35
-Jinja2;      python_version >= '3.6'                             # py36 and on
+Jinja2
 
 ##############################################################
 
 netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.
-psutil==1.2.1      # trusty
-python-keystoneclient==2.3.2 # xenial
-dnspython==1.11.1  # trusty
+psutil
+python-keystoneclient
+dnspython

--- a/tests/cli/test_cmdline.py
+++ b/tests/cli/test_cmdline.py
@@ -12,7 +12,7 @@ from pprint import pformat
 import yaml
 import csv
 
-from six import StringIO
+from io import StringIO
 
 from charmhelpers import cli
 

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import unittest
 from mock import patch, sentinel
-import six
 
 from charmhelpers import context
 from charmhelpers.core import hookenv
@@ -128,14 +127,13 @@ class TestRelations(unittest.TestCase):
 
         # Python 2 unicode strings work too.
         hookenv.relation_set.reset_mock()
-        r[sentinel.key] = six.u('value')
+        r[sentinel.key] = 'value'
         hookenv.relation_set.assert_called_once_with(
-            'rel:10', {sentinel.key: six.u('value')})
+            'rel:10', {sentinel.key: 'value'})
 
         # Byte strings fail under Python 3.
-        if six.PY3:
-            with self.assertRaises(ValueError):
-                r[sentinel.key] = six.b('value')
+        with self.assertRaises(ValueError):
+            r[sentinel.key] = b'value'
 
         # Deletes work
         del r[sentinel.key]
@@ -172,13 +170,12 @@ class TestLeader(unittest.TestCase):
         leader_set.assert_called_with({sentinel.key: None})
 
         # Python 2 unicode string values work too
-        leader[sentinel.key] = six.u('bar')
+        leader[sentinel.key] = 'bar'
         leader_set.assert_called_with({sentinel.key: 'bar'})
 
         # Byte strings fail under Python 3
-        if six.PY3:
-            with self.assertRaises(ValueError):
-                leader[sentinel.key] = six.b('baz')
+        with self.assertRaises(ValueError):
+            leader[sentinel.key] = b'baz'
 
         # Non strings fail, as implicit casting causes more trouble
         # than it solves. Simple types like integers would round trip

--- a/tests/contrib/charmhelpers/test_charmhelpers.py
+++ b/tests/contrib/charmhelpers/test_charmhelpers.py
@@ -4,7 +4,7 @@ import unittest
 import yaml
 from testtools import TestCase
 
-from six import StringIO
+from io import StringIO
 
 import sys
 # Path hack to ensure we test the local code, not a version installed in

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -124,7 +124,7 @@ class ClusterUtilsTests(TestCase):
                                                mock_log):
         '''It determines its unit is not leader'''
         self.get_unit_hostname.return_value = 'node1'
-        check_output.return_value = "resource vip is NOT running"
+        check_output.return_value = b"resource vip is NOT running"
         self.assertRaises(cluster_utils.CRMResourceNotFound,
                           cluster_utils.is_crm_leader, 'vip')
         mock_time.assert_has_calls([call.sleep(2), call.sleep(4),

--- a/tests/contrib/hardening/test_templating.py
+++ b/tests/contrib/hardening/test_templating.py
@@ -14,7 +14,6 @@
 
 import tempfile
 import os
-import six
 
 from mock import call, patch
 from unittest import TestCase
@@ -304,7 +303,7 @@ class TemplatingTestCase(TestCase):
 
     def tearDown(self):
         # Cleanup
-        for path in six.itervalues(self.pathindex):
+        for path in self.pathindex.values():
             os.remove(path)
 
         super(TemplatingTestCase, self).tearDown()

--- a/tests/contrib/hardening/test_utils.py
+++ b/tests/contrib/hardening/test_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import tempfile
 
 from mock import (
@@ -56,8 +55,6 @@ class UtilsTestCase(TestCase):
         mock_get_user_provided_overrides.return_value = {}
         self.assertEqual(utils.__SETTINGS__, {})
         self.assertTrue('sysctl' in utils.get_settings('os'))
-        self.assertEqual(sorted(list(six.iterkeys(utils.__SETTINGS__))),
-                         ['os'])
+        self.assertEqual(sorted(utils.__SETTINGS__.keys()), ['os'])
         self.assertTrue('server' in utils.get_settings('ssh'))
-        self.assertEqual(sorted(list(six.iterkeys(utils.__SETTINGS__))),
-                         ['os', 'ssh'])
+        self.assertEqual(sorted(utils.__SETTINGS__.keys()), ['os', 'ssh'])

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -8,14 +8,7 @@ import charmhelpers.contrib.network.ip as net_ip
 from mock import patch, MagicMock
 
 import nose.tools
-import six
 
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-    builtin_import = '__builtin__.__import__'
-else:
-    builtin_open = 'builtins.open'
-    builtin_import = 'builtins.__import__'
 
 DUMMY_ADDRESSES = {
     'lo': {
@@ -640,7 +633,7 @@ class IPTest(unittest.TestCase):
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_host_ip_with_hostname(self, apt_install):
         fake_dns = FakeDNS('10.0.0.1')
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com')
         self.assertEquals(ip, '10.0.0.1')
 
@@ -652,7 +645,7 @@ class IPTest(unittest.TestCase):
         ns_query.return_value = []
         fake_dns = FakeDNS(None)
         socket.return_value = '10.0.0.1'
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com')
         self.assertEquals(ip, '10.0.0.1')
 
@@ -669,32 +662,29 @@ class IPTest(unittest.TestCase):
             raise Exception()
 
         socket.side_effect = r
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com', fallback='127.0.0.1')
         self.assertEquals(ip, '127.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_host_ip_with_ip(self, apt_install):
         fake_dns = FakeDNS('5.5.5.5')
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('4.2.2.1')
         self.assertEquals(ip, '4.2.2.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_trigger_apt_install(self, apt_install):
         fake_dns = FakeDNS('5.5.5.5')
-        with patch(builtin_import, side_effect=[ImportError, fake_dns]):
+        with patch('builtins.__import__', side_effect=[ImportError, fake_dns]):
             nsq = net_ip.ns_query('5.5.5.5')
-            if six.PY2:
-                apt_install.assert_called_with('python-dnspython', fatal=True)
-            else:
-                apt_install.assert_called_with('python3-dnspython', fatal=True)
+            apt_install.assert_called_with('python3-dnspython', fatal=True)
         self.assertEquals(nsq, '5.5.5.5')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_ptr_record(self, apt_install):
         fake_dns = FakeDNS('127.0.0.1')
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             nsq = net_ip.ns_query('127.0.0.1')
         self.assertEquals(nsq, '127.0.0.1')
 
@@ -702,35 +692,35 @@ class IPTest(unittest.TestCase):
     def test_ns_query_a_record(self, apt_install):
         fake_dns = FakeDNS('127.0.0.1')
         fake_dns_name = FakeDNSName('www.somedomain.tld')
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             nsq = net_ip.ns_query(fake_dns_name)
         self.assertEquals(nsq, '127.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_blank_record(self, apt_install):
         fake_dns = FakeDNS(None)
-        with patch(builtin_import, side_effect=[fake_dns, fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             nsq = net_ip.ns_query(None)
         self.assertEquals(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_lookup_fail(self, apt_install):
         fake_dns = FakeDNS('')
-        with patch(builtin_import, side_effect=[fake_dns, fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             nsq = net_ip.ns_query('nonexistant')
         self.assertEquals(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_ip(self, apt_install):
         fake_dns = FakeDNS('www.ubuntu.com')
-        with patch(builtin_import, side_effect=[fake_dns, fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
         self.assertEquals(hn, 'www.ubuntu.com')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_ip_not_fqdn(self, apt_install):
         fake_dns = FakeDNS('packages.ubuntu.com')
-        with patch(builtin_import, side_effect=[fake_dns, fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1', fqdn=False)
         self.assertEquals(hn, 'packages')
 
@@ -752,13 +742,10 @@ class IPTest(unittest.TestCase):
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_trigger_apt_install(self, apt_install):
         fake_dns = FakeDNS('www.ubuntu.com')
-        with patch(builtin_import, side_effect=[ImportError, fake_dns,
-                                                fake_dns]):
+        with patch('builtins.__import__',
+                   side_effect=[ImportError, fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
-            if six.PY2:
-                apt_install.assert_called_with('python-dnspython', fatal=True)
-            else:
-                apt_install.assert_called_with('python3-dnspython', fatal=True)
+            apt_install.assert_called_with('python3-dnspython', fatal=True)
 
         self.assertEquals(hn, 'www.ubuntu.com')
 
@@ -769,7 +756,7 @@ class IPTest(unittest.TestCase):
         fake_dns = FakeDNS('www.ubuntu.com')
         ns_query.return_value = []
         socket.return_value = ()
-        with patch(builtin_import, side_effect=[fake_dns, fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
         self.assertEquals(hn, None)
 
@@ -781,7 +768,7 @@ class IPTest(unittest.TestCase):
         fake_dns = FakeDNS('www.ubuntu.com')
         ns_query.return_value = []
         socket.return_value = ("www.ubuntu.com", "", "")
-        with patch(builtin_import, side_effect=[fake_dns]):
+        with patch('builtins.__import__', side_effect=[fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
         self.assertEquals(hn, "www.ubuntu.com")
 

--- a/tests/contrib/openstack/test_audits.py
+++ b/tests/contrib/openstack/test_audits.py
@@ -1,12 +1,10 @@
-from testtools import TestCase, skipIf
+from testtools import TestCase
 from mock import patch, MagicMock, call
-import six
 
 import charmhelpers.contrib.openstack.audits as audits
 import charmhelpers.contrib.openstack.audits.openstack_security_guide as guide
 
 
-@skipIf(six.PY2, 'Audits only support Python3')
 class AuditTestCase(TestCase):
 
     @patch('charmhelpers.contrib.openstack.audits._audits', {})
@@ -27,7 +25,8 @@ class AuditTestCase(TestCase):
         audits.run({})
         self.assertTrue(variables['guard_called'])
         self.assertTrue(variables['test_run'])
-        self.assertEqual(audits._audits['test'], audits.Audit(test, (should_run,)))
+        self.assertEqual(
+            audits._audits['test'], audits.Audit(test, (should_run,)))
 
     @patch('charmhelpers.contrib.openstack.audits._audits', {})
     def test_wrapper_not_run(self):
@@ -47,7 +46,8 @@ class AuditTestCase(TestCase):
         audits.run({})
         self.assertTrue(variables['guard_called'])
         self.assertFalse(variables['test_run'])
-        self.assertEqual(audits._audits['test'], audits.Audit(test, (should_run,)))
+        self.assertEqual(
+            audits._audits['test'], audits.Audit(test, (should_run,)))
 
     @patch('charmhelpers.contrib.openstack.audits._audits', {})
     def test_duplicate_audit(self):
@@ -80,7 +80,8 @@ class AuditTestCase(TestCase):
             def test(options):
                 pass
         except RuntimeError as e:
-            self.assertEqual("Configuration includes non-callable filters: [3]", e.args[0])
+            self.assertEqual(
+                "Configuration includes non-callable filters: [3]", e.args[0])
             return
         self.assertTrue(False, "Duplicate audit should raise an exception")
 
@@ -185,15 +186,18 @@ class AuditsTestCase(TestCase):
         self.assertEqual(verifier(), False)
 
     def test_is_audit_type_empty(self):
-        verifier = audits.is_audit_type(audits.AuditType.OpenStackSecurityGuide)
+        verifier = audits.is_audit_type(
+            audits.AuditType.OpenStackSecurityGuide)
         self.assertEqual(verifier({}), False)
 
     def test_is_audit_type(self):
-        verifier = audits.is_audit_type(audits.AuditType.OpenStackSecurityGuide)
-        self.assertEqual(verifier({'audit_type': audits.AuditType.OpenStackSecurityGuide}), True)
+        verifier = audits.is_audit_type(
+            audits.AuditType.OpenStackSecurityGuide)
+        self.assertEqual(
+            verifier({'audit_type': audits.AuditType.OpenStackSecurityGuide}),
+            True)
 
 
-@skipIf(six.PY2, 'Audits only support Python3')
 class OpenstackSecurityGuideTestCase(TestCase):
 
     @patch('configparser.ConfigParser')
@@ -204,14 +208,17 @@ class OpenstackSecurityGuideTestCase(TestCase):
         _config_parser.assert_called_with(strict=False)
         parser.read.assert_called_with('test')
 
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._stat')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._stat')
     def test_internal_validate_file_ownership(self, _stat):
         _stat.return_value = guide.Ownership('test_user', 'test_group', '600')
-        guide._validate_file_ownership('test_user', 'test_group', 'test-file-name')
+        guide._validate_file_ownership(
+            'test_user', 'test_group', 'test-file-name')
         _stat.assert_called_with('test-file-name')
         pass
 
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._stat')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._stat')
     def test_internal_validate_file_mode(self, _stat):
         _stat.return_value = guide.Ownership('test_user', 'test_group', '600')
         guide._validate_file_mode('600', 'test-file-name')
@@ -219,8 +226,10 @@ class OpenstackSecurityGuideTestCase(TestCase):
         pass
 
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_mode')
-    def test_validate_file_permissions_defaults(self, _validate_mode, _is_file):
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_mode')
+    def test_validate_file_permissions_defaults(
+            self, _validate_mode, _is_file):
         _is_file.return_value = True
         config = {
             'files': {
@@ -231,7 +240,8 @@ class OpenstackSecurityGuideTestCase(TestCase):
         _validate_mode.assert_called_once_with('600', 'test', False)
 
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_mode')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_mode')
     def test_validate_file_permissions(self, _validate_mode, _is_file):
         _is_file.return_value = True
         config = {
@@ -246,8 +256,10 @@ class OpenstackSecurityGuideTestCase(TestCase):
 
     @patch('glob.glob')
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_mode')
-    def test_validate_file_permissions_glob(self, _validate_mode, _is_file, _glob):
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_mode')
+    def test_validate_file_permissions_glob(
+            self, _validate_mode, _is_file, _glob):
         _glob.return_value = ['test']
         _is_file.return_value = True
         config = {
@@ -261,7 +273,8 @@ class OpenstackSecurityGuideTestCase(TestCase):
         _validate_mode.assert_called_once_with('777', 'test', False)
 
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_ownership')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_ownership')
     def test_validate_file_ownership_defaults(self, _validate_owner, _is_file):
         _is_file.return_value = True
         config = {
@@ -273,7 +286,8 @@ class OpenstackSecurityGuideTestCase(TestCase):
         _validate_owner.assert_called_once_with('root', 'root', 'test', False)
 
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_ownership')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_ownership')
     def test_validate_file_ownership(self, _validate_owner, _is_file):
         _is_file.return_value = True
         config = {
@@ -285,12 +299,15 @@ class OpenstackSecurityGuideTestCase(TestCase):
             }
         }
         guide.validate_file_ownership(config)
-        _validate_owner.assert_called_once_with('test-user', 'test-group', 'test', False)
+        _validate_owner.assert_called_once_with(
+            'test-user', 'test-group', 'test', False)
 
     @patch('glob.glob')
     @patch('os.path.isfile')
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._validate_file_ownership')
-    def test_validate_file_ownership_glob(self, _validate_owner, _is_file, _glob):
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._validate_file_ownership')
+    def test_validate_file_ownership_glob(
+            self, _validate_owner, _is_file, _glob):
         _glob.return_value = ['test']
         _is_file.return_value = True
         config = {
@@ -302,17 +319,21 @@ class OpenstackSecurityGuideTestCase(TestCase):
             }
         }
         guide.validate_file_ownership(config)
-        _validate_owner.assert_called_once_with('test-user', 'test-group', 'test', False)
+        _validate_owner.assert_called_once_with(
+            'test-user', 'test-group', 'test', False)
 
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._config_section')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._config_section')
     def test_validate_uses_keystone(self, _config_section):
         _config_section.side_effect = [None, {
             'auth_strategy': 'keystone',
         }]
         guide.validate_uses_keystone({})
-        _config_section.assert_has_calls([call({}, 'api'), call({}, 'DEFAULT')])
+        _config_section.assert_has_calls(
+            [call({}, 'api'), call({}, 'DEFAULT')])
 
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._config_section')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._config_section')
     def test_validate_uses_tls_for_keystone(self, _config_section):
         _config_section.return_value = {
             'auth_uri': 'https://10.10.10.10',
@@ -320,7 +341,8 @@ class OpenstackSecurityGuideTestCase(TestCase):
         guide.validate_uses_tls_for_keystone({})
         _config_section.assert_called_with({}, 'keystone_authtoken')
 
-    @patch('charmhelpers.contrib.openstack.audits.openstack_security_guide._config_section')
+    @patch('charmhelpers.contrib.openstack.audits'
+           '.openstack_security_guide._config_section')
     def test_validate_uses_tls_for_glance(self, _config_section):
         _config_section.return_value = {
             'api_servers': 'https://10.10.10.10',

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -504,13 +504,14 @@ class CertUtilsTests(unittest.TestCase):
         self.assertEqual(cert_utils.get_cert_relation_ca_name(), '')
         remote_service_name.assert_not_called()
 
+    @mock.patch.object(cert_utils, 'log')
     @mock.patch.object(cert_utils, 'remote_service_name')
     @mock.patch.object(cert_utils.os, 'remove')
     @mock.patch.object(cert_utils.os.path, 'exists')
     @mock.patch.object(cert_utils, 'config')
     @mock.patch.object(cert_utils, 'install_ca_cert')
     def test__manage_ca_certs(self, install_ca_cert, config, os_exists,
-                              os_remove, remote_service_name):
+                              os_remove, remote_service_name, _log):
         remote_service_name.return_value = 'vault'
         _config = {}
         config.side_effect = lambda x: _config.get(x)

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -15,14 +15,6 @@ import charmhelpers.contrib.openstack.deferred_events as deferred_events
 from charmhelpers.contrib.openstack.exceptions import ServiceActionError
 import contextlib
 
-import six
-
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-    builtin_import = '__builtin__.__import__'
-else:
-    builtin_open = 'builtins.open'
-    builtin_import = 'builtins.__import__'
 
 FAKE_CODENAME = 'precise'
 # mocked return of openstack.lsb_release()
@@ -339,7 +331,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_get_installed_os_version.return_value = None
         with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
-            for pkg, vers in six.iteritems(FAKE_REPO):
+            for pkg, vers in FAKE_REPO.items():
                 # test fake repo for all "installed" packages
                 if pkg.startswith('bad-'):
                     continue
@@ -444,7 +436,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_get_installed_os_version.return_value = None
         with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
-            for pkg, vers in six.iteritems(FAKE_REPO):
+            for pkg, vers in FAKE_REPO.items():
                 if pkg.startswith('bad-'):
                     continue
                 if 'pkg_vers' not in vers:
@@ -523,7 +515,7 @@ class OpenStackHelpersTestCase(TestCase):
             "|key": ('', 'key'),
             "source": ('source', None),
         }
-        for k, v in six.iteritems(tests):
+        for k, v in tests.items():
             self.assertEqual(openstack.get_source_and_pgp_key(k), v)
 
     # These should still work, even though the bulk of the functionality has
@@ -555,7 +547,7 @@ class OpenStackHelpersTestCase(TestCase):
              'precise-havana main'], env={})
 
     @patch.object(fetch, 'get_distrib_codename')
-    @patch(builtin_open)
+    @patch('builtins.open')
     @patch('subprocess.check_call')
     def test_configure_install_source_distro_proposed(
             self, _spcc, _open, _lsb):
@@ -652,7 +644,7 @@ class OpenStackHelpersTestCase(TestCase):
                    'ppa:ubuntu-cloud-archive/folsom-staging']
             _subp.assert_called_with(cmd, env={})
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     @patch.object(fetch, 'apt_install')
     @patch.object(fetch, 'get_distrib_codename')
     @patch.object(fetch, 'filter_installed_packages')
@@ -708,7 +700,7 @@ class OpenStackHelpersTestCase(TestCase):
     @patch('os.mkdir')
     @patch('os.path.exists')
     @patch('charmhelpers.contrib.openstack.utils.charm_dir')
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_save_scriptrc(self, _open, _charm_dir, _exists, _mkdir):
         """Test generation of scriptrc from environment"""
         scriptrc = ['#!/bin/bash\n',
@@ -842,7 +834,7 @@ class OpenStackHelpersTestCase(TestCase):
         zap_disk.assert_called_with('/dev/vdb')
 
     @patch('os.path.isfile')
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_get_matchmaker_map(self, _open, _isfile):
         _isfile.return_value = True
         mm_data = """
@@ -860,7 +852,7 @@ class OpenStackHelpersTestCase(TestCase):
         )
 
     @patch('os.path.isfile')
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_get_matchmaker_map_nofile(self, _open, _isfile):
         _isfile.return_value = False
         self.assertEqual(

--- a/tests/contrib/openstack/test_os_templating.py
+++ b/tests/contrib/openstack/test_os_templating.py
@@ -8,12 +8,6 @@ import charmhelpers.contrib.openstack.templating as templating
 
 from jinja2.exceptions import TemplateNotFound
 
-import six
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
-
 
 class FakeContextGenerator(object):
     interfaces = None
@@ -78,10 +72,7 @@ class TemplatingTests(unittest.TestCase):
         templating.FileSystemLoader = MockFSLoader
         templating.ChoiceLoader = MockChoiceLoader
         templating.Environment = MagicMock
-        if six.PY2:
-            apt.assert_called_with('python-jinja2')
-        else:
-            apt.assert_called_with('python3-jinja2')
+        apt.assert_called_with('python3-jinja2')
 
     def test_create_renderer_invalid_templates_dir(self):
         '''Ensure OSConfigRenderer checks templates_dir'''
@@ -169,7 +160,7 @@ class TemplatingTests(unittest.TestCase):
     def test_render_template_by_basename(self):
         '''It renders template if it finds it by config file basename'''
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     @patch.object(templating, 'get_loader')
     def test_write_out_config(self, loader, _open):
         '''It writes a templated config when provided a complete context'''

--- a/tests/contrib/openstack/test_os_utils.py
+++ b/tests/contrib/openstack/test_os_utils.py
@@ -2,15 +2,9 @@ import collections
 import copy
 import json
 import mock
-import six
 import unittest
 
 from charmhelpers.contrib.openstack import utils
-
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
 
 
 class UtilsTests(unittest.TestCase):
@@ -225,7 +219,7 @@ class UtilsTests(unittest.TestCase):
         }
 
         mock_open = mock.mock_open(read_data=TEST_POLICY)
-        with mock.patch(builtin_open, mock_open) as mock_file:
+        with mock.patch('builtins.open', mock_open) as mock_file:
             utils.update_json_file(TEST_POLICY_FILE, {})
             self.assertFalse(mock_file.called)
 
@@ -244,7 +238,7 @@ class UtilsTests(unittest.TestCase):
         tmp.update(items_to_update)
         TEST_POLICY = json.dumps(tmp)
         mock_open = mock.mock_open(read_data=TEST_POLICY)
-        with mock.patch(builtin_open, mock_open) as mock_file:
+        with mock.patch('builtins.open', mock_open) as mock_file:
             utils.update_json_file(TEST_POLICY_FILE, items_to_update)
             mock_file.assert_has_calls([
                 mock.call(TEST_POLICY_FILE),

--- a/tests/contrib/openstack/test_policyd.py
+++ b/tests/contrib/openstack/test_policyd.py
@@ -3,16 +3,9 @@ import copy
 import io
 import os
 import mock
-import six
 import unittest
 
 from charmhelpers.contrib.openstack import policyd
-
-
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
 
 
 class PolicydTests(unittest.TestCase):
@@ -393,7 +386,7 @@ class PolicydTests(unittest.TestCase):
             mock_open = mock.MagicMock(spec=open)
             mock_file = mock.MagicMock(spec=io.FileIO)
 
-            with mock.patch(builtin_open, mock_open):
+            with mock.patch('builtins.open', mock_open):
                 yield mock_open, mock_file
 
         mock_clean_policyd_dir_for.reset_mock()

--- a/tests/contrib/openstack/test_ssh_migrations.py
+++ b/tests/contrib/openstack/test_ssh_migrations.py
@@ -1,18 +1,10 @@
 import mock
-import six
 import subprocess
 import unittest
 
 from tests.helpers import patch_open, mock_open
 
 import charmhelpers.contrib.openstack.ssh_migrations as ssh_migrations
-
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-    builtin_import = '__builtin__.__import__'
-else:
-    builtin_open = 'builtins.open'
-    builtin_import = 'builtins.__import__'
 
 
 UNIT1_HOST_KEY_1 = """|1|EaIiWNsBsaSke5T5bdDlaV5xKPU=|WKMu3Va+oNwRjXmPGOZ+mrpWbM8= ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZdZdR7I35ymFdspruN1CIez/0m62sJeld2nLuOGaNbdl/rk5bGrWUAZh6c9p9H53FAqGAXBD/1C8dZ5dgIAGdTs7PAZq7owXCpgUPQcGOYVAtBwv8qfnWyI1W+Vpi6vnb2sgYr6XGbB9b84i4vrd98IIpXIleC9qd0VUTSYgd7+NPaFNoK0HZmqcNEf5leaa8sgSf4t5F+BTWEXzU3ql/3isFT8lEpJ9N8wOvNzAoFEQcxqauvOJn72QQ6kUrQT3NdQFUMHquS/s+nBrQNPbUmzqrvSOed75Qk8359zqU1Rce7U39cqc0scYi1ak3oJdojwfLFKJw4TMPn/Pq7JnT"""
@@ -133,7 +125,7 @@ class SSHMigrationsTests(unittest.TestCase):
             mock.call('/etc/nova/compute_ssh/nova-compute-lxd')]
         self.mkdir.assert_has_calls(mkdir_calls)
 
-    @mock.patch(builtin_open)
+    @mock.patch('builtins.open')
     def test_ssh_directory_missing_file(self, _open):
         self.setup_mocks_ssh_directory_for_unit(
             'nova-compute-lxd',
@@ -149,7 +141,7 @@ class SSHMigrationsTests(unittest.TestCase):
             'w')
         self.assertFalse(self.mkdir.called)
 
-    @mock.patch(builtin_open)
+    @mock.patch('builtins.open')
     def test_ssh_directory_missing_files(self, _open):
         self.setup_mocks_ssh_directory_for_unit(
             'nova-compute-lxd',

--- a/tests/contrib/ssl/test_service.py
+++ b/tests/contrib/ssl/test_service.py
@@ -2,7 +2,6 @@ from testtools import TestCase
 import tempfile
 import shutil
 import subprocess
-import six
 import mock
 
 from os.path import exists, join, isdir
@@ -72,7 +71,5 @@ class ServiceCATest(TestCase):
 
         output = subprocess.check_output(cmd,
                                          stderr=subprocess.STDOUT).strip()
-        expected = '{}: OK'.format(full_cert_path)
-        if six.PY3:
-            expected = bytes(expected, 'utf-8')
+        expected = '{}: OK'.format(full_cert_path).encode('utf-8')
         self.assertEqual(expected, output)

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -1,7 +1,6 @@
 from mock import patch, call, mock_open
 
 import collections
-import six
 import errno
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -325,15 +324,15 @@ class CephUtilsTests(TestCase):
                           valid_range=[0])
 
     def test_validator_invalid_string_list(self):
-        # foo is a six.string_types that isn't in the valid string list
+        # foo is a str that isn't in the valid string list
         self.assertRaises(AssertionError, ceph_utils.validator,
                           value="foo",
-                          valid_type=six.string_types,
+                          valid_type=str,
                           valid_range=["valid", "list", "of", "strings"])
 
     def test_validator_valid_string(self):
         ceph_utils.validator(value="foo",
-                             valid_type=six.string_types,
+                             valid_type=str,
                              valid_range=["foo"])
 
     def test_validator_valid_string_type(self):
@@ -1013,9 +1012,7 @@ class CephUtilsTests(TestCase):
             '010d57d581604d411b315dd64112bff832ab92c7323fa06077134b50',
             '8e0a9705c1aeafa1ce250cc9f1bb443fc6e5150e5edcbeb6eeb82e3c',
             'c3f8d36ba098c23ee920cb08cfb9beda6b639f8433637c190bdd56ec']
-        _monmap_dump = MONMAP_DUMP
-        if six.PY3:
-            _monmap_dump = _monmap_dump.decode('UTF-8')
+        _monmap_dump = MONMAP_DUMP.decode('UTF-8')
         monmap.return_value = json.loads(_monmap_dump)
         hashed_mon_list = ceph_utils.hash_monitor_names(service='admin')
         self.assertEqual(expected=expected_hash_list, observed=hashed_mon_list)

--- a/tests/contrib/templating/test_contexts.py
+++ b/tests/contrib/templating/test_contexts.py
@@ -9,8 +9,6 @@ import tempfile
 import unittest
 import yaml
 
-import six
-
 import charmhelpers.contrib.templating.contexts
 
 
@@ -136,12 +134,12 @@ class JujuState2YamlTestCase(unittest.TestCase):
         }
         self.mock_relations.return_value = {
             'wsgi-file': {
-                six.u('wsgi-file:0'): {
-                    six.u('gunicorn/1'): {
-                        six.u('private-address'): six.u('10.0.3.99'),
+                'wsgi-file:0': {
+                    'gunicorn/1': {
+                        'private-address': '10.0.3.99',
                     },
                     'click-index/3': {
-                        six.u('wsgi_group'): six.u('ubunet'),
+                        'wsgi_group': 'ubunet',
                     },
                 },
             },
@@ -165,8 +163,8 @@ class JujuState2YamlTestCase(unittest.TestCase):
             expected["relations_full"]['wsgi-file'] = {
                 'wsgi-file:0': {
                     'gunicorn/1': {
-                        six.u('private-address'): six.u('10.0.3.99')},
-                    'click-index/3': {six.u('wsgi_group'): six.u('ubunet')},
+                        'private-address': '10.0.3.99'},
+                    'click-index/3': {'wsgi_group': 'ubunet'},
                 },
             }
             expected["relations"]["wsgi-file"] = [

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -12,7 +12,6 @@ from mock import patch, call, mock_open
 from testtools import TestCase
 from tests.helpers import patch_open
 from tests.helpers import mock_open as mocked_open
-import six
 
 from charmhelpers.core import host
 from charmhelpers.fetch import ubuntu_apt_pkg
@@ -1195,7 +1194,7 @@ class HelpersTest(TestCase):
     @patch.object(host, 'os')
     def test_writes_binary_contents(self, os_, log):
         path = '/some/path/{baz}'
-        fmtstr = six.u('what is {juju}\N{TRADE MARK SIGN}').encode('UTF-8')
+        fmtstr = 'what is {juju}\N{TRADE MARK SIGN}'.encode('UTF-8')
         fileno = 'some-fileno'
 
         with patch_open() as (mock_open, mock_file):

--- a/tests/core/test_sysctl.py
+++ b/tests/core/test_sysctl.py
@@ -8,11 +8,6 @@ from subprocess import CalledProcessError
 import unittest
 import tempfile
 
-import six
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
 
 __author__ = 'Jorge Niedbalski R. <jorge.niedbalski@canonical.com>'
 
@@ -36,7 +31,7 @@ class SysctlTests(unittest.TestCase):
         self.addCleanup(_m.stop)
         return mock
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create(self, mock_open):
         """Test create sysctl method"""
         _file = MagicMock(spec=io.FileIO)
@@ -55,7 +50,7 @@ class SysctlTests(unittest.TestCase):
             "sysctl", "-p",
             "/etc/sysctl.d/test-sysctl.conf"])
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create_with_ignore(self, mock_open):
         """Test create sysctl method"""
         _file = MagicMock(spec=io.FileIO)
@@ -76,7 +71,7 @@ class SysctlTests(unittest.TestCase):
             "sysctl", "-p",
             "/etc/sysctl.d/test-sysctl.conf", "-e"])
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create_with_dict(self, mock_open):
         """Test create sysctl method"""
         _file = MagicMock(spec=io.FileIO)
@@ -95,7 +90,7 @@ class SysctlTests(unittest.TestCase):
             "sysctl", "-p",
             "/etc/sysctl.d/test-sysctl.conf"])
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create_invalid_argument(self, mock_open):
         """Test create sysctl with an invalid argument"""
         _file = MagicMock(spec=io.FileIO)
@@ -107,7 +102,7 @@ class SysctlTests(unittest.TestCase):
             'Error parsing YAML sysctl_dict: {"kernel.max_pid": 1337 xxxx',
             level='ERROR')
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create_raises(self, mock_open):
         """CalledProcessErrors are propagated for non-container machines."""
         _file = MagicMock(spec=io.FileIO)
@@ -119,7 +114,7 @@ class SysctlTests(unittest.TestCase):
         with self.assertRaises(CalledProcessError):
             create('{"kernel.max_pid": 1337}', "/etc/sysctl.d/test-sysctl.conf")
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     def test_create_raises_container(self, mock_open):
         """CalledProcessErrors are logged for containers."""
         _file = MagicMock(spec=io.FileIO)

--- a/tests/fetch/python/test_packages.py
+++ b/tests/fetch/python/test_packages.py
@@ -2,7 +2,6 @@
 # coding: utf-8
 
 import mock
-import six
 
 from unittest import TestCase
 from charmhelpers.fetch.python import packages
@@ -170,10 +169,6 @@ class PipTestCase(TestCase):
         """
         join.return_value = 'joined-path'
         packages.pip_create_virtualenv()
-        if six.PY2:
-            self.apt_install.assert_called_with('python-virtualenv')
-            expect_flags = []
-        else:
-            self.apt_install.assert_called_with(['python3-virtualenv', 'virtualenv'])
-            expect_flags = ['--python=python3']
+        self.apt_install.assert_called_with(['python3-virtualenv', 'virtualenv'])
+        expect_flags = ['--python=python3']
         check_call.assert_called_with(['virtualenv', 'joined-path'] + expect_flags)

--- a/tests/fetch/test_archiveurl.py
+++ b/tests/fetch/test_archiveurl.py
@@ -13,13 +13,8 @@ from charmhelpers.fetch import (
     UnhandledSource,
 )
 
-import six
-if six.PY3:
-    from urllib.parse import urlparse
-    from urllib.error import URLError
-else:
-    from urllib2 import URLError
-    from urlparse import urlparse
+from urllib.parse import urlparse
+from urllib.error import URLError
 
 
 class ArchiveUrlFetchHandlerTest(TestCase):

--- a/tests/fetch/test_bzrurl.py
+++ b/tests/fetch/test_bzrurl.py
@@ -8,11 +8,7 @@ from mock import (
     patch,
 )
 
-import six
-if six.PY3:
-    from urllib.parse import urlparse
-else:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 try:
     from charmhelpers.fetch import (

--- a/tests/fetch/test_fetch.py
+++ b/tests/fetch/test_fetch.py
@@ -1,4 +1,3 @@
-import six
 import os
 import yaml
 
@@ -11,12 +10,7 @@ from mock import (
 
 from charmhelpers import fetch
 
-if six.PY3:
-    from urllib.parse import urlparse
-    builtin_open = 'builtins.open'
-else:
-    from urlparse import urlparse
-    builtin_open = '__builtin__.open'
+from urllib.parse import urlparse
 
 
 FAKE_APT_CACHE = {

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -1,4 +1,3 @@
-import six
 import subprocess
 import io
 import os
@@ -13,10 +12,6 @@ from mock import (
 )
 from charmhelpers.fetch import ubuntu as fetch
 
-if six.PY3:
-    builtin_open = 'builtins.open'
-else:
-    builtin_open = '__builtin__.open'
 
 # mocked return of openstack.get_distrib_codename()
 FAKE_CODENAME = 'precise'
@@ -430,16 +425,10 @@ class FetchTest(TestCase):
         check_call.side_effect = check_call_side_effect
 
         expected_key = '35F77D63B5CEC106C577ED856E85A86E4652B4E6'
-        if six.PY3:
-            popen.return_value.communicate.return_value = [b"""
+        popen.return_value.communicate.return_value = [b"""
 pub:-:1024:1:6E85A86E4652B4E6:2009-01-18:::-:Launchpad PPA for Landscape:
 fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
-            """, b'']
-        else:
-            popen.return_value.communicate.return_value = ["""
-pub:-:1024:1:6E85A86E4652B4E6:2009-01-18:::-:Launchpad PPA for Landscape:
-fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
-            """, '']
+        """, b'']
 
         dearmor_gpg_key.return_value = PGP_KEY_BIN_PGP
 
@@ -484,17 +473,10 @@ fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
 
         expected_key = '35F77D63B5CEC106C577ED856E85A86E4652B4E6'
 
-        if six.PY3:
-            popen.return_value.communicate.return_value = [b"""
+        popen.return_value.communicate.return_value = [b"""
 fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
 uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
-            """, b'']
-        else:
-            # python2 on a distro with gpg2 (unlikely, but possible)
-            popen.return_value.communicate.return_value = ["""
-fpr:::::::::35F77D63B5CEC106C577ED856E85A86E4652B4E6:
-uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
-            """, '']
+        """, b'']
 
         dearmor_gpg_key.return_value = PGP_KEY_BIN_PGP
 
@@ -686,7 +668,7 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
                    'ppa:ubuntu-cloud-archive/folsom-staging']
             _subp.assert_called_with(cmd, env={})
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     @patch('charmhelpers.fetch.ubuntu.apt_install')
     @patch('charmhelpers.fetch.ubuntu.get_distrib_codename')
     @patch('charmhelpers.fetch.ubuntu.filter_installed_packages')

--- a/tests/fetch/test_giturl.py
+++ b/tests/fetch/test_giturl.py
@@ -9,11 +9,7 @@ from mock import (
 )
 from charmhelpers.core.host import chdir
 
-import six
-if six.PY3:
-    from urllib.parse import urlparse
-else:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 
 try:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,12 +3,6 @@ from contextlib import contextmanager
 from mock import patch, MagicMock
 import io
 
-import six
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
-
 
 @contextmanager
 def patch_open():
@@ -24,7 +18,7 @@ def patch_open():
         mock_open(*args, **kwargs)
         yield mock_file
 
-    with patch(builtin_open, stub_open):
+    with patch('builtins.open', stub_open):
         yield mock_open, mock_file
 
 
@@ -33,13 +27,13 @@ def mock_open(filename, contents=None):
     ''' Slightly simpler mock of open to return contents for filename '''
     def mock_file(name, mode='r', buffering=-1):  # Python 2 signature.
         if name == filename:
-            if (not six.PY3) or 'b' in mode:
+            if 'b' in mode:
                 return io.BytesIO(contents)
             return io.StringIO(contents)
         else:
             return open(name, mode, buffering)
 
-    with patch(builtin_open, mock_file):
+    with patch('builtins.open', mock_file):
         yield
 
 

--- a/tests/tools/test_charm_helper_sync.py
+++ b/tests/tools/test_charm_helper_sync.py
@@ -4,12 +4,6 @@ import yaml
 
 import tools.charm_helpers_sync.charm_helpers_sync as sync
 
-import six
-if not six.PY3:
-    builtin_open = '__builtin__.open'
-else:
-    builtin_open = 'builtins.open'
-
 
 INCLUDE = """
 include:
@@ -53,7 +47,7 @@ class HelperSyncTests(unittest.TestCase):
         self.assertEquals('/tmp/mycharm/hooks/charmhelpers/contrib/openstack',
                           path)
 
-    @patch(builtin_open)
+    @patch('builtins.open')
     @patch('os.path.exists')
     @patch('os.walk')
     def test_ensure_init(self, walk, exists, _open):
@@ -121,7 +115,7 @@ class HelperSyncTests(unittest.TestCase):
         isfile.side_effect = _isfile
         isdir.side_effect = _isdir
         result = sync.get_filter(opts)(dir='/tmp/charm-helpers/core',
-                                       ls=six.iterkeys(files))
+                                       ls=files.keys())
         return result
 
     @patch('os.path.isdir')

--- a/tools/charm_helpers_sync/charm_helpers_sync.py
+++ b/tools/charm_helpers_sync/charm_helpers_sync.py
@@ -27,8 +27,6 @@ import tempfile
 import yaml
 from fnmatch import fnmatch
 
-import six
-
 CHARM_HELPERS_REPO = 'https://github.com/juju/charm-helpers'
 
 
@@ -171,7 +169,7 @@ def parse_sync_options(options):
 
 def extract_options(inc, global_options=None):
     global_options = global_options or []
-    if global_options and isinstance(global_options, six.string_types):
+    if global_options and isinstance(global_options, str):
         global_options = [global_options]
     if '|' not in inc:
         return (inc, global_options)
@@ -194,7 +192,7 @@ def sync_helpers(include, src, dest, options=None):
             sync(src, dest, inc, opts)
         elif isinstance(inc, dict):
             # could also do nested dicts here.
-            for k, v in six.iteritems(inc):
+            for k, v in inc.items():
                 if isinstance(v, list):
                     for m in v:
                         inc, opts = extract_options(m, global_options)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py2,py3
+envlist = pep8,py3
 skipsdist = true
 sitepackages = false
 # NOTE(beisner): Avoid false positives by not skipping missing interpreters.
@@ -24,24 +24,12 @@ minversion = 3.2.0
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 install_command = {toxinidir}/pip.sh install {opts} {packages}
-passenv = HOME TERM 
+passenv = HOME TERM
 commands = nosetests -s --nologcapture {posargs} --with-coverage --cover-package=charmhelpers tests/
-deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:py2]
-basepython = python
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:py34]
-basepython = python3.4
-deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:py35]
-basepython = python3.5
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:py36]


### PR DESCRIPTION
This patch, which when merged, will result in a charmhelpers 1.0.0
release, removes all py27 support code and pre py35 support.  This is
basically the removal of six and most hacks to support dual running on
py27.

Closes: #580 