### PR TITLE
Utilities for configuring deferred restarts NRPE checks

### DIFF
--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -28,6 +28,7 @@ import subprocess
 import yaml
 
 from charmhelpers.core.hookenv import (
+    application_name,
     config,
     hook_name,
     local_unit,
@@ -520,3 +521,29 @@ def remove_deprecated_check(nrpe, deprecated_services):
     for dep_svc in deprecated_services:
         log('Deprecated service: {}'.format(dep_svc))
         nrpe.remove_check(shortname=dep_svc)
+
+
+def add_deferred_restarts_check(nrpe):
+    unit_name = local_unit().replace('/', '-')
+    shortname = unit_name + '_deferred_restarts'
+    check_cmd = 'check_deferred_restarts.py --application {}'.format(
+        application_name())
+
+    log('Adding deferred restarts nrpe check: {}'.format(shortname))
+    nrpe.add_check(
+        shortname=shortname,
+        description='Check deferred service restarts {}'.format(unit_name),
+        check_cmd=check_cmd)
+
+
+def remove_deferred_restarts_check(nrpe):
+    unit_name = local_unit().replace('/', '-')
+    shortname = unit_name + '_deferred_restarts'
+    check_cmd = 'check_deferred_restarts.py --application {}'.format(
+        application_name())
+
+    log('Removing deferred restarts nrpe check: {}'.format(shortname))
+    nrpe.remove_check(
+        shortname=shortname,
+        description='Check deferred service restarts {}'.format(unit_name),
+        check_cmd=check_cmd)

--- a/charmhelpers/contrib/charmsupport/nrpe.py
+++ b/charmhelpers/contrib/charmsupport/nrpe.py
@@ -524,6 +524,11 @@ def remove_deprecated_check(nrpe, deprecated_services):
 
 
 def add_deferred_restarts_check(nrpe):
+    """
+    Add NRPE check for services with deferred restarts.
+
+    :param NRPE nrpe: NRPE object to add check to
+    """
     unit_name = local_unit().replace('/', '-')
     shortname = unit_name + '_deferred_restarts'
     check_cmd = 'check_deferred_restarts.py --application {}'.format(
@@ -537,6 +542,11 @@ def add_deferred_restarts_check(nrpe):
 
 
 def remove_deferred_restarts_check(nrpe):
+    """
+    Remove NRPE check for services with deferred service restarts.
+
+    :param NRPE nrpe: NRPE object to remove check from
+    """
     unit_name = local_unit().replace('/', '-')
     shortname = unit_name + '_deferred_restarts'
     check_cmd = 'check_deferred_restarts.py --application {}'.format(

--- a/charmhelpers/contrib/openstack/files/check_deferred_restarts.py
+++ b/charmhelpers/contrib/openstack/files/check_deferred_restarts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+"""
+Checks for services with deferred service restarts.
+
+This Nagios check will parse /var/lib/policy-rd.d/
+to find any restarts that are currently deferred.
+"""
+
+import argparse
+import glob
+import sys
+import yaml
+
+
+DEFERRED_EVENTS_DIR = '/var/lib/policy-rc.d'
+
+
+def get_deferred_events():
+    """
+    Return a list of deferred events dicts from policy-rc.d files
+
+    Events are of the form:
+     {
+        action: restart,
+        policy_requestor_name: rabbitmq-server,
+        policy_requestor_type: charm,
+        reason: 'Pkg update',
+        service: rabbitmq-server,
+        time: 1614328743
+    }
+
+    :returns: List of deferred event dicts
+    :rtype: List
+    """
+    deferred_events_files = glob.glob(
+        '{}/*.deferred'.format(DEFERRED_EVENTS_DIR))
+
+    deferred_events = []
+    for event_file in deferred_events_files:
+        with open(event_file, 'r') as f:
+            event = yaml.safe_load(f)
+            deferred_events.append(event)
+
+    return deferred_events
+
+
+def get_deferred_restart_services(application=None):
+    """
+    Reads deferred events and returns a list of services with deferred restarts.
+
+    :param str application: Name of the application that blocked the service restart.
+                            If application is None, all services with deferred restarts
+                            are returned. Services which are blocked by a non-charm
+                            requestor are always returned.
+    :returns: List of services with deferred restarts belonging to application.
+    :rtype: List[str]
+    """
+
+    deferred_restart_events = filter(
+        lambda e: e['action'] == 'restart', get_deferred_events())
+
+    deferred_restart_services = set()
+    for restart_event in deferred_restart_events:
+        if application:
+            if (
+                restart_event['policy_requestor_type'] != 'charm' or
+                restart_event['policy_requestor_type'] == 'charm' and
+                restart_event['policy_requestor_name'] == application
+            ):
+                deferred_restart_services.add(restart_event['service'])
+        else:
+            deferred_restart_services.add(restart_event['service'])
+
+    return list(deferred_restart_services)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Check for services with deferred restarts')
+    parser.add_argument(
+        '--application', help='Check services belonging to this application only')
+
+    args = parser.parse_args()
+
+    services = set(get_deferred_restart_services(args.application))
+
+    if not len(services):
+        print('OK: No deferred service restarts.')
+        sys.exit(0)
+    else:
+        print(
+            'CRITICAL: Restarts are deferred for services: {}.'.format(', '.join(services)))
+        sys.exit(2)

--- a/tests/contrib/openstack/test_files_check_deferred_restarts.py
+++ b/tests/contrib/openstack/test_files_check_deferred_restarts.py
@@ -1,0 +1,86 @@
+from mock import patch
+
+import charmhelpers.contrib.openstack.files.check_deferred_restarts as check_deferred_restarts
+from charmhelpers.contrib.openstack.files.check_deferred_restarts import get_deferred_restart_services
+import tests.utils
+
+
+class CheckDeferredRestartsTestCase(tests.utils.BaseTestCase):
+
+    @patch.object(check_deferred_restarts, "get_deferred_events")
+    def test_get_deferred_restart_services_no_restarts(self, mock_get_deferred_events):
+        mock_get_deferred_events.return_value = [
+            {
+                "action": "other_action",
+                "service": "service1",
+            }
+        ]
+
+        services = get_deferred_restart_services()
+        self.assertListEqual(services, [])
+
+    @patch.object(check_deferred_restarts, "get_deferred_events")
+    def test_get_deferred_restart_services_same_application(self, mock_get_deferred_events):
+        mock_get_deferred_events.return_value = [
+            {
+                "action": "restart",
+                "service": "service1",
+                "policy_requestor_type": "charm",
+                "policy_requestor_name": "app1",
+            }, {
+                "action": "restart",
+                "service": "service2",
+                "policy_requestor_type": "charm",
+                "policy_requestor_name": "app1",
+            }
+        ]
+
+        services = get_deferred_restart_services()
+        self.assertSetEqual(set(services), set(["service1", "service2"]))
+
+        services = get_deferred_restart_services("app1")
+        self.assertSetEqual(set(services), set(["service1", "service2"]))
+
+    @patch.object(check_deferred_restarts, "get_deferred_events")
+    def test_get_deferred_restart_services_different_applications(self, mock_get_deferred_events):
+        mock_get_deferred_events.return_value = [
+            {
+                "action": "restart",
+                "service": "service1",
+                "policy_requestor_type": "charm",
+                "policy_requestor_name": "app1",
+            }, {
+                "action": "restart",
+                "service": "service2",
+                "policy_requestor_type": "charm",
+                "policy_requestor_name": "app2",
+            }
+        ]
+
+        services = get_deferred_restart_services()
+        self.assertSetEqual(set(services), set(["service1", "service2"]))
+
+        services = get_deferred_restart_services("app1")
+        self.assertSetEqual(set(services), set(["service1"]))
+
+    @patch.object(check_deferred_restarts, "get_deferred_events")
+    def test_get_deferred_restart_services_other_requestor(self, mock_get_deferred_events):
+        mock_get_deferred_events.return_value = [
+            {
+                "action": "restart",
+                "service": "service1",
+                "policy_requestor_type": "charm",
+                "policy_requestor_name": "app1",
+            }, {
+                "action": "restart",
+                "service": "service2",
+                "policy_requestor_type": "not_charm",
+                "policy_requestor_name": "app2",
+            }
+        ]
+
+        services = get_deferred_restart_services()
+        self.assertSetEqual(set(services), set(["service1", "service2"]))
+
+        services = get_deferred_restart_services("app1")
+        self.assertSetEqual(set(services), set(["service1", "service2"]))


### PR DESCRIPTION
* Added new NRPE plugin 'check_deferred_restarts.py'. Charms can use
  copy_nrpe_checks() as needed to move it to the nagios plugin directory.
* Added {add,remove}_deferred_restarts_check utilities for adding and
  removing the NRPE checks.