### PR TITLE
Fix handling of profile-name

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -648,7 +648,7 @@ class ReplicatedPool(BasePool):
             # we will fail with KeyError if it is not provided.
             self.replicas = op['replicas']
             self.pg_num = op.get('pg_num')
-            self.profile_name = op.get('crush-profile', profile_name)
+            self.profile_name = op.get('crush-profile') or profile_name
         else:
             self.replicas = replicas or 2
             self.pg_num = pg_num


### PR DESCRIPTION
The current code:
self.profile_name = op.get('crush-profile', profile_name)

will only default to profile_name if the 'crush-profile' key
doesn't exist in the op dictionary. If the 'crush-profile' key
exists and is set to None, the default profile_name is not used.

This change will use the default profile_name in both cases.

Closes-Bug: #1960622