### PR TITLE
collect stdout from ansible-playbook execution

### DIFF
--- a/charmhelpers/contrib/ansible/__init__.py
+++ b/charmhelpers/contrib/ansible/__init__.py
@@ -218,7 +218,8 @@ def apply_playbook(playbook, tags=None, extra_vars=None):
         subprocess.check_output(call, env=env)
     except subprocess.CalledProcessError as e:
         charmhelpers.core.hookenv.log("Ansible playbook failed with {} "
-                                      "Stdout: {}".format(e, e.output))
+                                      "Stdout: {}".format(e, e.output),
+                                      level="ERROR")
         raise subprocess.CalledProcessError(e)
 
 

--- a/charmhelpers/contrib/ansible/__init__.py
+++ b/charmhelpers/contrib/ansible/__init__.py
@@ -214,7 +214,12 @@ def apply_playbook(playbook, tags=None, extra_vars=None):
         call.extend(['--tags', '{}'.format(tags)])
     if extra_vars:
         call.extend(['--extra-vars', json.dumps(extra_vars)])
-    subprocess.check_call(call, env=env)
+    try:
+        subprocess.check_output(call, env=env)
+    except subprocess.CalledProcessError as e:
+        charmhelpers.core.hookenv.log("Ansible playbook failed with {} "
+                                      "Stdout: {}".format(e, e.output))
+        raise subprocess.CalledProcessError(e)
 
 
 class AnsibleHooks(charmhelpers.core.hookenv.Hooks):

--- a/tests/contrib/ansible/test_ansible.py
+++ b/tests/contrib/ansible/test_ansible.py
@@ -137,7 +137,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
         charmhelpers.contrib.ansible.apply_playbook(
             'playbooks/dependencies.yaml')
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'playbooks/dependencies.yaml'],
             env={'PYTHONUNBUFFERED': '1'})
 
@@ -196,7 +196,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
         charmhelpers.contrib.ansible.apply_playbook(
             'playbooks/complete-state.yaml', tags=['install', 'somethingelse'])
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'playbooks/complete-state.yaml',
             '--tags', 'install,somethingelse'], env={'PYTHONUNBUFFERED': '1'})
 
@@ -206,7 +206,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
             'playbooks/complete-state.yaml', tags=['install', 'somethingelse'],
             extra_vars={'a': 'b'})
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'playbooks/complete-state.yaml',
             '--tags', 'install,somethingelse', '--extra-vars', '{"a": "b"}'],
             env={'PYTHONUNBUFFERED': '1'})
@@ -217,7 +217,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
             'playbooks/complete-state.yaml', tags=['install', 'somethingelse'],
             extra_vars='@myvars.json')
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'playbooks/complete-state.yaml',
             '--tags', 'install,somethingelse', '--extra-vars', '"@myvars.json"'],
             env={'PYTHONUNBUFFERED': '1'})
@@ -228,7 +228,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
             'playbooks/complete-state.yaml', tags=['install', 'somethingelse'],
             extra_vars={'pkg': {'a': 'present', 'b': 'absent'}})
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'playbooks/complete-state.yaml',
             '--tags', 'install,somethingelse', '--extra-vars',
             '{"pkg": {"a": "present", "b": "absent"}}'],
@@ -243,7 +243,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
         hooks.execute(['foo'])
 
         self.assertEqual(foo.call_count, 1)
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'my/playbook.yaml',
             '--tags', 'foo'], env={'PYTHONUNBUFFERED': '1'})
 
@@ -254,7 +254,7 @@ class ApplyPlaybookTestCases(unittest.TestCase):
 
         hooks.execute(['start'])
 
-        self.mock_subprocess.check_call.assert_called_once_with([
+        self.mock_subprocess.check_output.assert_called_once_with([
             'ansible-playbook', '-vvv', '-c', 'local', 'my/playbook.yaml',
             '--tags', 'start'], env={'PYTHONUNBUFFERED': '1'})
 


### PR DESCRIPTION
When Ansible playbooks fail, log the stdout so that we can read it and find out why the playbook failed.