### PR TITLE
contrib: Add `hardware` package with `pci` module

### DIFF
--- a/charmhelpers/contrib/hardware/__init__.py
+++ b/charmhelpers/contrib/hardware/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Canonical Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charmhelpers/contrib/hardware/pci.py
+++ b/charmhelpers/contrib/hardware/pci.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016-2022 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import itertools
+import logging
+import os
+import re
+import shlex
+import subprocess
+import typing
+
+
+def format_pci_addr(pci_addr: str) -> str:
+    """Format a PCI address with 0 fill for parts
+
+    :param: pci_addr: unformatted PCI address
+    :type: str
+    :returns: formatted PCI address
+    :rtype: str
+    """
+    domain, bus, slot_func = pci_addr.split(":")
+    slot, func = slot_func.split(".")
+    return "{}:{}:{}.{}".format(
+        domain.zfill(4), bus.zfill(2), slot.zfill(2), func
+    )
+
+
+def get_sysnet_interfaces_and_macs() -> list:
+    """Catalog interface information from local system
+
+    each device dict contains:
+
+        interface: logical name
+        mac_address: MAC address
+        pci_address: PCI address
+        state: Current interface state (up/down)
+        sriov: Boolean indicating whether interface is an SR-IOV
+               capable device.
+        sriov_totalvfs: Total VF capacity of device
+        sriov_numvfs: Configured VF capacity of device
+
+    :returns: array of dict objects containing details of each interface
+    :rtype: list
+    """
+    net_devs = []
+    for sdir in itertools.chain(
+            glob.glob("/sys/bus/pci/devices/*/net/../"),
+            glob.glob("/sys/bus/pci/devices/*/virtio*/net/../")):
+        fq_path = os.path.realpath(sdir)
+        path = fq_path.split("/")
+        if "virtio" in path[-1]:
+            pci_address = path[-2]
+        else:
+            pci_address = path[-1]
+        ifname = get_sysnet_interface(sdir)
+        if not ifname:
+            logging.warn("Unable to determine interface name for PCI "
+                         "device {}".format(pci_address))
+            continue
+        device = {
+            "interface": ifname,
+            "mac_address": get_sysnet_mac(sdir, ifname),
+            "pci_address": pci_address,
+            "state": get_sysnet_device_state(sdir, ifname),
+            "sriov": is_sriov(sdir),
+        }
+        if device["sriov"]:
+            device["sriov_totalvfs"] = get_sriov_totalvfs(sdir)
+            device["sriov_numvfs"] = get_sriov_numvfs(sdir)
+        net_devs.append(device)
+
+    return net_devs
+
+
+def get_sysnet_mac(sysdir: str, ifname: str) -> str:
+    """Determine MAC address for a device
+
+    :param: sysdir: path to device /sys directory
+    :type: str
+    :returns: MAC address of device
+    :rtype: str
+    """
+    mac_addr_file = os.path.join(sysdir, "net", ifname, "address")
+    with open(mac_addr_file, "r") as f:
+        read_data = f.read()
+    return read_data.strip()
+
+
+def get_sysnet_device_state(sysdir: str, ifname: str) -> str:
+    """Read operational state of a device
+
+    :param: sysdir: path to device /sys directory
+    :type: str
+    :returns: current device state
+    :rtype: str
+    """
+    state_file = os.path.join(sysdir, "net", ifname, "operstate")
+    with open(state_file, "r") as f:
+        read_data = f.read()
+    return read_data.strip()
+
+
+def is_sriov(sysdir: str) -> bool:
+    """Determine whether a device is SR-IOV capable
+
+    :param: sysdir: path to device /sys directory
+    :type: str
+    :returns: whether device is SR-IOV capable or not
+    :rtype: bool
+    """
+    return os.path.exists(os.path.join(sysdir, "sriov_totalvfs"))
+
+
+def get_sriov_totalvfs(sysdir: str) -> int:
+    """Read total VF capacity for a device
+
+    :param: sysdir: path to device /sys directory
+    :type: str
+    :returns: number of VF's the device supports
+    :rtype: int
+    """
+    sriov_totalvfs_file = os.path.join(sysdir, "sriov_totalvfs")
+    with open(sriov_totalvfs_file, "r") as f:
+        read_data = f.read()
+    return int(read_data.strip())
+
+
+def get_sriov_numvfs(sysdir: str) -> int:
+    """Read configured VF capacity for a device
+
+    :param: sysdir: path to device /sys directory
+    :type: str
+    :returns: number of VF's the device is configured with
+    :rtype: int
+    """
+    sriov_numvfs_file = os.path.join(sysdir, "sriov_numvfs")
+    with open(sriov_numvfs_file, "r") as f:
+        read_data = f.read()
+    return int(read_data.strip())
+
+
+# https://github.com/libvirt/libvirt/commit/5b1c525b1f3608156884aed0dc5e925306c1e260
+PF_PHYS_PORT_NAME_REGEX = re.compile(r"(p[0-9]+$)|(p[0-9]+s[0-9]+$)",
+                                     re.IGNORECASE)
+
+
+def _phys_port_name_is_pf(sysnetdir: str) -> typing.Optional[bool]:
+    try:
+        with open(os.path.join(sysnetdir, "phys_port_name"), "r") as fin:
+            return (PF_PHYS_PORT_NAME_REGEX.match(fin.read().strip())
+                    is not None)
+    except OSError:
+        return
+
+
+def get_sysnet_interface(sysdir: str) -> typing.Optional[str]:
+    sysnetdir = os.path.join(sysdir, "net")
+    netdevs = os.listdir(sysnetdir)
+    # Return early in case the PCI device only has one netdev
+    if len(netdevs) == 1:
+        return netdevs[0]
+
+    # When a PCI device has multiple netdevs we need to figure out which one
+    # represents the PF
+    for netdev in netdevs:
+        if _phys_port_name_is_pf(os.path.join(sysnetdir, netdev)):
+            return netdev
+
+
+def get_pci_ethernet_addresses() -> list:
+    """Generate list of PCI addresses for all network adapters
+
+    :returns: list of PCI addresses
+    :rtype: list
+    """
+    cmd = ["lspci", "-m", "-D"]
+    lspci_output = subprocess.check_output(cmd).decode("UTF-8")
+    pci_addresses = []
+    for line in lspci_output.split("\n"):
+        columns = shlex.split(line)
+        if len(columns) > 1 and columns[1] == "Ethernet controller":
+            pci_address = columns[0]
+            pci_addresses.append(format_pci_addr(pci_address))
+    return pci_addresses
+
+
+class PCINetDevice(object):
+    def __init__(self, pci_address):
+        self.pci_address = pci_address
+        self.interface_name = None
+        self.mac_address = None
+        self.state = None
+        self.sriov = False
+        self.sriov_totalvfs = None
+        self.sriov_numvfs = None
+        self.update_attributes()
+
+    def update_attributes(self):
+        self.update_interface_info()
+
+    def update_interface_info(self):
+        net_devices = get_sysnet_interfaces_and_macs()
+        for interface in net_devices:
+            if self.pci_address == interface["pci_address"]:
+                self.interface_name = interface["interface"]
+                self.mac_address = interface["mac_address"]
+                self.state = interface["state"]
+                self.sriov = interface["sriov"]
+                if self.sriov:
+                    self.sriov_totalvfs = interface["sriov_totalvfs"]
+                    self.sriov_numvfs = interface["sriov_numvfs"]
+
+    def _set_sriov_numvfs(self, numvfs: int):
+        sdevice = os.path.join(
+            "/sys/bus/pci/devices", self.pci_address, "sriov_numvfs"
+        )
+        with open(sdevice, "w") as sh:
+            sh.write(str(numvfs))
+        self.update_attributes()
+
+    def set_sriov_numvfs(self, numvfs: int) -> bool:
+        """Set the number of VF devices for a SR-IOV PF
+
+        Assuming the device is an SR-IOV device, this function will attempt
+        to change the number of VF's created by the PF.
+
+        @param numvfs: integer to set the current number of VF's to
+        @returns boolean indicating whether any changes where made
+        """
+        if self.sriov and numvfs != self.sriov_numvfs:
+            # NOTE(fnordahl): run-time change of numvfs is disallowed
+            # without resetting to 0 first.
+            self._set_sriov_numvfs(0)
+            self._set_sriov_numvfs(numvfs)
+            return True
+        return False
+
+
+class PCINetDevices(object):
+    def __init__(self):
+        self.pci_devices = [
+            PCINetDevice(dev) for dev in get_pci_ethernet_addresses()
+        ]
+
+    def update_devices(self):
+        for pcidev in self.pci_devices:
+            pcidev.update_attributes()
+
+    def get_macs(self) -> list:
+        macs = []
+        for pcidev in self.pci_devices:
+            if pcidev.mac_address:
+                macs.append(pcidev.mac_address)
+        return macs
+
+    def get_device_from_mac(self, mac: str) -> PCINetDevice:
+        for pcidev in self.pci_devices:
+            if pcidev.mac_address == mac:
+                return pcidev
+        return None
+
+    def get_device_from_pci_address(self, pci_addr: str) -> PCINetDevice:
+        for pcidev in self.pci_devices:
+            if pcidev.pci_address == pci_addr:
+                return pcidev
+        return None
+
+    def get_device_from_interface_name(
+        self, interface_name: str
+    ) -> PCINetDevice:
+        for pcidev in self.pci_devices:
+            if pcidev.interface_name == interface_name:
+                return pcidev
+        return None

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -118,12 +118,7 @@ from charmhelpers.contrib.openstack.utils import (
 )
 from charmhelpers.core.unitdata import kv
 
