### PR TITLE
Validate X509 certificate inputs

### DIFF
--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -24,6 +24,8 @@
 
 import os
 
+from base64 import b64decode
+
 from charmhelpers.core import host
 from charmhelpers.core.hookenv import (
     config as config_get,
@@ -31,7 +33,12 @@ from charmhelpers.core.hookenv import (
     relation_ids,
     related_units as relation_list,
     log,
+    ERROR,
     INFO,
+)
+from charmhelpers.contrib.openstack.cert_utils import (
+    x509_get_pubkey,
+    x509_validate_cert,
 )
 
 # This file contains the CA cert from the charms ssl_ca configuration
@@ -61,6 +68,11 @@ def get_cert(cn=None):
                 if not key:
                     key = relation_get(ssl_key_attr,
                                        rid=r_id, unit=unit)
+
+    # this likely fails too quietly, raise?
+    if not x509_validate_cert(b64decode(cert), ssl_key=b64decode(key)):
+        return (None, None)
+
     return (cert, key)
 
 
@@ -75,6 +87,11 @@ def get_ca_cert():
                 if ca_cert is None:
                     ca_cert = relation_get('ca_cert',
                                            rid=r_id, unit=unit)
+
+    # this likely fails too quietly, raise?
+    if not x509_get_pubkey(b64decode(ca_cert)):
+        return None
+
     return ca_cert
 
 

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -1,3 +1,5 @@
+from base64 import b64encode
+
 from mock import patch, call
 
 from testtools import TestCase
@@ -5,8 +7,174 @@ from tests.helpers import patch_open, FakeRelation
 
 import charmhelpers.contrib.hahelpers.apache as apache_utils
 
-cert = '''
-        -----BEGIN CERTIFICATE-----
+rsa_certs = {  # check for intermediate CAs?
+    'ca_key': b64encode('''-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAnhnAUJC+ZLlkmFZq1adbFgzJelPtr/M5T/7ao2kbVQEaocMS
+TR9FLbhgfDvbNVQKB/YcsdT+Vb0CJTZ/0pQAhF51y9TqJDII/++q+7PGwBRBv4O4
+I4FI/120vKu7FTu9oKRBVxsIRolyn6mpvxmlEcZXsfsuyoNrdKUdG1rOEbyRJRZY
+8En67UkRLnMajPod4bguZc8qktt/R0kD18U8V9k1ROXGM8XTlgPyAmdkguo9heic
+ZB+moXgCGveyxktIM1Lm2v2uM7MiM/Hln4cRcxnI63saAhbQcdoRoP9YyUQ3lV5y
+XyrQd1vhmqSrn7lHbR8OJNAy983smPfcIv2r8QIDAQABAoIBAAlcLO6YIy2DbFk4
+hIqxpcrgZu0/GstX8wSxafBSwLN/pTv+eI7oUwgp6kxwnsHBf/aIs5ozqfsZfY8G
+cvrcmEs97Gts54/NBotgfRb5xcKJcHsOKVCwzsmPmquw3xqattdT4ipuB0dly8t4
+F/ygYA11WKvI2zRSI4J8ZATCk4CpOXaUMB06Es6VUb0dDhwncCfXoOyo3CSp5/8L
+SCF4xpogqos8waXUWbUTIFw/SxIkY1WcQwACEMFw6JZdH33N0DDFFEdXGfl+VXp7
+Bzjru6c8raO8VsMUsazMTmdpyNrwF7Q1RBoz46F3jlPfoVS0DRZ42PjEy52Dj3FW
+U4leqYECgYEA0hx9d/DHcYdSA5IisPCRhjA0FY7rrfZzZoPbXBJWNScCqzrka1jQ
+2a+LzAMk8KzxqJvrWcyZE6BC8+ELnekip/xpnb/aNrWJ7V3a4/ErgI9nQ++SRZdC
+XlmLpE0DUQvXI5bRQUFpza52iRkVA9a/rCCPnvbdiCTwediVsrw19A0CgYEAwKFL
+5rX/GoJ1tlt4ULkSzIY/bYm0+/uLrpsYunWruWhPGu+o4laaOBc9Mzv7xH/4OGk5
+ZJ6UxoBOQgCKC7KU9t94hgsUmcNJeN+OtnfLsWtUPjoQQKlqCXwzS9Q8aIzNf2OR
+ZOENsJ3uVRzhIF+UrAX3dFnn0kJK6TD1oku3KnUCgYB5sXKiM1zwzlWcJ9nb7Zn7
+xJOGIP80BNgV+izlCOHRa0TKdBO0cP6V9mzbvr54f1KAO752hl/q1BmzMxcNYOhn
+r3Rkn6f9o+u9BW0wNJDjpytCV9G6aL9R8j9E7C4NlPQIcuPEDeT/8hpJkbNwQ8NE
+KJ/GjGkG345ApEcf/I6rSQKBgGE2hYmPO4jzYdh/3P5QCE6zSXtMTcwFLH8XwqkH
+DXzqSVG8tSxUrEu2XqpmkS6frnM5lz9SUJ7Ezbm9b+1rWIYmTTrIiML4rTGVEP7B
+AkktczxcLSuU0/Cpf3G7UCkrNeIeK5gPg8soSMknY+3kjrEp6bIMVVPlJMz+alhX
+gb6pAoGBAI/Ue1O6nXez/eCvARENo+5q86MGKj0EaO6O11AHSGpQyNOvNFAKjOv6
+USJcDiGtVXjpw7Cy2FmNMtdWdbD/L6xo65Z3i9FUXvfx7i8laYjviZhsKNZNMMbE
+q5pvXG3kwLYCqss381upQoKSYd4QuoVTKC19qZ12ubfiB45B/4nr
+-----END RSA PRIVATE KEY-----'''.encode()),
+    'ca_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUfhjNMTbE2ufAPObs8lV1RQaZ/RswDQYJKoZIhvcNAQEL
+BQAwEjEQMA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDQxMjE0MjVaFw0yNjA0MDQx
+MjE0MjVaMBIxEDAOBgNVBAMMB3Jvb3RfY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCeGcBQkL5kuWSYVmrVp1sWDMl6U+2v8zlP/tqjaRtVARqhwxJN
+H0UtuGB8O9s1VAoH9hyx1P5VvQIlNn/SlACEXnXL1OokMgj/76r7s8bAFEG/g7gj
+gUj/XbS8q7sVO72gpEFXGwhGiXKfqam/GaURxlex+y7Kg2t0pR0bWs4RvJElFljw
+SfrtSREucxqM+h3huC5lzyqS239HSQPXxTxX2TVE5cYzxdOWA/ICZ2SC6j2F6Jxk
+H6aheAIa97LGS0gzUuba/a4zsyIz8eWfhxFzGcjrexoCFtBx2hGg/1jJRDeVXnJf
+KtB3W+GapKufuUdtHw4k0DL3zeyY99wi/avxAgMBAAGjgYwwgYkwHQYDVR0OBBYE
+FKDWfP1/EF2aAlcJyQJMPGJ9GszYME0GA1UdIwRGMESAFKDWfP1/EF2aAlcJyQJM
+PGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A85uzyVXVF
+Bpn9GzAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQsFAAOC
+AQEAhILWfl+ldAnfRuXj3qHs6q/0zZz1uSlG8gSFlO/KuINYi6/Vp1r7BjRmTymD
+J1lPY7haQ8nlraT/j3CjXcCHHeUBCjShT8oWyLFxu/2FpMbw9B7zqqoSy1LVrIKh
+xfuRma2TUx3vxUpAvQIsw98si/2EH1qzUuvv47jb8Zg59EULtjT8pkN81FgXVOme
+s3V7YqAUSDLechoCN+rR0iWi7zVI6LeFnlfwWwMqYW/5SiWasgQohZM9eAjXECo7
+cSXGCUfL3EDAmbRxOMCOLFF5WNmGsm//a2ZEegnY/GmCNw501e3spqXzXIe5HRRR
+jOm40xKhkPtObqOe2lRsRzT1ww==
+-----END CERTIFICATE-----'''.encode()),
+    'ca_pub': '''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnhnAUJC+ZLlkmFZq1adb
+FgzJelPtr/M5T/7ao2kbVQEaocMSTR9FLbhgfDvbNVQKB/YcsdT+Vb0CJTZ/0pQA
+hF51y9TqJDII/++q+7PGwBRBv4O4I4FI/120vKu7FTu9oKRBVxsIRolyn6mpvxml
+EcZXsfsuyoNrdKUdG1rOEbyRJRZY8En67UkRLnMajPod4bguZc8qktt/R0kD18U8
+V9k1ROXGM8XTlgPyAmdkguo9heicZB+moXgCGveyxktIM1Lm2v2uM7MiM/Hln4cR
+cxnI63saAhbQcdoRoP9YyUQ3lV5yXyrQd1vhmqSrn7lHbR8OJNAy983smPfcIv2r
+8QIDAQAB
+-----END PUBLIC KEY-----'''.encode(),
+    'server_key': b64encode('''-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3f7DzliwS5KsZ
+QNSK+9Zq+qZuLO4ptwCGGcfFYV8WTziy1ORvCJk5adRlS4kEhq4KBE+l+EJVOSrx
+PxUS8z/2JalxJ2fD6jrUrkEp9AAJefwpbK9qTMJ4PeuoLaPnzxtuvDesdzdSX4F1
+Ubm5Wr0g3RqDwrp5lrrAQNT65rXq7Vm7BRNFcLowpP3c9mno2IW1jA2oDgBP0P5J
+YICCA82E6Oz/hvp80uLUcu7Om0RaYf8Z8JwfkvK1qhrdJEMaqfdAhNJ0HlWPVnQz
+Io9H8XDJkIlLL1UNCTVRoJb2OgnKvGFIU+Rwa7bG2Wq5QceH/4T+KUeWvf9VN9Ef
+K0wURcrpAgMBAAECggEAJ2dDHzt7IV97IkQan/GuPHCwdm4tgkWq1iEJFehv28GN
+QlGW8ATfqkWAd3P96zvkeYAtfk1OKTDKeN178ALOFFRIC2VT0e0lTvBQS+r6aw6H
+yHlvPZtYEyvww79xN+DwWhoOtnkvJwAdM40mHZhPjpQMEokpM9zbI1eIpIwQOm76
+N65FwyiCghumUKPLDRvTjiVPDT/RuIDMzUAUKXSkh/2wfNarGWy6jDZS03b+8uBe
+ggPUSqTmtoSxL9C5aAG9CJi8SUkakw2s2fjwQxyeXC1GaWWnziFDA1Rhl1xnbehO
+QgDKhcwZMmddc1fySanei9EX5zgB2M8nQGeRljlCEQKBgQDgM7ht53Z0dxGHcbgE
+pJQBJQc9RScfTlU/L09DBOJI2rw5VtBXhCXEIQLxCM/A2H+e9vV8bhYbLLOB0vm8
+wCEs06gfikCzOKid+gr6gV1yfURCvd7zKv7HLZY9938oeqHuKYUef4gvFy/Ivw7U
+oGpkL1xlXD3FKbbAD6/S8WOxvQKBgQDRhiBTMO6eOvuiSj5YvCXMsRnicJDIOVaK
+ZuhgQo9WMZoAgX238Zpm63MQmqGc1NQt/uJXnyEr83/xtf+lGeGiWDzk8CJvPNNG
+fDhgAMqAtkjYUkPmVaR3xWwt9cxiMIK3edoiB9WYjuQChYP+75VqV0r85AFFoi5s
+qNWlPBSSnQKBgCz4EsDwkSDRFRH+rDM6M3l7TNVsPmmYE58lxRcjLqQAQ4qYsBct
+qUmKeYWRB+KdShO/YwO/LO3sbGDYyUCjpMPR/EG/QDTyY1e0ZGlUc0LYf02HueU6
+NXoL2bu6HaYn2rzjVREF8XHIi8wPDlF1j4FiwnyOINGgCUjCnLiJtD5dAoGAVJ56
+x55ngHgJ0I1ziJrUGUsdTRpxHqwpi1PsXZQEF6eIrtOdVoC4/v/wRLBuvMwntTvP
+Zdvapcl9zrzWNnOxcMN6NGvXPF2wZjMdAYjQQBNecB8pVQkZl1WgTx+KH82/vSH1
+OvE3DpoG9A3ANWHFUmFW47Oh3+GUJkY5orYVCPECgYEAya7XvUKwzsW1481+cHMw
+D9gAKMxkkPw+66SFZpRXGhCmAbhOxWaMRnT/CLDYf4jRkuFp0O7uh3rtVrhZf71z
+KAXlrNCq0cJotAQmfK7h4/8TgECz+h4KFfE6q3IlqbOOhCwYczRGkjGmh5qRYidu
+ksQN9IhwJNVGqPMhWznB11s=
+-----END PRIVATE KEY-----'''.encode()),
+    'server_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIDVjCCAj6gAwIBAgIQc3/Zflj6FxtoQphOJRYFuTANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQDDAdyb290X2NhMB4XDTIyMDQwNDEyMTQyNVoXDTI2MDQwNDEyMTQy
+NVowETEPMA0GA1UEAwwGc2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAt3+w85YsEuSrGUDUivvWavqmbizuKbcAhhnHxWFfFk84stTkbwiZOWnU
+ZUuJBIauCgRPpfhCVTkq8T8VEvM/9iWpcSdnw+o61K5BKfQACXn8KWyvakzCeD3r
+qC2j588bbrw3rHc3Ul+BdVG5uVq9IN0ag8K6eZa6wEDU+ua16u1ZuwUTRXC6MKT9
+3PZp6NiFtYwNqA4AT9D+SWCAggPNhOjs/4b6fNLi1HLuzptEWmH/GfCcH5Lytaoa
+3SRDGqn3QITSdB5Vj1Z0MyKPR/FwyZCJSy9VDQk1UaCW9joJyrxhSFPkcGu2xtlq
+uUHHh/+E/ilHlr3/VTfRHytMFEXK6QIDAQABo4GoMIGlMAkGA1UdEwQCMAAwHQYD
+VR0OBBYEFFNUTBIAyHywQtnxLinEV0ptSQpeME0GA1UdIwRGMESAFKDWfP1/EF2a
+AlcJyQJMPGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A8
+5uzyVXVFBpn9GzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwCwYDVR0P
+BAQDAgWgMA0GCSqGSIb3DQEBCwUAA4IBAQCI6nGhEj74Yr8hvMMBsvWsD2OqFy9c
+gg+5gT9+d+mSszuJPA/oXX7xeXEw0PLezKTR4OYKcZP3m9IMDuvlWAeyosNcm/VN
+rkBJD5SqbAYQPRl2uo1LlhnvpOWVI6E3ik8KcKb7D6OtPOB851kCl21bD30zr9fu
+HIg8fx07p7AbtVlJB3zAy2pF4zwMuPe0IIil0op7UJNRNhYfH8uQneUw4TPv3h5d
+ZKSHtCFgRce/T7PX+4/GcQEycmrTrbhkuJ5uY/9VcFi5j6pvFuGcT/rmlbLfqabX
+3szYaO+M+6TVvDzadMgMDObEeH56JP3lHFwj/WgEIBInkr9P/bcA4Sm/
+-----END CERTIFICATE-----'''.encode()),
+    'server_pub': '''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt3+w85YsEuSrGUDUivvW
+avqmbizuKbcAhhnHxWFfFk84stTkbwiZOWnUZUuJBIauCgRPpfhCVTkq8T8VEvM/
+9iWpcSdnw+o61K5BKfQACXn8KWyvakzCeD3rqC2j588bbrw3rHc3Ul+BdVG5uVq9
+IN0ag8K6eZa6wEDU+ua16u1ZuwUTRXC6MKT93PZp6NiFtYwNqA4AT9D+SWCAggPN
+hOjs/4b6fNLi1HLuzptEWmH/GfCcH5Lytaoa3SRDGqn3QITSdB5Vj1Z0MyKPR/Fw
+yZCJSy9VDQk1UaCW9joJyrxhSFPkcGu2xtlquUHHh/+E/ilHlr3/VTfRHytMFEXK
+6QIDAQAB
+-----END PUBLIC KEY-----'''.encode(),
+}
+
+ec_certs = {
+    'ca_key': b64encode('''-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDBaLKFGs/6gl0qr46DOvKchCjLR/Qwa5bX0ofvHZ6XzziwPiJpNRIXr
+DGn6dy0ahTSgBwYFK4EEACKhZANiAATbytPyF9NnVS5MLVHLyc22t3b3FHsH9LRt
+VnRWky2uxdfmGqjjFZaCWxz2D3AsQyYEVmnkInRV0nbD1WkBCQntp/WHS8DVIt7j
+vQPw90VefzGd9lN5UZKNwHlBhQb+Vxc=
+-----END EC PRIVATE KEY-----'''.encode()),
+    'ca_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIB7zCCAXagAwIBAgIUPdrHjpTzdGmxOhOb6PLPgz1KNP8wCgYIKoZIzj0EAwIw
+EjEQMA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDUxNzUyMTRaFw0yNjA0MDUxNzUy
+MTRaMBIxEDAOBgNVBAMMB3Jvb3RfY2EwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATb
+ytPyF9NnVS5MLVHLyc22t3b3FHsH9LRtVnRWky2uxdfmGqjjFZaCWxz2D3AsQyYE
+VmnkInRV0nbD1WkBCQntp/WHS8DVIt7jvQPw90VefzGd9lN5UZKNwHlBhQb+Vxej
+gYwwgYkwHQYDVR0OBBYEFOtxQHpF0SK7iBjbrkmvLyzsGikEME0GA1UdIwRGMESA
+FOtxQHpF0SK7iBjbrkmvLyzsGikEoRakFDASMRAwDgYDVQQDDAdyb290X2NhghQ9
+2seOlPN0abE6E5vo8s+DPUo0/zAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjAK
+BggqhkjOPQQDAgNnADBkAjABM001FiLLs7Bx70Qvy8norf4dvHf0o3D5ZK/sjeu6
+olh0hEPuPThpbaDY23PCfv4CMHQi1mO4TYp9Wn4PVaQ+NFcgjJN/Mq2V9wxJBdwy
+vhJnoYvJ7XVDjUX6iFDPjOr9Vw==
+-----END CERTIFICATE-----'''.encode()),
+    'ca_pub': '''-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE28rT8hfTZ1UuTC1Ry8nNtrd29xR7B/S0
+bVZ0VpMtrsXX5hqo4xWWglsc9g9wLEMmBFZp5CJ0VdJ2w9VpAQkJ7af1h0vA1SLe
+470D8PdFXn8xnfZTeVGSjcB5QYUG/lcX
+-----END PUBLIC KEY-----''',
+    'server_key': b64encode('''-----BEGIN PRIVATE KEY-----
+MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDDsO4KohkPyc6RgCup3
+eBUokioiX1k9DmC8L43vzDTEn4KPVZ0wRpd/BM0Vl/zjcfShZANiAAR9yklMOLox
+dmxdW2KrnfgqQ1J4dqR2ipPwK0f4OnDgx7nXujqhfWAS4XvipD+G9NYUbsXvUxQh
+T03NgsoSsA+Hxz4TseasHc+lkeWRjxLbsk6gxcj581WZSAdiSK4ICiY=
+-----END PRIVATE KEY-----'''.encode()),
+    'server_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIICCDCCAY6gAwIBAgIRAOZVMlJSudlDtvzTDG4wL9EwCgYIKoZIzj0EAwIwEjEQ
+MA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDUxNzUyMTRaFw0yNjA0MDUxNzUyMTRa
+MBExDzANBgNVBAMMBnNlcnZlcjB2MBAGByqGSM49AgEGBSuBBAAiA2IABH3KSUw4
+ujF2bF1bYqud+CpDUnh2pHaKk/ArR/g6cODHude6OqF9YBLhe+KkP4b01hRuxe9T
+FCFPTc2CyhKwD4fHPhOx5qwdz6WR5ZGPEtuyTqDFyPnzVZlIB2JIrggKJqOBqDCB
+pTAJBgNVHRMEAjAAMB0GA1UdDgQWBBSVrhk5/QGvQZn0Csakls7OIC2x5jBNBgNV
+HSMERjBEgBTrcUB6RdEiu4gY265Jry8s7BopBKEWpBQwEjEQMA4GA1UEAwwHcm9v
+dF9jYYIUPdrHjpTzdGmxOhOb6PLPgz1KNP8wHQYDVR0lBBYwFAYIKwYBBQUHAwEG
+CCsGAQUFBwMCMAsGA1UdDwQEAwIFoDAKBggqhkjOPQQDAgNoADBlAjBoRHrBPGNA
+x5ZH0MmzG9PQHva5R59UiMTv1mZrDvTe51Ihr1XuWhxU3uzcfyZgvZICMQCsYicQ
+dhuYoD4409H47k+LCUNpOEZCeVmUrKyVeyIo/+Hs87Bo2T3+4yG3slkGEds=
+-----END CERTIFICATE-----'''.encode()),
+    'server_pub': '''-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfcpJTDi6MXZsXVtiq534KkNSeHakdoqT
+8CtH+Dpw4Me517o6oX1gEuF74qQ/hvTWFG7F71MUIU9NzYLKErAPh8c+E7HmrB3P
+pZHlkY8S27JOoMXI+fNVmUgHYkiuCAom
+-----END PUBLIC KEY-----''',
+}
+
+cert = '''-----BEGIN CERTIFICATE-----
 MIIDXTCCAkWgAwIBAgIJAMO1fWOu8ntUMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
 BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
 aWRnaXRzIFB0eSBMdGQwHhcNMTQwNDIyMTUzNDA0WhcNMjQwNDE5MTUzNDA0WjBF
