### PR TITLE
Ease KeepAliveTimeout in line with keystoneauth1.session.Session

### DIFF
--- a/charmhelpers/contrib/openstack/templates/openstack_https_frontend
+++ b/charmhelpers/contrib/openstack/templates/openstack_https_frontend
@@ -22,6 +22,8 @@ Listen {{ ext_port }}
     ProxyPassReverse / http://localhost:{{ int }}/
     ProxyPreserveHost on
     RequestHeader set X-Forwarded-Proto "https"
+    KeepAliveTimeout 75
+    MaxKeepAliveRequests 1000
 </VirtualHost>
 {% endfor -%}
 <Proxy *>

--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -20,6 +20,8 @@ Listen {{ public_port }}
     WSGIScriptAlias / {{ script }}
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
+    KeepAliveTimeout 75
+    MaxKeepAliveRequests 1000
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
@@ -46,6 +48,8 @@ Listen {{ public_port }}
     WSGIScriptAlias / {{ admin_script }}
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
+    KeepAliveTimeout 75
+    MaxKeepAliveRequests 1000
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
@@ -72,6 +76,8 @@ Listen {{ public_port }}
     WSGIScriptAlias / {{ public_script }}
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
+    KeepAliveTimeout 75
+    MaxKeepAliveRequests 1000
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>


### PR DESCRIPTION
Apache2's default value for KeepAliveTimeout is 5 seconds, which is okay
for general web-page serving use cases. However, sessions and connection
pools created by keystoneauth1.session.Session can be terminated
unnecessarily during multiple API calls in a session due to the short
KeepAliveTimeout.

Let's ease KeepAliveTimeout to 75 seconds, which is fairly standard for
API services behind a reverse proxy since it's the default value of
nginx.

Closes-Bug: #1947010
(cherry picked from commit 9a5bf40790080362cf340692b8992f31a6750cda)