### PR TITLE
Make inability to determine Openstack codename version non-fatal

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -400,13 +400,16 @@ def get_os_codename_version(vers):
         error_out(e)
 
 
-def get_os_version_codename(codename, version_map=OPENSTACK_CODENAMES):
+def get_os_version_codename(codename, version_map=OPENSTACK_CODENAMES,
+                            raise_exception=False):
     '''Determine OpenStack version number from codename.'''
     for k, v in version_map.items():
         if v == codename:
             return k
     e = 'Could not derive OpenStack version for '\
         'codename: %s' % codename
+    if raise_exception:
+        raise ValueError(str(e))
     error_out(e)
 
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -280,6 +280,13 @@ class OpenStackHelpersTestCase(TestCase):
         expected_err = 'Could not derive OpenStack version for codename: foo'
         mocked_error.assert_called_with(expected_err)
 
+        try:
+            openstack.get_os_version_codename('foo', raise_exception=True)
+            raise Exception("Failed call should have raised ValueError")
+        except ValueError as e:
+            self.assertEquals(e.args[0],
+                              "Could not derive OpenStack version for codename: foo")
+
     def test_os_version_swift_from_codename(self):
         """Test mapping a swift codename to numerical version"""
         self.assertEquals(openstack.get_os_version_codename_swift('liberty'),


### PR DESCRIPTION
This change allows `error_out` callers to specify a function signalling an error, appropriate to it's context.

Related change: https://review.opendev.org/c/openstack/charm-keystone/+/835087
Related issue: [LP#1965966](https://bugs.launchpad.net/charm-keystone/+bug/1965966/)