### PR TITLE
Remove __future__ imports as no longer needed.

### DIFF
--- a/charmhelpers/__init__.py
+++ b/charmhelpers/__init__.py
@@ -14,9 +14,6 @@
 
 # Bootstrap charm-helpers, installing its dependencies if necessary using
 # only standard libraries.
-from __future__ import print_function
-from __future__ import absolute_import
-
 import functools
 import inspect
 import subprocess

--- a/charmhelpers/contrib/hardening/audits/apt.py
+++ b/charmhelpers/contrib/hardening/audits/apt.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import  # required for external apt import
-
 from charmhelpers.fetch import (
     apt_cache,
     apt_purge

--- a/charmhelpers/contrib/python.py
+++ b/charmhelpers/contrib/python.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 # deprecated aliases for backwards compatibility
 from charmhelpers.fetch.python import debug  # noqa
 from charmhelpers.fetch.python import packages  # noqa

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -17,7 +17,6 @@
 # Authors:
 #  Charm Helpers Developers <juju@lists.ubuntu.com>
 
-from __future__ import print_function
 import copy
 from distutils.version import LooseVersion
 from enum import Enum

--- a/charmhelpers/fetch/python/debug.py
+++ b/charmhelpers/fetch/python/debug.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import atexit
 import sys
 

--- a/tests/contrib/network/test_ufw.py
+++ b/tests/contrib/network/test_ufw.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import mock
 import os
 import subprocess

--- a/tests/contrib/python/test_python.py
+++ b/tests/contrib/python/test_python.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from __future__ import absolute_import
-
 from unittest import TestCase
 
 from charmhelpers.fetch.python import debug


### PR DESCRIPTION
The __future__ module [1] was used in this context to ensure compatibility
between python 2 and python 3.

We previously dropped the support of python 2.7 [2] and now we only
support python 3 so we don't need to continue to use this module and the
imports listed below.

Imports commonly used and their related PEPs:
- `division` is related to PEP 238 [3]
- `print_function` is related to PEP 3105 [4]
- `unicode_literals` is related to PEP 3112 [5]
- `with_statement` is related to PEP 343 [6]
- `absolute_import` is related to PEP 328 [7]

This commit message was borrowed from [8] as it explains it far better
than I would!

[1] https://docs.python.org/3/library/__future__.html
[2] https://governance.openstack.org/tc/goals/selected/ussuri/drop-py27.html
[3] https://www.python.org/dev/peps/pep-0238
[4] https://www.python.org/dev/peps/pep-3105
[5] https://www.python.org/dev/peps/pep-3112
[6] https://www.python.org/dev/peps/pep-0343
[7] https://www.python.org/dev/peps/pep-0328
[8] https://review.opendev.org/c/openstack/charm-cinder-backup/+/732775