### PR TITLE
Add service_type to keystone-authtoken section

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -426,6 +426,9 @@ class IdentityServiceContext(OSContextGenerator):
             ('password', ctxt.get('admin_password', '')),
             ('signing_dir', ctxt.get('signing_dir', '')),))
 
+        if ctxt.get('service_type'):
+            c.update((('service_type', ctxt.get('service_type')),))
+
         return c
 
     def __call__(self):
@@ -467,6 +470,9 @@ class IdentityServiceContext(OSContextGenerator):
                              'auth_protocol': auth_protocol,
                              'internal_protocol': int_protocol,
                              'api_version': api_version})
+
+                if rdata.get('service_type'):
+                    ctxt['service_type'] = rdata.get('service_type')
 
                 if float(api_version) > 2:
                     ctxt.update({
@@ -538,6 +544,9 @@ class IdentityCredentialsContext(IdentityServiceContext):
                     'auth_protocol': auth_protocol,
                     'api_version': api_version
                 })
+
+                if rdata.get('service_type'):
+                    ctxt['service_type'] = rdata.get('service_type')
 
                 if float(api_version) > 2:
                     ctxt.update({'admin_domain_name':

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
@@ -9,4 +9,7 @@ project_name = {{ admin_tenant_name }}
 username = {{ admin_user }}
 password = {{ admin_password }}
 signing_dir = {{ signing_dir }}
+{% if service_type -%}
+service_type = {{ service_type }}
+{% endif -%}
 {% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -6,6 +6,9 @@ auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v3
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
 project_domain_name = {{ admin_domain_name }}
 user_domain_name = {{ admin_domain_name }}
+{% if service_type -%}
+service_type = {{ service_type }}
+{% endif -%}
 {% else -%}
 auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -141,6 +141,7 @@ IDENTITY_SERVICE_RELATION_HTTP = {
     'service_password': 'foo',
     'service_username': 'adam',
     'service_protocol': 'http',
+    'service_type': 'volume',
     'auth_protocol': 'http',
     'internal_protocol': 'http',
 }
@@ -170,6 +171,7 @@ IDENTITY_CREDENTIALS_RELATION_UNSET = {
     'credentials_password': 'foo',
     'credentials_username': 'adam',
     'credentials_protocol': 'https',
+    'service_type': 'volume',
 }
 
 
@@ -186,6 +188,7 @@ APIIDENTITY_SERVICE_RELATION_UNSET = {
             'service_tenant': 'admin',
             'service_password': 'foo',
             'service_username': 'adam',
+            'service_type': 'volume',
         }
     }
 }
@@ -202,6 +205,7 @@ IDENTITY_SERVICE_RELATION_HTTPS = {
     'service_password': 'foo',
     'service_username': 'adam',
     'service_protocol': 'https',
+    'service_type': 'volume',
     'auth_protocol': 'https',
     'internal_protocol': 'https',
 }
@@ -1052,6 +1056,7 @@ class ContextTests(unittest.TestCase):
             'auth_protocol': 'https',
             'service_host': 'keystonehost.local',
             'service_port': '5000',
+            'service_type': 'volume',
             'service_protocol': 'https',
             'api_version': '2.0',
         }
@@ -1083,6 +1088,7 @@ class ContextTests(unittest.TestCase):
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'http',
+            'service_type': 'volume',
             'internal_host': 'keystone-internal.local',
             'internal_port': '5000',
             'internal_protocol': 'http',
@@ -1143,6 +1149,7 @@ class ContextTests(unittest.TestCase):
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'http',
+            'service_type': 'volume',
             'internal_host': 'keystone-internal.local',
             'internal_port': '5000',
             'internal_protocol': 'http',
@@ -1171,6 +1178,7 @@ class ContextTests(unittest.TestCase):
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'https',
+            'service_type': 'volume',
             'internal_host': 'keystone-internal.local',
             'internal_port': '5000',
             'internal_protocol': 'https',
@@ -1203,6 +1211,7 @@ class ContextTests(unittest.TestCase):
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'https',
+            'service_type': 'volume',
             'internal_host': 'keystone-internal.local',
             'internal_port': '5000',
             'internal_protocol': 'https',
@@ -1230,6 +1239,7 @@ class ContextTests(unittest.TestCase):
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'https',
+            'service_type': 'volume',
             'api_version': '3',
         }
         self.assertEquals(result, expected)
@@ -1256,6 +1266,7 @@ class ContextTests(unittest.TestCase):
             'service_host': '[2001:db8:1::1]',
             'service_port': '5000',
             'service_protocol': 'http',
+            'service_type': 'volume',
             'internal_host': '[2001:db8:1::1]',
             'internal_port': '5000',
             'internal_protocol': 'http',
@@ -1302,6 +1313,7 @@ class ContextTests(unittest.TestCase):
             ('username', 'adam'),
             ('password', 'foo'),
             ('signing_dir', ''),
+            ('service_type', 'volume'),
         ))
 
         self.assertEquals(keystone_authtoken, expected)


### PR DESCRIPTION
This also moves the service types map here from the keystone
charm so that it can be used for all charms.

Related-Bug: #1965967