### PR TITLE
Remove tempita as it doesn't seem to be required anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ PyYAML
 Jinja2
 
 netaddr
-Tempita
 
 pbr!=2.1.0,>=2.0.0 # Apache-2.0


### PR DESCRIPTION
It is a dependency that has been hanging around since 2014.  Let's get rid of it as it breaks when 2to3 tools are missing.