### PR TITLE
Fix get_mon_map() for octopus and later

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -813,8 +813,10 @@ def get_mon_map(service):
              ceph command fails.
     """
     try:
+        octopus_or_later = cmp_pkgrevno('ceph-common', '15.0.0') >= 0
+        mon_status_cmd = 'quorum_status' if octopus_or_later else 'mon_status'
         mon_status = check_output(['ceph', '--id', service,
-                                   'mon_status', '--format=json'])
+                                   mon_status_cmd, '--format=json'])
         if six.PY3:
             mon_status = mon_status.decode('UTF-8')
         try:

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -985,12 +985,25 @@ class CephUtilsTests(TestCase):
         self.assertRaises(CalledProcessError, ceph_utils.monitor_key_delete,
                           service='admin', key='foo')
 
-    def test_get_monmap(self):
+    @patch.object(ceph_utils, 'cmp_pkgrevno')
+    def test_get_monmap_pre_octopus(self, mock_cmp_pkgrevno):
+        mock_cmp_pkgrevno.return_value = -1
         self.check_output.return_value = MONMAP_DUMP
         cmd = ['ceph', '--id', 'admin',
                'mon_status', '--format=json']
         ceph_utils.get_mon_map(service='admin')
         self.check_output.assert_called_with(cmd)
+        mock_cmp_pkgrevno.assert_called_once_with('ceph-common', '15.0.0')
+
+    @patch.object(ceph_utils, 'cmp_pkgrevno')
+    def test_get_monmap_octopus_and_later(self, mock_cmp_pkgrevno):
+        mock_cmp_pkgrevno.return_value = 0
+        self.check_output.return_value = MONMAP_DUMP
+        cmd = ['ceph', '--id', 'admin',
+               'quorum_status', '--format=json']
+        ceph_utils.get_mon_map(service='admin')
+        self.check_output.assert_called_with(cmd)
+        mock_cmp_pkgrevno.assert_called_once_with('ceph-common', '15.0.0')
 
     @patch.object(ceph_utils, 'get_mon_map')
     def test_hash_monitor_names(self, monmap):


### PR DESCRIPTION
The "ceph mon_status" command seems to have disappeared on octopus and
later, and is replaced by "ceph quorum_status".  This changes the
get_mon_map() function to detect the underlying ceph version and do the
right thing.

Cherry-picked from: 1cf0226b
Related-Bug: https://bugs.launchpad.net/charm-ceph-mon/+bug/1951094