@@ -26,14 +194,13 @@ bwFImc9ar0h+o3/VH1hry+2vEVikXiKK5uKZI6B7ejNYfAWydq6ilzfKIh75W852
 OSbKt3NB/BTZZUdCvK6+B+MoeuzQHDO0/QKBEBfaKFeJki3mdyzFlNbYio1z00rM
 E2zl3kh9gkZnMuV1uzHdfKJbtTcNn4hCls5x7T21jn4joADHaVez8FloykBUABu3
 qw==
------END CERTIFICATE-----
-'''
+-----END CERTIFICATE-----'''.encode()
 
 IDENTITY_NEW_STYLE_CERTS = {
     'identity-service:0': {
         'keystone/0': {
-            'ssl_cert_test-cn': 'keystone_provided_cert',
-            'ssl_key_test-cn': 'keystone_provided_key',
+            'ssl_cert_test-cn': rsa_certs['server_cert'],
+            'ssl_key_test-cn': rsa_certs['server_key'],
         }
     }
 }
@@ -41,8 +208,8 @@ IDENTITY_NEW_STYLE_CERTS = {
 IDENTITY_OLD_STYLE_CERTS = {
     'identity-service:0': {
         'keystone/0': {
-            'ssl_cert': 'keystone_provided_cert',
-            'ssl_key': 'keystone_provided_key',
+            'ssl_cert': rsa_certs['server_cert'],
+            'ssl_key': rsa_certs['server_key'],
         }
     }
 }
@@ -69,15 +236,15 @@ class ApacheUtilsTests(TestCase):
     def test_get_cert_from_config(self):
         '''Ensure cert and key from charm config override relation'''
         self.config_get.side_effect = [
-            'some_ca_cert',  # config_get('ssl_cert')
-            'some_ca_key',  # config_Get('ssl_key')
+            rsa_certs['ca_cert'],  # config_get('ssl_cert')
+            rsa_certs['ca_key'],  # config_get('ssl_key')
         ]
         result = apache_utils.get_cert('test-cn')
-        self.assertEquals(('some_ca_cert', 'some_ca_key'), result)
+        self.assertEquals((rsa_certs['ca_cert'], rsa_certs['ca_key']), result)
 
     def test_get_ca_cert_from_config(self):
-        self.config_get.return_value = "some_ca_cert"
-        self.assertEquals('some_ca_cert', apache_utils.get_ca_cert())
+        self.config_get.return_value = rsa_certs['ca_cert']
+        self.assertEquals(rsa_certs['ca_cert'], apache_utils.get_ca_cert())
 
     def test_get_cert_from_relation(self):
         self.config_get.return_value = None
@@ -86,7 +253,7 @@ class ApacheUtilsTests(TestCase):
         self.relation_list.side_effect = rel.relation_units
         self.relation_get.side_effect = rel.get
         result = apache_utils.get_cert('test-cn')
-        self.assertEquals(('keystone_provided_cert', 'keystone_provided_key'),
+        self.assertEquals((rsa_certs['server_cert'], rsa_certs['server_key']),
                           result)
 
     def test_get_cert_from_relation_deprecated(self):
@@ -96,7 +263,7 @@ class ApacheUtilsTests(TestCase):
         self.relation_list.side_effect = rel.relation_units
         self.relation_get.side_effect = rel.get
         result = apache_utils.get_cert()
-        self.assertEquals(('keystone_provided_cert', 'keystone_provided_key'),
+        self.assertEquals((rsa_certs['server_cert'], rsa_certs['server_key']),
                           result)
 
     def test_get_ca_cert_from_relation(self):
@@ -105,13 +272,12 @@ class ApacheUtilsTests(TestCase):
                                          ['identity-credentials:1']]
         self.relation_list.return_value = 'keystone/0'
         self.relation_get.side_effect = [
-            'keystone_provided_ca',
+            rsa_certs['ca_cert'],
         ]
         result = apache_utils.get_ca_cert()
         self.relation_ids.assert_has_calls([call('identity-service'),
                                             call('identity-credentials')])
-        self.assertEquals('keystone_provided_ca',
-                          result)
+        self.assertEquals(rsa_certs['ca_cert'], result)
 
     @patch.object(apache_utils.os.path, 'isfile')
     def test_retrieve_ca_cert(self, _isfile):

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -4,6 +4,165 @@ import unittest
 
 import charmhelpers.contrib.openstack.cert_utils as cert_utils
 
+from base64 import b64decode, b64encode
+
+rsa_certs = {
+    'ca_key': b64encode('''-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAnhnAUJC+ZLlkmFZq1adbFgzJelPtr/M5T/7ao2kbVQEaocMS
+TR9FLbhgfDvbNVQKB/YcsdT+Vb0CJTZ/0pQAhF51y9TqJDII/++q+7PGwBRBv4O4
+I4FI/120vKu7FTu9oKRBVxsIRolyn6mpvxmlEcZXsfsuyoNrdKUdG1rOEbyRJRZY
+8En67UkRLnMajPod4bguZc8qktt/R0kD18U8V9k1ROXGM8XTlgPyAmdkguo9heic
+ZB+moXgCGveyxktIM1Lm2v2uM7MiM/Hln4cRcxnI63saAhbQcdoRoP9YyUQ3lV5y
+XyrQd1vhmqSrn7lHbR8OJNAy983smPfcIv2r8QIDAQABAoIBAAlcLO6YIy2DbFk4
+hIqxpcrgZu0/GstX8wSxafBSwLN/pTv+eI7oUwgp6kxwnsHBf/aIs5ozqfsZfY8G
+cvrcmEs97Gts54/NBotgfRb5xcKJcHsOKVCwzsmPmquw3xqattdT4ipuB0dly8t4
+F/ygYA11WKvI2zRSI4J8ZATCk4CpOXaUMB06Es6VUb0dDhwncCfXoOyo3CSp5/8L
+SCF4xpogqos8waXUWbUTIFw/SxIkY1WcQwACEMFw6JZdH33N0DDFFEdXGfl+VXp7
+Bzjru6c8raO8VsMUsazMTmdpyNrwF7Q1RBoz46F3jlPfoVS0DRZ42PjEy52Dj3FW
+U4leqYECgYEA0hx9d/DHcYdSA5IisPCRhjA0FY7rrfZzZoPbXBJWNScCqzrka1jQ
+2a+LzAMk8KzxqJvrWcyZE6BC8+ELnekip/xpnb/aNrWJ7V3a4/ErgI9nQ++SRZdC
+XlmLpE0DUQvXI5bRQUFpza52iRkVA9a/rCCPnvbdiCTwediVsrw19A0CgYEAwKFL
+5rX/GoJ1tlt4ULkSzIY/bYm0+/uLrpsYunWruWhPGu+o4laaOBc9Mzv7xH/4OGk5
+ZJ6UxoBOQgCKC7KU9t94hgsUmcNJeN+OtnfLsWtUPjoQQKlqCXwzS9Q8aIzNf2OR
+ZOENsJ3uVRzhIF+UrAX3dFnn0kJK6TD1oku3KnUCgYB5sXKiM1zwzlWcJ9nb7Zn7
+xJOGIP80BNgV+izlCOHRa0TKdBO0cP6V9mzbvr54f1KAO752hl/q1BmzMxcNYOhn
+r3Rkn6f9o+u9BW0wNJDjpytCV9G6aL9R8j9E7C4NlPQIcuPEDeT/8hpJkbNwQ8NE
+KJ/GjGkG345ApEcf/I6rSQKBgGE2hYmPO4jzYdh/3P5QCE6zSXtMTcwFLH8XwqkH
+DXzqSVG8tSxUrEu2XqpmkS6frnM5lz9SUJ7Ezbm9b+1rWIYmTTrIiML4rTGVEP7B
+AkktczxcLSuU0/Cpf3G7UCkrNeIeK5gPg8soSMknY+3kjrEp6bIMVVPlJMz+alhX
+gb6pAoGBAI/Ue1O6nXez/eCvARENo+5q86MGKj0EaO6O11AHSGpQyNOvNFAKjOv6
+USJcDiGtVXjpw7Cy2FmNMtdWdbD/L6xo65Z3i9FUXvfx7i8laYjviZhsKNZNMMbE
+q5pvXG3kwLYCqss381upQoKSYd4QuoVTKC19qZ12ubfiB45B/4nr
+-----END RSA PRIVATE KEY-----'''.encode()),
+    'ca_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUfhjNMTbE2ufAPObs8lV1RQaZ/RswDQYJKoZIhvcNAQEL
+BQAwEjEQMA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDQxMjE0MjVaFw0yNjA0MDQx
+MjE0MjVaMBIxEDAOBgNVBAMMB3Jvb3RfY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCeGcBQkL5kuWSYVmrVp1sWDMl6U+2v8zlP/tqjaRtVARqhwxJN
+H0UtuGB8O9s1VAoH9hyx1P5VvQIlNn/SlACEXnXL1OokMgj/76r7s8bAFEG/g7gj
+gUj/XbS8q7sVO72gpEFXGwhGiXKfqam/GaURxlex+y7Kg2t0pR0bWs4RvJElFljw
+SfrtSREucxqM+h3huC5lzyqS239HSQPXxTxX2TVE5cYzxdOWA/ICZ2SC6j2F6Jxk
+H6aheAIa97LGS0gzUuba/a4zsyIz8eWfhxFzGcjrexoCFtBx2hGg/1jJRDeVXnJf
+KtB3W+GapKufuUdtHw4k0DL3zeyY99wi/avxAgMBAAGjgYwwgYkwHQYDVR0OBBYE
+FKDWfP1/EF2aAlcJyQJMPGJ9GszYME0GA1UdIwRGMESAFKDWfP1/EF2aAlcJyQJM
+PGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A85uzyVXVF
+Bpn9GzAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQsFAAOC
+AQEAhILWfl+ldAnfRuXj3qHs6q/0zZz1uSlG8gSFlO/KuINYi6/Vp1r7BjRmTymD
+J1lPY7haQ8nlraT/j3CjXcCHHeUBCjShT8oWyLFxu/2FpMbw9B7zqqoSy1LVrIKh
+xfuRma2TUx3vxUpAvQIsw98si/2EH1qzUuvv47jb8Zg59EULtjT8pkN81FgXVOme
+s3V7YqAUSDLechoCN+rR0iWi7zVI6LeFnlfwWwMqYW/5SiWasgQohZM9eAjXECo7
+cSXGCUfL3EDAmbRxOMCOLFF5WNmGsm//a2ZEegnY/GmCNw501e3spqXzXIe5HRRR
+jOm40xKhkPtObqOe2lRsRzT1ww==
+-----END CERTIFICATE-----'''.encode()),
+    'server_key': b64encode('''-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3f7DzliwS5KsZ
+QNSK+9Zq+qZuLO4ptwCGGcfFYV8WTziy1ORvCJk5adRlS4kEhq4KBE+l+EJVOSrx
+PxUS8z/2JalxJ2fD6jrUrkEp9AAJefwpbK9qTMJ4PeuoLaPnzxtuvDesdzdSX4F1
+Ubm5Wr0g3RqDwrp5lrrAQNT65rXq7Vm7BRNFcLowpP3c9mno2IW1jA2oDgBP0P5J
+YICCA82E6Oz/hvp80uLUcu7Om0RaYf8Z8JwfkvK1qhrdJEMaqfdAhNJ0HlWPVnQz
+Io9H8XDJkIlLL1UNCTVRoJb2OgnKvGFIU+Rwa7bG2Wq5QceH/4T+KUeWvf9VN9Ef
+K0wURcrpAgMBAAECggEAJ2dDHzt7IV97IkQan/GuPHCwdm4tgkWq1iEJFehv28GN
+QlGW8ATfqkWAd3P96zvkeYAtfk1OKTDKeN178ALOFFRIC2VT0e0lTvBQS+r6aw6H
+yHlvPZtYEyvww79xN+DwWhoOtnkvJwAdM40mHZhPjpQMEokpM9zbI1eIpIwQOm76
+N65FwyiCghumUKPLDRvTjiVPDT/RuIDMzUAUKXSkh/2wfNarGWy6jDZS03b+8uBe
+ggPUSqTmtoSxL9C5aAG9CJi8SUkakw2s2fjwQxyeXC1GaWWnziFDA1Rhl1xnbehO
+QgDKhcwZMmddc1fySanei9EX5zgB2M8nQGeRljlCEQKBgQDgM7ht53Z0dxGHcbgE
+pJQBJQc9RScfTlU/L09DBOJI2rw5VtBXhCXEIQLxCM/A2H+e9vV8bhYbLLOB0vm8
+wCEs06gfikCzOKid+gr6gV1yfURCvd7zKv7HLZY9938oeqHuKYUef4gvFy/Ivw7U
+oGpkL1xlXD3FKbbAD6/S8WOxvQKBgQDRhiBTMO6eOvuiSj5YvCXMsRnicJDIOVaK
+ZuhgQo9WMZoAgX238Zpm63MQmqGc1NQt/uJXnyEr83/xtf+lGeGiWDzk8CJvPNNG
+fDhgAMqAtkjYUkPmVaR3xWwt9cxiMIK3edoiB9WYjuQChYP+75VqV0r85AFFoi5s
+qNWlPBSSnQKBgCz4EsDwkSDRFRH+rDM6M3l7TNVsPmmYE58lxRcjLqQAQ4qYsBct
+qUmKeYWRB+KdShO/YwO/LO3sbGDYyUCjpMPR/EG/QDTyY1e0ZGlUc0LYf02HueU6
+NXoL2bu6HaYn2rzjVREF8XHIi8wPDlF1j4FiwnyOINGgCUjCnLiJtD5dAoGAVJ56
+x55ngHgJ0I1ziJrUGUsdTRpxHqwpi1PsXZQEF6eIrtOdVoC4/v/wRLBuvMwntTvP
+Zdvapcl9zrzWNnOxcMN6NGvXPF2wZjMdAYjQQBNecB8pVQkZl1WgTx+KH82/vSH1
+OvE3DpoG9A3ANWHFUmFW47Oh3+GUJkY5orYVCPECgYEAya7XvUKwzsW1481+cHMw
+D9gAKMxkkPw+66SFZpRXGhCmAbhOxWaMRnT/CLDYf4jRkuFp0O7uh3rtVrhZf71z
+KAXlrNCq0cJotAQmfK7h4/8TgECz+h4KFfE6q3IlqbOOhCwYczRGkjGmh5qRYidu
+ksQN9IhwJNVGqPMhWznB11s=
+-----END PRIVATE KEY-----'''.encode()),
+    'server_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIDVjCCAj6gAwIBAgIQc3/Zflj6FxtoQphOJRYFuTANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQDDAdyb290X2NhMB4XDTIyMDQwNDEyMTQyNVoXDTI2MDQwNDEyMTQy
+NVowETEPMA0GA1UEAwwGc2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAt3+w85YsEuSrGUDUivvWavqmbizuKbcAhhnHxWFfFk84stTkbwiZOWnU
+ZUuJBIauCgRPpfhCVTkq8T8VEvM/9iWpcSdnw+o61K5BKfQACXn8KWyvakzCeD3r
+qC2j588bbrw3rHc3Ul+BdVG5uVq9IN0ag8K6eZa6wEDU+ua16u1ZuwUTRXC6MKT9
+3PZp6NiFtYwNqA4AT9D+SWCAggPNhOjs/4b6fNLi1HLuzptEWmH/GfCcH5Lytaoa
+3SRDGqn3QITSdB5Vj1Z0MyKPR/FwyZCJSy9VDQk1UaCW9joJyrxhSFPkcGu2xtlq
+uUHHh/+E/ilHlr3/VTfRHytMFEXK6QIDAQABo4GoMIGlMAkGA1UdEwQCMAAwHQYD
+VR0OBBYEFFNUTBIAyHywQtnxLinEV0ptSQpeME0GA1UdIwRGMESAFKDWfP1/EF2a
+AlcJyQJMPGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A8
+5uzyVXVFBpn9GzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwCwYDVR0P
+BAQDAgWgMA0GCSqGSIb3DQEBCwUAA4IBAQCI6nGhEj74Yr8hvMMBsvWsD2OqFy9c
+gg+5gT9+d+mSszuJPA/oXX7xeXEw0PLezKTR4OYKcZP3m9IMDuvlWAeyosNcm/VN
+rkBJD5SqbAYQPRl2uo1LlhnvpOWVI6E3ik8KcKb7D6OtPOB851kCl21bD30zr9fu
+HIg8fx07p7AbtVlJB3zAy2pF4zwMuPe0IIil0op7UJNRNhYfH8uQneUw4TPv3h5d
+ZKSHtCFgRce/T7PX+4/GcQEycmrTrbhkuJ5uY/9VcFi5j6pvFuGcT/rmlbLfqabX
+3szYaO+M+6TVvDzadMgMDObEeH56JP3lHFwj/WgEIBInkr9P/bcA4Sm/
+-----END CERTIFICATE-----'''.encode()),
+    'server_pub': '''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt3+w85YsEuSrGUDUivvW
+avqmbizuKbcAhhnHxWFfFk84stTkbwiZOWnUZUuJBIauCgRPpfhCVTkq8T8VEvM/
+9iWpcSdnw+o61K5BKfQACXn8KWyvakzCeD3rqC2j588bbrw3rHc3Ul+BdVG5uVq9
+IN0ag8K6eZa6wEDU+ua16u1ZuwUTRXC6MKT93PZp6NiFtYwNqA4AT9D+SWCAggPN
+hOjs/4b6fNLi1HLuzptEWmH/GfCcH5Lytaoa3SRDGqn3QITSdB5Vj1Z0MyKPR/Fw
+yZCJSy9VDQk1UaCW9joJyrxhSFPkcGu2xtlquUHHh/+E/ilHlr3/VTfRHytMFEXK
+6QIDAQAB
+-----END PUBLIC KEY-----'''.encode(),
+}
+
+ec_certs = {
+    'ca_key': b64encode('''-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDBaLKFGs/6gl0qr46DOvKchCjLR/Qwa5bX0ofvHZ6XzziwPiJpNRIXr
+DGn6dy0ahTSgBwYFK4EEACKhZANiAATbytPyF9NnVS5MLVHLyc22t3b3FHsH9LRt
+VnRWky2uxdfmGqjjFZaCWxz2D3AsQyYEVmnkInRV0nbD1WkBCQntp/WHS8DVIt7j
+vQPw90VefzGd9lN5UZKNwHlBhQb+Vxc=
+-----END EC PRIVATE KEY-----'''.encode()),
+    'ca_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIIB7zCCAXagAwIBAgIUPdrHjpTzdGmxOhOb6PLPgz1KNP8wCgYIKoZIzj0EAwIw
+EjEQMA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDUxNzUyMTRaFw0yNjA0MDUxNzUy
+MTRaMBIxEDAOBgNVBAMMB3Jvb3RfY2EwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATb
+ytPyF9NnVS5MLVHLyc22t3b3FHsH9LRtVnRWky2uxdfmGqjjFZaCWxz2D3AsQyYE
+VmnkInRV0nbD1WkBCQntp/WHS8DVIt7jvQPw90VefzGd9lN5UZKNwHlBhQb+Vxej
+gYwwgYkwHQYDVR0OBBYEFOtxQHpF0SK7iBjbrkmvLyzsGikEME0GA1UdIwRGMESA
+FOtxQHpF0SK7iBjbrkmvLyzsGikEoRakFDASMRAwDgYDVQQDDAdyb290X2NhghQ9
+2seOlPN0abE6E5vo8s+DPUo0/zAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjAK
+BggqhkjOPQQDAgNnADBkAjABM001FiLLs7Bx70Qvy8norf4dvHf0o3D5ZK/sjeu6
+olh0hEPuPThpbaDY23PCfv4CMHQi1mO4TYp9Wn4PVaQ+NFcgjJN/Mq2V9wxJBdwy
+vhJnoYvJ7XVDjUX6iFDPjOr9Vw==
+-----END CERTIFICATE-----'''.encode()),
+    'ca_pub': '''-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE28rT8hfTZ1UuTC1Ry8nNtrd29xR7B/S0
+bVZ0VpMtrsXX5hqo4xWWglsc9g9wLEMmBFZp5CJ0VdJ2w9VpAQkJ7af1h0vA1SLe
+470D8PdFXn8xnfZTeVGSjcB5QYUG/lcX
+-----END PUBLIC KEY-----''',
+    'server_key': b64encode('''-----BEGIN PRIVATE KEY-----
+MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDDsO4KohkPyc6RgCup3
+eBUokioiX1k9DmC8L43vzDTEn4KPVZ0wRpd/BM0Vl/zjcfShZANiAAR9yklMOLox
+dmxdW2KrnfgqQ1J4dqR2ipPwK0f4OnDgx7nXujqhfWAS4XvipD+G9NYUbsXvUxQh
+T03NgsoSsA+Hxz4TseasHc+lkeWRjxLbsk6gxcj581WZSAdiSK4ICiY=
+-----END PRIVATE KEY-----'''.encode()),
+    'server_cert': b64encode('''-----BEGIN CERTIFICATE-----
+MIICCDCCAY6gAwIBAgIRAOZVMlJSudlDtvzTDG4wL9EwCgYIKoZIzj0EAwIwEjEQ
+MA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDUxNzUyMTRaFw0yNjA0MDUxNzUyMTRa
+MBExDzANBgNVBAMMBnNlcnZlcjB2MBAGByqGSM49AgEGBSuBBAAiA2IABH3KSUw4
+ujF2bF1bYqud+CpDUnh2pHaKk/ArR/g6cODHude6OqF9YBLhe+KkP4b01hRuxe9T
+FCFPTc2CyhKwD4fHPhOx5qwdz6WR5ZGPEtuyTqDFyPnzVZlIB2JIrggKJqOBqDCB
+pTAJBgNVHRMEAjAAMB0GA1UdDgQWBBSVrhk5/QGvQZn0Csakls7OIC2x5jBNBgNV
+HSMERjBEgBTrcUB6RdEiu4gY265Jry8s7BopBKEWpBQwEjEQMA4GA1UEAwwHcm9v
+dF9jYYIUPdrHjpTzdGmxOhOb6PLPgz1KNP8wHQYDVR0lBBYwFAYIKwYBBQUHAwEG
+CCsGAQUFBwMCMAsGA1UdDwQEAwIFoDAKBggqhkjOPQQDAgNoADBlAjBoRHrBPGNA
+x5ZH0MmzG9PQHva5R59UiMTv1mZrDvTe51Ihr1XuWhxU3uzcfyZgvZICMQCsYicQ
+dhuYoD4409H47k+LCUNpOEZCeVmUrKyVeyIo/+Hs87Bo2T3+4yG3slkGEds=
+-----END CERTIFICATE-----'''.encode()),
+    'server_pub': '''-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfcpJTDi6MXZsXVtiq534KkNSeHakdoqT
+8CtH+Dpw4Me517o6oX1gEuF74qQ/hvTWFG7F71MUIU9NzYLKErAPh8c+E7HmrB3P
+pZHlkY8S27JOoMXI+fNVmUgHYkiuCAom
+-----END PUBLIC KEY-----''',
+}
 
 class CertUtilsTests(unittest.TestCase):
 
@@ -516,31 +675,34 @@ class CertUtilsTests(unittest.TestCase):
         _config = {}
         config.side_effect = lambda x: _config.get(x)
         os_exists.return_value = False
-        cert_utils._manage_ca_certs('CA', 'certificates:2')
+        cert_utils._manage_ca_certs(b64decode(rsa_certs['ca_cert']).decode(), 'certificates:2')
         install_ca_cert.assert_called_once_with(
-            b'CA',
+            b64decode(rsa_certs['ca_cert']),
             name='vault_juju_ca_cert')
         self.assertFalse(os_remove.called)
+
         # Test old cert removed.
         install_ca_cert.reset_mock()
         os_exists.reset_mock()
+
         os_exists.return_value = True
-        cert_utils._manage_ca_certs('CA', 'certificates:2')
+        cert_utils._manage_ca_certs(b64decode(rsa_certs['ca_cert']).decode(), 'certificates:2')
         install_ca_cert.assert_called_once_with(
-            b'CA',
+            b64decode(rsa_certs['ca_cert']),
             name='vault_juju_ca_cert')
         os_remove.assert_called_once_with(
             '/usr/local/share/ca-certificates/keystone_juju_ca_cert.crt')
+
         # Test cert is installed from config
-        _config['ssl_ca'] = 'Q0FGUk9NQ09ORklHCg=='
+        _config['ssl_ca'] = rsa_certs['ca_cert']
         install_ca_cert.reset_mock()
         os_remove.reset_mock()
         os_exists.reset_mock()
         os_exists.return_value = True
-        cert_utils._manage_ca_certs('CA', 'certificates:2')
+        cert_utils._manage_ca_certs(b64decode(rsa_certs['ca_cert']).decode(), 'certificates:2')
         expected = [
-            mock.call(b'CAFROMCONFIG', name='keystone_juju_ca_cert'),
-            mock.call(b'CA', name='vault_juju_ca_cert')]
+            mock.call(b64decode(rsa_certs['ca_cert']), name='keystone_juju_ca_cert'),
+            mock.call(b64decode(rsa_certs['ca_cert']), name='vault_juju_ca_cert')]
         install_ca_cert.assert_has_calls(expected)
         self.assertFalse(os_remove.called)
 
@@ -723,3 +885,64 @@ class CertUtilsTests(unittest.TestCase):
             expect.sort())
         get_relation_ip.assert_has_calls(
             expected_get_relation_ip_calls, any_order=True)
+
+    def test__x509_normalize_input(self):
+        self.assertEqual(
+            cert_utils._x509_normalize_input('str'), 'str'.encode())
+        self.assertEqual(
+            cert_utils._x509_normalize_input(b'bytes'), 'bytes'.encode())
+        self.assertEqual(
+            cert_utils._x509_normalize_input(None), bytes())
+
+    def test_x509_get_pubkey(self):
+        self.assertEqual(
+            cert_utils.x509_get_pubkey(b64decode(rsa_certs['server_cert'])),
+            rsa_certs['server_pub'])
+
+    def test_x509_validate_cert_chain(self):
+        self.assertTrue(cert_utils.x509_validate_cert_chain(
+            b64decode(rsa_certs['server_cert']),
+            ssl_ca=b64decode(rsa_certs['ca_cert'])))
+        self.assertFalse(cert_utils.x509_validate_cert_chain(
+            b64decode(rsa_certs['server_cert']),
+            ssl_ca=b64decode(ec_certs['ca_cert'])))
+
+    def test_x509_validate_cert_parity(self):
+        self.assertFalse(cert_utils.x509_validate_cert_parity(
+            b64decode(rsa_certs['server_cert']),
+            b64decode(rsa_certs['ca_key'])))
+        self.assertFalse(cert_utils.x509_validate_cert_parity(
+            bytes(), b64decode(rsa_certs['ca_key'])))
+        self.assertFalse(cert_utils.x509_validate_cert_parity(
+            b64decode(rsa_certs['ca_cert']), bytes()))
+        self.assertTrue(cert_utils.x509_validate_cert_parity(
+            b64decode(rsa_certs['ca_cert']), b64decode(rsa_certs['ca_key'])))
+
+    def test_x509_validate_cert(self):
+        self.assertFalse(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(rsa_certs['ca_key']),
+                            validate_chain=False))
+        self.assertTrue(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(rsa_certs['server_key']),
+                            validate_chain=False))
+        self.assertFalse(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(rsa_certs['server_key']),
+                            ssl_ca=b64decode(ec_certs['ca_cert']),
+                            validate_chain=True))
+        self.assertFalse(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(rsa_certs['server_key']),
+                            validate_chain=True))
+        self.assertFalse(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(ec_certs['server_key']),
+                            ssl_ca=b64decode(rsa_certs['ca_cert']),
+                            validate_chain=True))
+        self.assertTrue(cert_utils.x509_validate_cert(
+                            b64decode(rsa_certs['server_cert']),
+                            ssl_key=b64decode(rsa_certs['server_key']),
+                            ssl_ca=b64decode(rsa_certs['ca_cert']),
+                            validate_chain=True))

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1,3 +1,4 @@
+import base64
 import collections
 import copy
 import json
@@ -17,6 +18,75 @@ from tests.helpers import patch_open
 import tests.utils
 
 import charmhelpers.contrib.openstack.context as context
+
+SSL_CA = base64.b64encode('''-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUfhjNMTbE2ufAPObs8lV1RQaZ/RswDQYJKoZIhvcNAQEL
+BQAwEjEQMA4GA1UEAwwHcm9vdF9jYTAeFw0yMjA0MDQxMjE0MjVaFw0yNjA0MDQx
+MjE0MjVaMBIxEDAOBgNVBAMMB3Jvb3RfY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCeGcBQkL5kuWSYVmrVp1sWDMl6U+2v8zlP/tqjaRtVARqhwxJN
+H0UtuGB8O9s1VAoH9hyx1P5VvQIlNn/SlACEXnXL1OokMgj/76r7s8bAFEG/g7gj
+gUj/XbS8q7sVO72gpEFXGwhGiXKfqam/GaURxlex+y7Kg2t0pR0bWs4RvJElFljw
+SfrtSREucxqM+h3huC5lzyqS239HSQPXxTxX2TVE5cYzxdOWA/ICZ2SC6j2F6Jxk
+H6aheAIa97LGS0gzUuba/a4zsyIz8eWfhxFzGcjrexoCFtBx2hGg/1jJRDeVXnJf
+KtB3W+GapKufuUdtHw4k0DL3zeyY99wi/avxAgMBAAGjgYwwgYkwHQYDVR0OBBYE
+FKDWfP1/EF2aAlcJyQJMPGJ9GszYME0GA1UdIwRGMESAFKDWfP1/EF2aAlcJyQJM
+PGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A85uzyVXVF
+Bpn9GzAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQsFAAOC
+AQEAhILWfl+ldAnfRuXj3qHs6q/0zZz1uSlG8gSFlO/KuINYi6/Vp1r7BjRmTymD
+J1lPY7haQ8nlraT/j3CjXcCHHeUBCjShT8oWyLFxu/2FpMbw9B7zqqoSy1LVrIKh
+xfuRma2TUx3vxUpAvQIsw98si/2EH1qzUuvv47jb8Zg59EULtjT8pkN81FgXVOme
+s3V7YqAUSDLechoCN+rR0iWi7zVI6LeFnlfwWwMqYW/5SiWasgQohZM9eAjXECo7
+cSXGCUfL3EDAmbRxOMCOLFF5WNmGsm//a2ZEegnY/GmCNw501e3spqXzXIe5HRRR
+jOm40xKhkPtObqOe2lRsRzT1ww==
+-----END CERTIFICATE-----'''.encode())
+SSL_KEY = base64.b64encode('''-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC3f7DzliwS5KsZ
+QNSK+9Zq+qZuLO4ptwCGGcfFYV8WTziy1ORvCJk5adRlS4kEhq4KBE+l+EJVOSrx
+PxUS8z/2JalxJ2fD6jrUrkEp9AAJefwpbK9qTMJ4PeuoLaPnzxtuvDesdzdSX4F1
+Ubm5Wr0g3RqDwrp5lrrAQNT65rXq7Vm7BRNFcLowpP3c9mno2IW1jA2oDgBP0P5J
+YICCA82E6Oz/hvp80uLUcu7Om0RaYf8Z8JwfkvK1qhrdJEMaqfdAhNJ0HlWPVnQz
+Io9H8XDJkIlLL1UNCTVRoJb2OgnKvGFIU+Rwa7bG2Wq5QceH/4T+KUeWvf9VN9Ef
+K0wURcrpAgMBAAECggEAJ2dDHzt7IV97IkQan/GuPHCwdm4tgkWq1iEJFehv28GN
+QlGW8ATfqkWAd3P96zvkeYAtfk1OKTDKeN178ALOFFRIC2VT0e0lTvBQS+r6aw6H
+yHlvPZtYEyvww79xN+DwWhoOtnkvJwAdM40mHZhPjpQMEokpM9zbI1eIpIwQOm76
+N65FwyiCghumUKPLDRvTjiVPDT/RuIDMzUAUKXSkh/2wfNarGWy6jDZS03b+8uBe
+ggPUSqTmtoSxL9C5aAG9CJi8SUkakw2s2fjwQxyeXC1GaWWnziFDA1Rhl1xnbehO
+QgDKhcwZMmddc1fySanei9EX5zgB2M8nQGeRljlCEQKBgQDgM7ht53Z0dxGHcbgE
+pJQBJQc9RScfTlU/L09DBOJI2rw5VtBXhCXEIQLxCM/A2H+e9vV8bhYbLLOB0vm8
+wCEs06gfikCzOKid+gr6gV1yfURCvd7zKv7HLZY9938oeqHuKYUef4gvFy/Ivw7U
+oGpkL1xlXD3FKbbAD6/S8WOxvQKBgQDRhiBTMO6eOvuiSj5YvCXMsRnicJDIOVaK
+ZuhgQo9WMZoAgX238Zpm63MQmqGc1NQt/uJXnyEr83/xtf+lGeGiWDzk8CJvPNNG
+fDhgAMqAtkjYUkPmVaR3xWwt9cxiMIK3edoiB9WYjuQChYP+75VqV0r85AFFoi5s
+qNWlPBSSnQKBgCz4EsDwkSDRFRH+rDM6M3l7TNVsPmmYE58lxRcjLqQAQ4qYsBct
+qUmKeYWRB+KdShO/YwO/LO3sbGDYyUCjpMPR/EG/QDTyY1e0ZGlUc0LYf02HueU6
+NXoL2bu6HaYn2rzjVREF8XHIi8wPDlF1j4FiwnyOINGgCUjCnLiJtD5dAoGAVJ56
+x55ngHgJ0I1ziJrUGUsdTRpxHqwpi1PsXZQEF6eIrtOdVoC4/v/wRLBuvMwntTvP
+Zdvapcl9zrzWNnOxcMN6NGvXPF2wZjMdAYjQQBNecB8pVQkZl1WgTx+KH82/vSH1
+OvE3DpoG9A3ANWHFUmFW47Oh3+GUJkY5orYVCPECgYEAya7XvUKwzsW1481+cHMw
+D9gAKMxkkPw+66SFZpRXGhCmAbhOxWaMRnT/CLDYf4jRkuFp0O7uh3rtVrhZf71z
+KAXlrNCq0cJotAQmfK7h4/8TgECz+h4KFfE6q3IlqbOOhCwYczRGkjGmh5qRYidu
+ksQN9IhwJNVGqPMhWznB11s=
+-----END PRIVATE KEY-----'''.encode())
+SSL_CERT = base64.b64encode('''-----BEGIN CERTIFICATE-----
+MIIDVjCCAj6gAwIBAgIQc3/Zflj6FxtoQphOJRYFuTANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQDDAdyb290X2NhMB4XDTIyMDQwNDEyMTQyNVoXDTI2MDQwNDEyMTQy
+NVowETEPMA0GA1UEAwwGc2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAt3+w85YsEuSrGUDUivvWavqmbizuKbcAhhnHxWFfFk84stTkbwiZOWnU
+ZUuJBIauCgRPpfhCVTkq8T8VEvM/9iWpcSdnw+o61K5BKfQACXn8KWyvakzCeD3r
+qC2j588bbrw3rHc3Ul+BdVG5uVq9IN0ag8K6eZa6wEDU+ua16u1ZuwUTRXC6MKT9
+3PZp6NiFtYwNqA4AT9D+SWCAggPNhOjs/4b6fNLi1HLuzptEWmH/GfCcH5Lytaoa
+3SRDGqn3QITSdB5Vj1Z0MyKPR/FwyZCJSy9VDQk1UaCW9joJyrxhSFPkcGu2xtlq
+uUHHh/+E/ilHlr3/VTfRHytMFEXK6QIDAQABo4GoMIGlMAkGA1UdEwQCMAAwHQYD
+VR0OBBYEFFNUTBIAyHywQtnxLinEV0ptSQpeME0GA1UdIwRGMESAFKDWfP1/EF2a
+AlcJyQJMPGJ9GszYoRakFDASMRAwDgYDVQQDDAdyb290X2NhghR+GM0xNsTa58A8
+5uzyVXVFBpn9GzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwCwYDVR0P
+BAQDAgWgMA0GCSqGSIb3DQEBCwUAA4IBAQCI6nGhEj74Yr8hvMMBsvWsD2OqFy9c
+gg+5gT9+d+mSszuJPA/oXX7xeXEw0PLezKTR4OYKcZP3m9IMDuvlWAeyosNcm/VN
+rkBJD5SqbAYQPRl2uo1LlhnvpOWVI6E3ik8KcKb7D6OtPOB851kCl21bD30zr9fu
+HIg8fx07p7AbtVlJB3zAy2pF4zwMuPe0IIil0op7UJNRNhYfH8uQneUw4TPv3h5d
+ZKSHtCFgRce/T7PX+4/GcQEycmrTrbhkuJ5uY/9VcFi5j6pvFuGcT/rmlbLfqabX
+3szYaO+M+6TVvDzadMgMDObEeH56JP3lHFwj/WgEIBInkr9P/bcA4Sm/
+-----END CERTIFICATE-----'''.encode())
 
 
 class FakeRelation(object):
@@ -105,9 +175,9 @@ SHARED_DB_RELATION_ALT_RID = {
 SHARED_DB_RELATION_SSL = {
     'db_host': 'dbserver.local',
     'password': 'foo',
-    'ssl_ca': 'Zm9vCg==',
-    'ssl_cert': 'YmFyCg==',
-    'ssl_key': 'Zm9vYmFyCg==',
+    'ssl_ca': SSL_CA,
+    'ssl_cert': SSL_CERT,
+    'ssl_key': SSL_KEY,
 }
 
 SHARED_DB_CONFIG = {
@@ -265,7 +335,7 @@ AMQP_RELATION_WITH_SSL = {
     'password': 'foobar',
     'vip': '10.0.0.1',
     'ssl_port': 5671,
-    'ssl_ca': 'cert',
+    'ssl_ca': SSL_CA,
     'ha_queues': 'queues',
 }
 
@@ -661,7 +731,6 @@ ABSENT_MACS = "aa:a5:ae:ae:ab:a4 "
 
 # Imported in contexts.py and needs patching in setUp()
 TO_PATCH = [
-    'b64decode',
     'check_call',
     'get_cert',
     'get_ca_cert',
@@ -874,12 +943,12 @@ class ContextTests(unittest.TestCase):
         for f in files:
             self.assertIn(f, _open.call_args_list)
         self.assertEquals(db_ssl_ctxt, expected)
-        decode = [
-            call(SHARED_DB_RELATION_SSL['ssl_ca']),
-            call(SHARED_DB_RELATION_SSL['ssl_cert']),
-            call(SHARED_DB_RELATION_SSL['ssl_key'])
-        ]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        #decode = [
+        #    call(SHARED_DB_RELATION_SSL['ssl_ca']),
+        #    call(SHARED_DB_RELATION_SSL['ssl_cert']),
+        #    call(SHARED_DB_RELATION_SSL['ssl_key'])
+        #]
+        #self.assertEquals(decode, _b64dec.call_args_list)
 
     def test_db_ssl_nossldir(self):
         db_ssl_ctxt = context.db_ssl(SHARED_DB_RELATION_SSL, {}, None)
@@ -1394,8 +1463,8 @@ class ContextTests(unittest.TestCase):
         }
         _open.assert_called_once_with(ssl_dir + '/rabbit-client-ca.pem', 'wb')
         self.assertEquals(result, expected)
-        self.assertEquals([call(AMQP_RELATION_WITH_SSL['ssl_ca'])],
-                          self.b64decode.call_args_list)
+        #self.assertEquals([call(AMQP_RELATION_WITH_SSL['ssl_ca'])],
+        #                  _b64dec.call_args_list)
 
     def test_amqp_context_with_data_ssl_noca(self):
         '''Test amqp context with all required data with ssl but missing ca'''
@@ -1411,7 +1480,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_user': 'adam',
             'rabbit_ssl_port': 5671,
             'rabbitmq_virtual_host': 'foo',
-            'rabbit_ssl_ca': 'cert',
+            'rabbit_ssl_ca': SSL_CA,
             'rabbitmq_ha_queues': True,
             'transport_url': 'rabbit://adam:foobar@rabbithost:5671/foo'
         }
@@ -2677,10 +2746,14 @@ class ContextTests(unittest.TestCase):
         ex_cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers']
         self.check_call.assert_called_with(ex_cmd)
 
-    def test_https_configure_cert(self):
+    @patch.object(context, 'b64decode')
+    def test_https_configure_cert(self, _b64dec):
         # Test apache2 properly installs certs and keys to disk
-        self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
-        self.b64decode.side_effect = [b'SSL_CERT', b'SSL_KEY']
+        self.get_cert.return_value = (SSL_CERT, SSL_KEY)
+        _b64dec.side_effect = [
+            base64.b64decode(SSL_CERT),
+            base64.b64decode(SSL_KEY)
+        ]
         apache = context.ApacheSSLContext()
         apache.service_namespace = 'cinder'
         apache.configure_cert('test-cn')
@@ -2688,20 +2761,24 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert_test-cn',
-                      content=b'SSL_CERT', owner='root', group='root',
+                      content=base64.b64decode(SSL_CERT), owner='root', group='root',
                       perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key_test-cn',
-                      content=b'SSL_KEY', owner='root', group='root',
+                      content=base64.b64decode(SSL_KEY), owner='root', group='root',
                       perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
-        decode = [call('SSL_CERT'), call('SSL_KEY')]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        decode = [call(SSL_CERT), call(SSL_KEY)]
+        self.assertEquals(decode, _b64dec.call_args_list)
 
-    def test_https_configure_cert_deprecated(self):
+    @patch.object(context, 'b64decode')
+    def test_https_configure_cert_deprecated(self, _b64dec):
         # Test apache2 properly installs certs and keys to disk
-        self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
-        self.b64decode.side_effect = ['SSL_CERT', 'SSL_KEY']
+        self.get_cert.return_value = [SSL_CERT, SSL_KEY]
+        _b64dec.side_effect = [
+            base64.b64decode(SSL_CERT),
+            base64.b64decode(SSL_KEY)
+        ]
         apache = context.ApacheSSLContext()
         apache.service_namespace = 'cinder'
         apache.configure_cert()
@@ -2709,15 +2786,15 @@ class ContextTests(unittest.TestCase):
         self.mkdir.assert_called_with(path='/etc/apache2/ssl/cinder')
         # appropriate files are written.
         files = [call(path='/etc/apache2/ssl/cinder/cert',
-                      content='SSL_CERT', owner='root', group='root',
+                      content=base64.b64decode(SSL_CERT), owner='root', group='root',
                       perms=0o640),
                  call(path='/etc/apache2/ssl/cinder/key',
-                      content='SSL_KEY', owner='root', group='root',
+                      content=base64.b64decode(SSL_KEY), owner='root', group='root',
                       perms=0o640)]
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
-        decode = [call('SSL_CERT'), call('SSL_KEY')]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        decode = [call(SSL_CERT), call(SSL_KEY)]
+        self.assertEquals(decode, _b64dec.call_args_list)
 
     def test_https_canonical_names(self):
         rel = FakeRelation(IDENTITY_RELATION_SINGLE_CERT)

--- a/tools/generate-easyrsa-pki.sh
+++ b/tools/generate-easyrsa-pki.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -x
+EASYRSA_LOC="${EASYRSA_LOC:-/usr/share/easy-rsa}"
+
+case "x${1}" in
+  xec)    PARAMS="--use-algo=ec --curve=secp384r1";;
+  xrsa|x) PARAMS="--use-algo=rsa --keysize=2048";;
+  *)      echo "Wrong algo kind, exiting."; exit 1;;
+esac
+
+export PATH="${EASYRSA_LOC}${PATH:+:${PATH}}"
+easyrsa init-pki
+#ln -s "${EASYRSA_LOC}/openssl-easyrsa.cnf" pki/openssl-easyrsa.cnf
+#ln -s "${EASYRSA_LOC}/safessl-easyrsa.cnf" pki/safessl-easyrsa.cnf
+ln -s "${EASYRSA_LOC}/x509-types"
+
+easyrsa --req-c=GB --req-city=London --days=1461 --batch ${EC_PARAMS} \
+  --req-st='' --req-email='' --req-ou='' \
+  --req-org="Canonical Group Limited" --req-cn=root_ca \
+  build-ca nopass
+
+if [ -n "${SUB_CA}" ]; then
+  mkdir -p sub; cd sub
+  easyrsa init-pki
+  easyrsa --req-c=GB --req-city=London --days=1461 --batch ${EC_PARAMS} \
+    --req-st='' --req-email='' --req-ou='' \
+    --req-org="Canonical UK Limited" --req-cn=sub_ca \
+    build-ca nopass subca
+  cd ..
+
+  cp sub/pki/reqs/ca.req pki/reqs/sub_ca.req
+  easyrsa --batch sign-req ca sub_ca nopass
+  cp pki/issued/sub_ca.crt sub/pki/ca.crt
+fi
+
+#cd sub
+easyrsa --req-c=GB --req-city=London --days=1461 --batch ${EC_PARAMS} \
+  --req-st='' --req-email='' --req-ou='' \
+  --req-org="Canonical UK Limited" \
+  build-serverClient-full server nopass
+#cd ..


### PR DESCRIPTION
This change attempts to validate `ssl_*` configuration options and relations for valid X509 certificates, as well as verify their trust chains.

Related change: https://review.opendev.org/c/openstack/charm-openstack-dashboard/+/836797
Related issue: [LP#1772674](https://bugs.launchpad.net/charm-openstack-dashboard/+bug/1772674)