### PR TITLE
Adding new function for enabling service

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -114,6 +114,33 @@ def service_stop(service_name, **kwargs):
     return service('stop', service_name, **kwargs)
 
 
+def service_enable(service_name, **kwargs):
+    """Enable a system service.
+
+    The specified service name is managed via the system level init system.
+    Some init systems (e.g. upstart) require that additional arguments be
+    provided in order to directly control service instances whereas other init
+    systems allow for addressing instances of a service directly by name (e.g.
+    systemd).
+
+    The kwargs allow for the additional parameters to be passed to underlying
+    init systems for those systems which require/allow for them. For example,
+    the ceph-osd upstart script requires the id parameter to be passed along
+    in order to identify which running daemon should be restarted. The follow-
+    ing example restarts the ceph-osd service for instance id=4:
+
+    service_enable('ceph-osd', id=4)
+
+    :param service_name: the name of the service to enable
+    :param **kwargs: additional parameters to pass to the init system when
+                     managing services. These will be passed as key=value
+                     parameters to the init system's commandline. kwargs
+                     are ignored for init systems not allowing additional
+                     parameters via the commandline (systemd).
+    """
+    return service('enable', service_name)
+
+
 def service_restart(service_name, **kwargs):
     """Restart a system service.
 
@@ -134,7 +161,7 @@ def service_restart(service_name, **kwargs):
     :param service_name: the name of the service to restart
     :param **kwargs: additional parameters to pass to the init system when
                      managing services. These will be passed as key=value
-                     parameters to the  init system's commandline. kwargs
+                     parameters to the init system's commandline. kwargs
                      are ignored for init systems not allowing additional
                      parameters via the commandline (systemd).
     """

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -114,29 +114,13 @@ def service_stop(service_name, **kwargs):
     return service('stop', service_name, **kwargs)
 
 
-def service_enable(service_name, **kwargs):
+def service_enable(service_name):
     """Enable a system service.
 
     The specified service name is managed via the system level init system.
-    Some init systems (e.g. upstart) require that additional arguments be
-    provided in order to directly control service instances whereas other init
-    systems allow for addressing instances of a service directly by name (e.g.
-    systemd).
-
-    The kwargs allow for the additional parameters to be passed to underlying
-    init systems for those systems which require/allow for them. For example,
-    the ceph-osd upstart script requires the id parameter to be passed along
-    in order to identify which running daemon should be restarted. The follow-
-    ing example restarts the ceph-osd service for instance id=4:
-
-    service_enable('ceph-osd', id=4)
+    Enabling a service allows it to run automatically on boot.
 
     :param service_name: the name of the service to enable
-    :param **kwargs: additional parameters to pass to the init system when
-                     managing services. These will be passed as key=value
-                     parameters to the init system's commandline. kwargs
-                     are ignored for init systems not allowing additional
-                     parameters via the commandline (systemd).
     """
     return service('enable', service_name)
 

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -114,15 +114,31 @@ def service_stop(service_name, **kwargs):
     return service('stop', service_name, **kwargs)
 
 
-def service_enable(service_name):
+def service_enable(service_name, **kwargs):
     """Enable a system service.
 
     The specified service name is managed via the system level init system.
-    Enabling a service allows it to run automatically on boot.
+    Some init systems (e.g. upstart) require that additional arguments be
+    provided in order to directly control service instances whereas other init
+    systems allow for addressing instances of a service directly by name (e.g.
+    systemd).
+
+    The kwargs allow for the additional parameters to be passed to underlying
+    init systems for those systems which require/allow for them. For example,
+    the ceph-osd upstart script requires the id parameter to be passed along
+    in order to identify which running daemon should be restarted. The follow-
+    ing example restarts the ceph-osd service for instance id=4:
+
+    service_enable('ceph-osd', id=4)
 
     :param service_name: the name of the service to enable
+    :param **kwargs: additional parameters to pass to the init system when
+                     managing services. These will be passed as key=value
+                     parameters to the init system's commandline. kwargs
+                     are ignored for init systems not allowing additional
+                     parameters via the commandline (systemd).
     """
-    return service('enable', service_name)
+    return service('enable', service_name, **kwargs)
 
 
 def service_restart(service_name, **kwargs):

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -184,7 +184,7 @@ class HelpersTest(TestCase):
         self.assertTrue(host.service_stop(service_name))
 
         service.assert_called_with('stop', service_name)
-    
+
     @patch.object(host, 'service')
     def test_enables_a_service(self, service):
         service_name = 'foo-service'

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -184,6 +184,14 @@ class HelpersTest(TestCase):
         self.assertTrue(host.service_stop(service_name))
 
         service.assert_called_with('stop', service_name)
+    
+    @patch.object(host, 'service')
+    def test_enables_a_service(self, service):
+        service_name = 'foo-service'
+        service.side_effect = [True]
+        self.assertTrue(host.service_enable(service_name))
+
+        service.assert_called_with('enable', service_name)
 
     @patch.object(host, 'service')
     def test_restarts_a_service(self, service):


### PR DESCRIPTION
* add a service_enable function in charmhelpers/core/host.py
* add a unit test for service_enable function in tests/core/test_host.py

Some charms, such as charm-glance (concerning bug/1960636), requires calling
an additional function during installation to enable services. This new function
can be used to address such a problem.