### PR TITLE
Support HAproxy https health checks

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -82,7 +82,11 @@ backend {{ service }}_{{ frontend }}
     {% endif -%}
     {% endif -%}
     {% for unit, address in frontends[frontend]['backends'].items() -%}
+    {% if https -%}
+    server {{ unit }} {{ address }}:{{ ports[1] }} check check-ssl verify none
+    {% else -%}
     server {{ unit }} {{ address }}:{{ ports[1] }} check
+    {% endif -%}
     {% endfor %}
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
This change adds the option of running HTTPS health checks. It is
proposed in the context of LP: #1946280 where the backend radosgw server
can be configured to run in https mode.
We disable certificate verification because we are only interested in
the health of the service.


Related ceph-radosgw change:
* https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/817582