### PR TITLE
Fix get_mon_map() for octopus and later

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -814,8 +814,10 @@ def get_mon_map(service):
              ceph command fails.
     """
     try:
+        octopus_or_later = cmp_pkgrevno('ceph-common', '15.0.0') >= 0
+        mon_status_cmd = 'quorum_status' if octopus_or_later else 'mon_status'
         mon_status = check_output(['ceph', '--id', service,
-                                   'mon_status', '--format=json'])
+                                   mon_status_cmd, '--format=json'])
         if six.PY3:
             mon_status = mon_status.decode('UTF-8')
         try:


### PR DESCRIPTION
The "ceph mon_status" command seems to have disappeared on octopus and
later, and is replaced by "ceph quorum_status".  This changes the
get_mon_map() function to detect the underlying ceph version and do the
right thing.

Related bug: https://bugs.launchpad.net/charm-ceph-mon/+bug/1951094