### PR TITLE
Avoid using a private attribute from MySQLdb

### DIFF
--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -729,7 +729,7 @@ class MySQL8Helper(MySQLHelper):
                 remote_ip=remote_ip,
                 password=password)
             )
-        except MySQLdb._exceptions.OperationalError:
+        except MySQLdb.OperationalError:
             log("DB user {} already exists.".format(db_user),
                 "WARNING")
         finally:


### PR DESCRIPTION
Bionic ships with mysqlclient version 1.3 and the MySQLdb._exceptions attribute was introduced on 1.4.0 (renamed from MySQLdb._mysql_exceptions, see commit 8ad1525c on mysqlclient's repo).

Even if that wouldn't have changed, it's not good practice to use private attributes of external packages.

Fixes launchpad issue [#1905586](https://bugs.launchpad.net/charm-helpers/+bug/1905586).