### PR TITLE
 Ensure get_os_codename_install_source() for bug/665

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -361,6 +361,8 @@ def get_os_codename_install_source(src):
     rel = ''
     if src is None:
         return rel
+    if src in OPENSTACK_RELEASES:
+        return src
     if src in ['distro', 'distro-proposed', 'proposed']:
         try:
             rel = UBUNTU_OPENSTACK_RELEASE[ubuntu_rel]

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -226,6 +226,14 @@ class OpenStackHelpersTestCase(TestCase):
         self.assertEquals(openstack.get_os_codename_install_source(None),
                           '')
 
+        # check that bare ubuntu releases end up as the release.
+        self.assertEquals(openstack.get_os_codename_install_source('essex'),
+                          'essex')
+        self.assertEquals(openstack.get_os_codename_install_source('ussuri'),
+                          'ussuri')
+        self.assertEquals(openstack.get_os_codename_install_source('queens'),
+                          'queens')
+
     @patch.object(openstack, 'get_os_version_codename')
     @patch.object(openstack, 'get_os_codename_install_source')
     def test_os_version_from_install_source(self, codename, version):


### PR DESCRIPTION
get_os_codename_install_source() needs to work with bare OpenStack names
e.g "ussuri", rather than "bionic-ussuri".  This patch updates it to
work with bare names.

Fixes: #665