-try:
-    from sriov_netplan_shim import pci
-except ImportError:
-    # The use of the function and contexts that require the pci module is
-    # optional.
-    pass
+from charmhelpers.contrib.hardware import pci
 
 try:
     import psutil
@@ -3120,7 +3115,7 @@ class SRIOVContext(OSContextGenerator):
         """Determine number of Virtual Functions (VFs) configured for device.
 
         :param device: Object describing a PCI Network interface card (NIC)/
-        :type device: sriov_netplan_shim.pci.PCINetDevice
+        :type device: contrib.hardware.pci.PCINetDevice
         :param sriov_numvfs: Number of VFs requested for blanket configuration.
         :type sriov_numvfs: int
         :returns: Number of VFs to configure for device

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,6 @@ import mock
 
 
 sys.modules['yum'] = mock.MagicMock()
-sys.modules['sriov_netplan_shim'] = mock.MagicMock()
-sys.modules['sriov_netplan_shim.pci'] = mock.MagicMock()
 with mock.patch('charmhelpers.deprecate') as ch_deprecate:
     def mock_deprecate(warning, date=None, log=None):
         def mock_wrap(f):

--- a/tests/contrib/hardware/__init__.py
+++ b/tests/contrib/hardware/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Canonical Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/contrib/hardware/pci_responses.py
+++ b/tests/contrib/hardware/pci_responses.py
@@ -1,0 +1,93 @@
+# Copyright 2016 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+LSPCI = b"""
+0000:00:00.0 "Host bridge" "Intel Corporation" "Haswell-E DMI2" -r02 "Intel Corporation" "Device 0000"
+0000:00:03.0 "PCI bridge" "Intel Corporation" "Haswell-E PCI Express Root Port 3" -r02 "" ""
+0000:00:03.2 "PCI bridge" "Intel Corporation" "Haswell-E PCI Express Root Port 3" -r02 "" ""
+0000:00:05.0 "System peripheral" "Intel Corporation" "Haswell-E Address Map, VTd_Misc, System Management" -r02 "" ""
+0000:00:05.1 "System peripheral" "Intel Corporation" "Haswell-E Hot Plug" -r02 "" ""
+0000:00:05.2 "System peripheral" "Intel Corporation" "Haswell-E RAS, Control Status and Global Errors" -r02 "" ""
+0000:00:05.4 "PIC" "Intel Corporation" "Haswell-E I/O Apic" -r02 -p20 "Intel Corporation" "Device 0000"
+0000:00:11.0 "Unassigned class [ff00]" "Intel Corporation" "Wellsburg SPSR" -r05 "Intel Corporation" "Device 7270"
+0000:00:11.4 "SATA controller" "Intel Corporation" "Wellsburg sSATA Controller [AHCI mode]" -r05 -p01 "Cisco Systems Inc" "Device 0067"
+0000:00:16.0 "Communication controller" "Intel Corporation" "Wellsburg MEI Controller #1" -r05 "Intel Corporation" "Device 7270"
+0000:00:16.1 "Communication controller" "Intel Corporation" "Wellsburg MEI Controller #2" -r05 "Intel Corporation" "Device 7270"
+0000:00:1a.0 "USB controller" "Intel Corporation" "Wellsburg USB Enhanced Host Controller #2" -r05 -p20 "Intel Corporation" "Device 7270"
+0000:00:1c.0 "PCI bridge" "Intel Corporation" "Wellsburg PCI Express Root Port #1" -rd5 "" ""
+0000:00:1c.3 "PCI bridge" "Intel Corporation" "Wellsburg PCI Express Root Port #4" -rd5 "" ""
+0000:00:1c.4 "PCI bridge" "Intel Corporation" "Wellsburg PCI Express Root Port #5" -rd5 "" ""
+0000:00:1d.0 "USB controller" "Intel Corporation" "Wellsburg USB Enhanced Host Controller #1" -r05 -p20 "Intel Corporation" "Device 7270"
+0000:00:1f.0 "ISA bridge" "Intel Corporation" "Wellsburg LPC Controller" -r05 "Intel Corporation" "Device 7270"
+0000:00:1f.2 "SATA controller" "Intel Corporation" "Wellsburg 6-Port SATA Controller [AHCI mode]" -r05 -p01 "Cisco Systems Inc" "Device 0067"
+0000:01:00.0 "PCI bridge" "Cisco Systems Inc" "VIC 82 PCIe Upstream Port" -r01 "" ""
+0000:02:00.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:02:01.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:03:00.0 "Unclassified device [00ff]" "Cisco Systems Inc" "VIC Management Controller" -ra2 "Cisco Systems Inc" "Device 012e"
+0000:04:00.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Upstream Port" -ra2 "" ""
+0000:05:00.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:05:01.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:05:02.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:05:03.0 "PCI bridge" "Cisco Systems Inc" "VIC PCIe Downstream Port" -ra2 "" ""
+0000:08:00.0 "Fibre Channel" "Cisco Systems Inc" "VIC FCoE HBA" -ra2 "Cisco Systems Inc" "Device 012e"
+0000:09:00.0 "Fibre Channel" "Cisco Systems Inc" "VIC FCoE HBA" -ra2 "Cisco Systems Inc" "Device 012e"
+0000:0b:00.0 "RAID bus controller" "LSI Logic / Symbios Logic" "MegaRAID SAS-3 3108 [Invader]" -r02 "Cisco Systems Inc" "Device 00db"
+0000:0f:00.0 "VGA compatible controller" "Matrox Electronics Systems Ltd." "MGA G200e [Pilot] ServerEngines (SEP1)" -r02 "Cisco Systems Inc" "Device 0101"
+0000:10:00.0 "Ethernet controller" "Intel Corporation" "I350 Gigabit Network Connection" -r01 "Cisco Systems Inc" "Device 00d6"
+0000:10:00.1 "Ethernet controller" "Intel Corporation" "I350 Gigabit Network Connection" -r01 "Cisco Systems Inc" "Device 00d6"
+0000:7f:08.0 "System peripheral" "Intel Corporation" "Haswell-E QPI Link 0" -r02 "Intel Corporation" "Haswell-E QPI Link 0"
+"""
+
+SYS_TREE = {
+    "/sys/class/net/eth2": "../../devices/pci0000:00/0000:00:1c.4/0000:10:00.0/net/eth2",
+    "/sys/class/net/eth3": "../../devices/pci0000:00/0000:00:1c.4/0000:10:00.1/net/eth3",
+    "/sys/class/net/juju-br0": "../../devices/virtual/net/juju-br0",
+    "/sys/class/net/lo": "../../devices/virtual/net/lo",
+    "/sys/class/net/lxcbr0": "../../devices/virtual/net/lxcbr0",
+    "/sys/class/net/veth1GVRCF": "../../devices/virtual/net/veth1GVRCF",
+    "/sys/class/net/veth7AXEUK": "../../devices/virtual/net/veth7AXEUK",
+    "/sys/class/net/vethACOIJJ": "../../devices/virtual/net/vethACOIJJ",
+    "/sys/class/net/vethMQ819H": "../../devices/virtual/net/vethMQ819H",
+    "/sys/class/net/virbr0": "../../devices/virtual/net/virbr0",
+    "/sys/class/net/virbr0-nic": "../../devices/virtual/net/virbr0-nic",
+    "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.0/net/eth2/device": "../../../0000:10:00.0",
+    "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.1/net/eth3/device": "../../../0000:10:00.1",
+    "/sys/bus/pci/devices/0000:10:00.0": "../../../devices/pci0000:00/0000:00:1c.4/0000:10:00.0",
+    "/sys/bus/pci/devices/0000:10:00.1": "../../../devices/pci0000:00/0000:00:1c.4/0000:10:00.1",
+    "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.0": "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.0",
+    "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.1": "/sys/devices/pci0000:00/0000:00:1c.4/0000:10:00.1",
+}
+
+NETDEVS = {
+    "/sys/bus/pci/devices/0000:10:00.0/net": ["eth2"],
+    # list the pf last so we validate the code successfully traversing the
+    # non-pf netdevs
+    "/sys/bus/pci/devices/0000:10:00.1/net": ["eth33", "eth51", "eth3"],
+}
+
+FILE_CONTENTS = {
+    "/sys/bus/pci/devices/0000:10:00.0/net/eth2/address": "a8:9d:21:cf:93:fc",
+    "/sys/bus/pci/devices/0000:10:00.1/net/eth3/address": "a8:9d:21:cf:93:fd",
+    "/sys/bus/pci/devices/0000:10:00.0/net/eth2/operstate": "up",
+    "/sys/bus/pci/devices/0000:10:00.1/net/eth3/operstate": "down",
+    "/sys/bus/pci/devices/0000:10:00.1/net/eth3/phys_port_name": "p0",
+    "/sys/bus/pci/devices/0000:10:00.1/net/eth33/phys_port_name": "notapf",
+    # eth51 deliberately not listed to validate non-presence of or failure to
+    # open phys_port_name
+}
+
+COMMANDS = {"LSPCI_MD": ["lspci", "-m", "-D"]}
+
+NET_SETUP = {"LSPCI_MD": LSPCI}

--- a/tests/contrib/hardware/test_pci.py
+++ b/tests/contrib/hardware/test_pci.py
@@ -1,0 +1,359 @@
+# Copyright 2016 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.contrib.hardware.test_utils import CharmTestCase
+from tests.contrib.hardware.test_utils import patch_open
+
+from tests.contrib.hardware.test_pci_helper import check_device
+from tests.contrib.hardware.test_pci_helper import mocked_filehandle
+from tests.contrib.hardware.test_pci_helper import mocked_globs
+from tests.contrib.hardware.test_pci_helper import mocked_islink
+from tests.contrib.hardware.test_pci_helper import mocked_listdir
+from tests.contrib.hardware.test_pci_helper import mocked_realpath
+from tests.contrib.hardware.test_pci_helper import mocked_subprocess
+
+from mock import call
+from mock import MagicMock
+from mock import patch
+
+from charmhelpers.contrib.hardware import pci
+
+TO_PATCH = ["glob", "subprocess"]
+NOT_JSON = "Im not json"
+
+
+class PCITest(CharmTestCase):
+    def setUp(self):
+        super(PCITest, self).setUp(pci, TO_PATCH)
+
+    def test_format_pci_addr(self):
+        self.assertEqual(pci.format_pci_addr("0:0:1.1"), "0000:00:01.1")
+        self.assertEqual(pci.format_pci_addr("0000:00:02.1"), "0000:00:02.1")
+
+
+class PCINetDeviceTest(CharmTestCase):
+    def setUp(self):
+        super(PCINetDeviceTest, self).setUp(pci, TO_PATCH)
+
+    @patch("os.path.islink")
+    @patch("os.path.realpath")
+    def eth_int(self, pci_address, _osrealpath, _osislink, subproc_map=None):
+        self.glob.glob.side_effect = mocked_globs
+        _osislink.side_effect = mocked_islink
+        _osrealpath.side_effect = mocked_realpath
+        self.subprocess.check_output.side_effect = mocked_subprocess(
+            subproc_map=subproc_map
+        )
+
+        with patch_open() as (_open, _file):
+            super_fh = mocked_filehandle()
+            _file.readlines = MagicMock()
+            _open.side_effect = super_fh._setfilename
+            _file.read.side_effect = super_fh._getfilecontents_read
+            _file.readlines.side_effect = super_fh._getfilecontents_readlines
+            netint = pci.PCINetDevice(pci_address)
+        return netint
+
+    @patch("os.listdir")
+    def test_base_eth_device(self, _oslistdir):
+        _oslistdir.side_effect = mocked_listdir
+        net = self.eth_int("0000:10:00.0")
+        expect = {
+            "interface_name": "eth2",
+            "mac_address": "a8:9d:21:cf:93:fc",
+            "pci_address": "0000:10:00.0",
+            "state": "up",
+            "sriov": False,
+        }
+        self.assertTrue(check_device(net, expect))
+
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_interfaces_and_macs")
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_update_interface_info(self, _update, _sysnet_ints):
+        dev = pci.PCINetDevice("0000:10:00.0")
+        _sysnet_ints.return_value = [
+            {
+                "interface": "eth2",
+                "mac_address": "a8:9d:21:cf:93:fc",
+                "pci_address": "0000:10:00.0",
+                "state": "up",
+                "sriov": False,
+            },
+            {
+                "interface": "eth3",
+                "mac_address": "a8:9d:21:cf:93:fd",
+                "pci_address": "0000:10:00.1",
+                "state": "down",
+                "sriov": False,
+            },
+        ]
+        dev.update_interface_info()
+        self.assertEqual(dev.interface_name, "eth2")
+
+    @patch("os.path.islink")
+    @patch("os.path.realpath")
+    @patch("charmhelpers.contrib.hardware.pci.is_sriov")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_device_state")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_mac")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_interface")
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_get_sysnet_interfaces_and_macs(
+        self, _update, _interface, _mac, _state, _sriov, _osrealpath, _osislink
+    ):
+        self.glob.glob.side_effect = (
+            ["/sys/bus/pci/devices/0000:10:00.0"],
+            [])
+        _interface.return_value = "eth2"
+        _mac.return_value = "a8:9d:21:cf:93:fc"
+        _state.return_value = "up"
+        _sriov.return_value = False
+        _osrealpath.return_value = (
+            "/sys/devices/pci0000:00/0000:00:02.0/"
+            "0000:02:00.0/0000:03:00.0/0000:04:00.0/"
+            "0000:05:01.0/0000:07:00.0"
+        )
+        expect = {
+            "interface": "eth2",
+            "mac_address": "a8:9d:21:cf:93:fc",
+            "pci_address": "0000:07:00.0",
+            "state": "up",
+            "sriov": False,
+        }
+        self.assertEqual(pci.get_sysnet_interfaces_and_macs(), [expect])
+
+    @patch("os.path.islink")
+    @patch("os.path.realpath")
+    @patch("charmhelpers.contrib.hardware.pci.is_sriov")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_device_state")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_mac")
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_interface")
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_get_sysnet_interfaces_and_macs_virtio(
+        self, _update, _interface, _mac, _state, _sriov, _osrealpath, _osislink
+    ):
+        self.glob.glob.side_effect = (
+            ["/sys/bus/pci/devices/0000:10:00.0"],
+            [])
+        _interface.return_value = "eth2"
+        _mac.return_value = "a8:9d:21:cf:93:fc"
+        _state.return_value = "up"
+        _sriov.return_value = False
+        _osrealpath.return_value = (
+            "/sys/devices/pci0000:00/0000:00:07.0/" "virtio5"
+        )
+        expect = {
+            "interface": "eth2",
+            "mac_address": "a8:9d:21:cf:93:fc",
+            "pci_address": "0000:00:07.0",
+            "state": "up",
+            "sriov": False,
+        }
+        self.assertEqual(pci.get_sysnet_interfaces_and_macs(), [expect])
+
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_get_sysnet_mac(self, _update):
+        with patch_open() as (_open, _file):
+            super_fh = mocked_filehandle()
+            _file.readlines = MagicMock()
+            _open.side_effect = super_fh._setfilename
+            _file.read.side_effect = super_fh._getfilecontents_read
+            macaddr = pci.get_sysnet_mac(
+                "/sys/bus/pci/devices/0000:10:00.1", "eth3")
+        self.assertEqual(macaddr, "a8:9d:21:cf:93:fd")
+
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_get_sysnet_device_state(self, _update):
+        with patch_open() as (_open, _file):
+            super_fh = mocked_filehandle()
+            _file.readlines = MagicMock()
+            _open.side_effect = super_fh._setfilename
+            _file.read.side_effect = super_fh._getfilecontents_read
+            state = pci.get_sysnet_device_state(
+                "/sys/bus/pci/devices/0000:10:00.1", "eth3")
+        self.assertEqual(state, "down")
+
+    @patch("os.listdir")
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_get_sysnet_interface(self, _update, _oslistdir):
+        _oslistdir.side_effect = mocked_listdir
+        with patch_open() as (_open, _file):
+            super_fh = mocked_filehandle()
+            _file.readlines = MagicMock()
+            _open.side_effect = super_fh._setfilename
+            _file.read.side_effect = super_fh._getfilecontents_read
+            self.assertEqual(
+                pci.get_sysnet_interface("/sys/bus/pci/devices/0000:10:00.1"),
+                "eth3"
+            )
+
+    @patch("charmhelpers.contrib.hardware.pci.get_sysnet_interfaces_and_macs")
+    def test__set_sriov_numvfs(self, mock_sysnet_ints):
+        mock_sysnet_ints.side_effect = (
+            [
+                {
+                    "interface": "eth2",
+                    "mac_address": "a8:9d:21:cf:93:fc",
+                    "pci_address": "0000:10:00.0",
+                    "state": "up",
+                    "sriov": True,
+                    "sriov_totalvfs": 7,
+                    "sriov_numvfs": 0,
+                }
+            ],
+            [
+                {
+                    "interface": "eth2",
+                    "mac_address": "a8:9d:21:cf:93:fc",
+                    "pci_address": "0000:10:00.0",
+                    "state": "up",
+                    "sriov": True,
+                    "sriov_totalvfs": 7,
+                    "sriov_numvfs": 4,
+                }
+            ],
+        )
+        dev = pci.PCINetDevice("0000:10:00.0")
+        self.assertEqual("eth2", dev.interface_name)
+        self.assertTrue(dev.sriov)
+        self.assertEqual(7, dev.sriov_totalvfs)
+        self.assertEqual(0, dev.sriov_numvfs)
+
+        with patch_open() as (mock_open, mock_file):
+            dev._set_sriov_numvfs(4)
+            mock_open.assert_called_with(
+                "/sys/bus/pci/devices/0000:10:00.0/sriov_numvfs", "w"
+            )
+            mock_file.write.assert_called_with("4")
+            self.assertTrue(dev.sriov)
+            self.assertEqual(7, dev.sriov_totalvfs)
+            self.assertEqual(4, dev.sriov_numvfs)
+
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice._set_sriov_numvfs")
+    def test_set_sriov_numvfs(self, mock__set_sriov_numvfs):
+        dev = pci.PCINetDevice("0000:10:00.0")
+        dev.sriov = True
+        dev.set_sriov_numvfs(4)
+        mock__set_sriov_numvfs.assert_has_calls([call(0), call(4)])
+
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice._set_sriov_numvfs")
+    def test_set_sriov_numvfs_avoid_call(self, mock__set_sriov_numvfs):
+        dev = pci.PCINetDevice("0000:10:00.0")
+        dev.sriov = True
+        dev.sriov_numvfs = 4
+        dev.set_sriov_numvfs(4)
+        self.assertFalse(mock__set_sriov_numvfs.called)
+
+
+class PCINetDevicesTest(CharmTestCase):
+    def setUp(self):
+        super(PCINetDevicesTest, self).setUp(pci, TO_PATCH)
+
+    @patch("os.path.islink")
+    def pci_devs(self, _osislink, subproc_map=None):
+        self.glob.glob.side_effect = mocked_globs
+        rp_patcher = patch("os.path.realpath")
+        rp_mock = rp_patcher.start()
+        rp_mock.side_effect = mocked_realpath
+        _osislink.side_effect = mocked_islink
+        self.subprocess.check_output.side_effect = mocked_subprocess(
+            subproc_map=subproc_map
+        )
+        listdir_patch = patch("os.listdir")
+        listdir_mock = listdir_patch.start()
+        listdir_mock.side_effect = mocked_listdir
+
+        with patch_open() as (_open, _file):
+            super_fh = mocked_filehandle()
+            _file.readlines = MagicMock()
+            _open.side_effect = super_fh._setfilename
+            _file.read.side_effect = super_fh._getfilecontents_read
+            _file.readlines.side_effect = super_fh._getfilecontents_readlines
+            devices = pci.PCINetDevices()
+        rp_patcher.stop()
+        listdir_patch.stop()
+        return devices
+
+    def test_base(self):
+        devices = self.pci_devs()
+        self.assertEqual(len(devices.pci_devices), 2)
+        expect = {
+            "0000:10:00.0": {
+                "interface_name": "eth2",
+                "mac_address": "a8:9d:21:cf:93:fc",
+                "pci_address": "0000:10:00.0",
+                "state": "up",
+                "sriov": False,
+            },
+            "0000:10:00.1": {
+                "interface_name": "eth3",
+                "mac_address": "a8:9d:21:cf:93:fd",
+                "pci_address": "0000:10:00.1",
+                "state": "down",
+                "sriov": False,
+            },
+        }
+        for device in devices.pci_devices:
+            self.assertTrue(check_device(device, expect[device.pci_address]))
+
+    def test_get_pci_ethernet_addresses(self):
+        self.pci_devs()
+        expect = ["0000:10:00.0", "0000:10:00.1"]
+        self.assertEqual(pci.get_pci_ethernet_addresses(), expect)
+
+    @patch("charmhelpers.contrib.hardware.pci.PCINetDevice.update_attributes")
+    def test_update_devices(self, _update):
+        devices = self.pci_devs()
+        call_count = _update.call_count
+        devices.update_devices()
+        self.assertEqual(_update.call_count, call_count + 2)
+
+    def test_get_macs(self):
+        devices = self.pci_devs()
+        expect = ["a8:9d:21:cf:93:fc", "a8:9d:21:cf:93:fd"]
+        self.assertEqual(devices.get_macs(), expect)
+
+    def test_get_device_from_mac(self):
+        devices = self.pci_devs()
+        expect = {
+            "0000:10:00.1": {
+                "interface_name": "eth3",
+                "mac_address": "a8:9d:21:cf:93:fd",
+                "pci_address": "0000:10:00.1",
+                "state": "down",
+                "sriov": False,
+            }
+        }
+        self.assertTrue(
+            check_device(
+                devices.get_device_from_mac("a8:9d:21:cf:93:fd"),
+                expect["0000:10:00.1"],
+            )
+        )
+
+    def test_get_device_from_pci_address(self):
+        devices = self.pci_devs()
+        expect = {
+            "0000:10:00.1": {
+                "interface_name": "eth3",
+                "mac_address": "a8:9d:21:cf:93:fd",
+                "pci_address": "0000:10:00.1",
+                "state": "down",
+            }
+        }
+        self.assertTrue(
+            check_device(
+                devices.get_device_from_pci_address("0000:10:00.1"),
+                expect["0000:10:00.1"],
+            )
+        )

--- a/tests/contrib/hardware/test_pci_helper.py
+++ b/tests/contrib/hardware/test_pci_helper.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from mock import MagicMock
+from mock import patch
+
+from charmhelpers.contrib.hardware import pci
+from tests.contrib.hardware import pci_responses
+from tests.contrib.hardware.test_utils import patch_open
+
+
+def check_device(device, attr_dict):
+    equal = (
+        device.interface_name == attr_dict["interface_name"] and
+        device.mac_address == attr_dict["mac_address"] and
+        device.pci_address == attr_dict["pci_address"] and
+        device.state == attr_dict["state"]
+    )
+    return equal
+
+
+def mocked_subprocess(subproc_map=None):
+    def _subproc(cmd, stdin=None):
+        for key in pci_responses.COMMANDS.keys():
+            if pci_responses.COMMANDS[key] == cmd:
+                return subproc_map[key]
+            elif pci_responses.COMMANDS[key] == cmd[:-1]:
+                return subproc_map[cmd[-1]][key]
+
+    if not subproc_map:
+        subproc_map = pci_responses.NET_SETUP
+    return _subproc
+
+
+class mocked_filehandle(object):
+    def _setfilename(self, fname, omode):
+        self.FILENAME = fname
+
+    def _getfilecontents_read(self):
+        try:
+            return pci_responses.FILE_CONTENTS[self.FILENAME]
+        except KeyError:
+            raise OSError()
+
+    def _getfilecontents_readlines(self):
+        return pci_responses.FILE_CONTENTS[self.FILENAME].split("\n")
+
+
+def mocked_globs(path):
+    check_path = path.split("*")[0].rstrip("/")
+    dirs = []
+    for sdir in pci_responses.SYS_TREE:
+        if check_path in sdir:
+            dirs.append(sdir)
+    return dirs
+
+
+def mocked_islink(link):
+    resolved_relpath = mocked_resolve_link(link)
+    if pci_responses.SYS_TREE.get(resolved_relpath):
+        return True
+    else:
+        return False
+
+
+def mocked_resolve_link(link):
+    resolved_relpath = None
+    for sdir in pci_responses.SYS_TREE:
+        if sdir in link:
+            rep_dir = "{}/{}".format(
+                os.path.dirname(sdir), pci_responses.SYS_TREE[sdir]
+            )
+            resolved_symlink = link.replace(sdir, rep_dir)
+            resolved_relpath = os.path.abspath(resolved_symlink)
+    return resolved_relpath
+
+
+def mocked_realpath(link):
+    resolved_link = mocked_resolve_link(link)
+    return pci_responses.SYS_TREE[resolved_link]
+
+
+def mocked_listdir(path):
+    return pci_responses.NETDEVS[path]
+
+
+@patch("pci.cached")
+@patch("pci.log")
+@patch("pci.subprocess.Popen")
+@patch("pci.subprocess.check_output")
+@patch("pci.glob.glob")
+@patch("pci.os.path.islink")
+def pci_devs(
+    _osislink, _glob, _check_output, _Popen, _log, _cached, subproc_map=None
+):
+    _glob.side_effect = mocked_globs
+    _osislink.side_effect = mocked_islink
+    _check_output.side_effect = mocked_subprocess(subproc_map=subproc_map)
+
+    with patch_open() as (_open, _file), patch(
+        "pci.os.path.realpath"
+    ) as _realpath:
+        super_fh = mocked_filehandle()
+        _file.readlines = MagicMock()
+        _open.side_effect = super_fh._setfilename
+        _file.read.side_effect = super_fh._getfilecontents_read
+        _file.readlines.side_effect = super_fh._getfilecontents_readlines
+        _realpath.side_effect = mocked_realpath
+        devices = pci.PCINetDevices()
+    return devices

--- a/tests/contrib/hardware/test_utils.py
+++ b/tests/contrib/hardware/test_utils.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import unittest
+
+from contextlib import contextmanager
+
+from mock import MagicMock
+from mock import patch
+
+
+class CharmTestCase(unittest.TestCase):
+    def setUp(self, obj, patches):
+        super(CharmTestCase, self).setUp()
+        self.patches = patches
+        self.obj = obj
+        self.patch_all()
+
+    def patch(self, method):
+        _m = patch.object(self.obj, method)
+        mock = _m.start()
+        self.addCleanup(_m.stop)
+        return mock
+
+    def patch_all(self):
+        for method in self.patches:
+            setattr(self, method, self.patch(method))
+
+
+@contextmanager
+def patch_open():
+    """Patch open builtin
+
+    Patch open() to allow mocking both open() itself and the file that is
+    yielded.
+
+    Yields the mock for "open" and "file", respectively.
+    """
+    mock_open = MagicMock(spec=open)
+    mock_file = MagicMock(spec=io.FileIO)
+
+    @contextmanager
+    def stub_open(*args, **kwargs):
+        mock_open(*args, **kwargs)
+        yield mock_file
+
+    with patch("builtins.open", stub_open):
+        yield mock_open, mock_file


### PR DESCRIPTION
Now that netplan.io has support for configuring both
embedded-switch-mode [0] and SR-IOV [1] we no longer need the
Networking Tools for Charms PPA [2].

As a consequence we need to import the `pci` module from that
package as this is consumed by both Classic, Reactive and
Operator Framework charms.

0: https://launchpad.net/bugs/1964481
1: https://launchpad.net/bugs/1871825
2: https://launchpad.net/~openstack-charmers/+archive/ubuntu/networking-tools

Co-authored-by: James Page <james.page@ubuntu.com>