### PR TITLE
Python 3.10 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = charmhelpers/
+omit =
+    */templates/*
+    tests/*
+    tools/*
+    setup.py
+    .tox/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             env: pep8,py37
           - python-version: 3.8
             env: pep8,py38
+          - python-version: "3.10"
+            env: pep8,py310
 
     steps:
     - uses: actions/checkout@v2

--- a/charmhelpers/core/services/base.py
+++ b/charmhelpers/core/services/base.py
@@ -15,7 +15,8 @@
 import os
 import json
 import inspect
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 
 from charmhelpers.core import host
 from charmhelpers.core import hookenv

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,9 @@ git+https://git.launchpad.net/ubuntu/+source/python-distutils-extra
 pip
 coverage>=3.6
 mock>=1.0.1,<1.1.0
-nose>=1.3.1
+nose>=1.3.1; python_version < '3.10'
+nose2; python_version >= '3.10'
+nose2[coverage_plugin]; python_version >= '3.10'
 flake8
 # testtools==0.9.14  # Before dependent on modern 'six'
 testtools

--- a/tests/cli/test_cmdline.py
+++ b/tests/cli/test_cmdline.py
@@ -1,6 +1,7 @@
 """Tests for the commandant code that analyzes a function signature to
 determine the parameters to argparse."""
 
+import sys
 from unittest import TestCase
 from mock import (
     patch,
@@ -42,11 +43,15 @@ class SubCommandTest(TestCase):
         def payload():
             "A function that does work."
             pass
-        with self.assertRaises(TypeError):
-            with patch("sys.argv", "tests deliberately bad input".split()):
-                with patch("sys.stderr"):
+
+        with patch("sys.argv", "tests deliberately bad input".split()):
+            with patch("sys.stderr"):
+                if sys.version_info < (3, 10):
+                    self.assertRaises(TypeError,
+                                      self.cl.argument_parser.parse_args)
+                else:
                     self.cl.argument_parser.parse_args()
-        _sys_exit.assert_called_once_with(2)
+        _sys_exit.assert_called_with(2)
 
     @patch('sys.exit')
     def test_subcommand_wrapper_cmdline_options(self, _sys_exit):

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -7,8 +7,6 @@ import netifaces
 import charmhelpers.contrib.network.ip as net_ip
 from mock import patch, MagicMock
 
-import nose.tools
-
 
 DUMMY_ADDRESSES = {
     'lo': {
@@ -304,7 +302,7 @@ class IPTest(unittest.TestCase):
     def test_get_ipv6_addr_no_ipv6(self, _interfaces, _ifaddresses):
         _interfaces.return_value = DUMMY_ADDRESSES.keys()
         _ifaddresses.side_effect = DUMMY_ADDRESSES.__getitem__
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_ipv6_addr('eth0:1')
 
     @patch.object(netifaces, 'ifaddresses')
@@ -448,7 +446,7 @@ class IPTest(unittest.TestCase):
     @patch.object(netifaces, 'interfaces')
     def test_get_iface_addr_invalid_type(self, _interfaces):
         _interfaces.return_value = DUMMY_ADDRESSES.keys()
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_iface_addr(iface='eth0', inet_type='AF_BOB')
 
     @patch.object(netifaces, 'ifaddresses')
@@ -461,14 +459,14 @@ class IPTest(unittest.TestCase):
     @patch.object(netifaces, 'interfaces')
     def test_get_iface_addr_invalid_interface_fatal(self, _interfaces):
         _interfaces.return_value = DUMMY_ADDRESSES.keys()
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_ipv4_addr("eth3", fatal=True)
 
     @patch.object(netifaces, 'interfaces')
     def test_get_iface_addr_invalid_interface_fatal_incaliases(self,
                                                                _interfaces):
         _interfaces.return_value = DUMMY_ADDRESSES.keys()
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_ipv4_addr("eth3", fatal=True, inc_aliases=True)
 
     @patch.object(netifaces, 'ifaddresses')
@@ -580,12 +578,12 @@ class IPTest(unittest.TestCase):
     def test_get_ipv6_global_dynamic_address_invalid_address(
             self, mock_get_iface_addr, mock_check_out):
         mock_get_iface_addr.return_value = []
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_ipv6_addr()
 
         mock_get_iface_addr.return_value = ['2001:db8:1:0:2918:3444:852:5b8a']
         mock_check_out.return_value = IP_OUTPUT_NO_VALID
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_ipv6_addr()
 
     @patch('charmhelpers.contrib.network.ip.get_iface_addr')
@@ -622,7 +620,7 @@ class IPTest(unittest.TestCase):
         addr = 'fe80::3e97:eff:fe8b:1cf7'
         self.assertEqual(net_ip.get_iface_from_addr(addr), 'eth0')
 
-        with nose.tools.assert_raises(Exception):
+        with self.assertRaises(Exception):
             net_ip.get_iface_from_addr('1.2.3.4')
 
     def test_is_ip(self):

--- a/tests/contrib/openstack/test_neutron_utils.py
+++ b/tests/contrib/openstack/test_neutron_utils.py
@@ -1,6 +1,5 @@
 import unittest
 from mock import patch
-from nose.tools import raises
 import charmhelpers.contrib.openstack.neutron as neutron
 
 TO_PATCH = [
@@ -121,18 +120,16 @@ class NeutronTests(unittest.TestCase):
         plugins = neutron.neutron_plugin_attribute('ovs', 'services')
         self.assertEquals(plugins, ['neutron-plugin-openvswitch-agent'])
 
-    @raises(Exception)
     @patch.object(neutron, 'network_manager')
     def test_neutron_plugin_attribute_foo(self, _network_manager):
         _network_manager.return_value = 'foo'
-        self.assertRaises(Exception, neutron.neutron_plugin_attribute('ovs', 'services'))
+        self.assertRaises(Exception, neutron.neutron_plugin_attribute, 'ovs', 'services')
 
-    @raises(Exception)
     @patch.object(neutron, 'network_manager')
     def test_neutron_plugin_attribute_plugin_keyerror(self, _network_manager):
         self.config.return_value = 'foo'
         _network_manager.return_value = 'quantum'
-        self.assertRaises(Exception, neutron.neutron_plugin_attribute('foo', 'foo'))
+        self.assertRaises(Exception, neutron.neutron_plugin_attribute, 'foo', 'foo')
 
     @patch.object(neutron, 'network_manager')
     def test_neutron_plugin_attribute_attr_keyerror(self, _network_manager):
@@ -141,17 +138,18 @@ class NeutronTests(unittest.TestCase):
         plugins = neutron.neutron_plugin_attribute('ovs', 'foo')
         self.assertEquals(plugins, None)
 
-    @raises(Exception)
     def test_network_manager_essex(self):
         essex_cases = {
             'quantum': 'quantum',
             'neutron': 'quantum',
-            'newhotness': 'newhotness',
         }
         self.os_release.return_value = 'essex'
         for nwmanager in essex_cases:
             self.config.return_value = nwmanager
-            self.assertRaises(Exception, neutron.network_manager())
+            self.assertRaises(Exception, neutron.network_manager)
+
+        self.config.return_value = "newhotness"
+        self.assertEqual(neutron.network_manager(), "newhotness")
 
     def test_network_manager_folsom(self):
         folsom_cases = {

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4449,8 +4449,9 @@ PCI_DEVICE_MAP = {
 
 class TestDPDKUtils(tests.utils.BaseTestCase):
 
-    def test_resolve_pci_from_mapping_config(self):
-        # FIXME: need to mock out the unit key value store
+    @mock.patch.object(context, "kv")
+    def test_resolve_pci_from_mapping_config(self, kv):
+        kv.return_value = TestDB()
         self.patch_object(context, 'config')
         self.config.side_effect = lambda x: {
             'data-port': DPDK_DATA_PORTS,

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -15,7 +15,6 @@ import charmhelpers.contrib.storage.linux.ceph as ceph_utils
 from charmhelpers.core.unitdata import Storage
 from subprocess import CalledProcessError
 from tests.helpers import patch_open, FakeRelation
-import nose.plugins.attrib
 import os
 import time
 
@@ -1461,7 +1460,6 @@ class CephUtilsTests(TestCase):
         self.log.assert_called_with(
             'Gave up waiting on block device %s' % device, level='ERROR')
 
-    @nose.plugins.attrib.attr('slow')
     def test_make_filesystem_timeout(self):
         """
         make_filesystem() allows to specify how long it should wait for the
@@ -1478,7 +1476,6 @@ class CephUtilsTests(TestCase):
         self.log.assert_called_with(
             'Gave up waiting on block device %s' % device, level='ERROR')
 
-    @nose.plugins.attrib.attr('slow')
     def test_device_is_formatted_if_it_appears(self):
         """
         The specified device is formatted if it appears before the timeout

--- a/tests/core/test_fstab.py
+++ b/tests/core/test_fstab.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from charmhelpers.core.fstab import Fstab
-from nose.tools import (assert_is,
-                        assert_is_not,
-                        assert_equal)
 import unittest
 import tempfile
 import os
@@ -38,47 +35,51 @@ class FstabTest(unittest.TestCase):
 
     def test_entries(self):
         """Test if entries are correctly read from fstab file"""
-        assert_equal(sorted(GENERATED_FSTAB_FILE.splitlines()),
-                     sorted(str(entry) for entry in self.fstab.entries))
+        self.assertEqual(sorted(GENERATED_FSTAB_FILE.splitlines()),
+                         sorted(str(entry) for entry in self.fstab.entries))
 
     def test_get_entry_by_device_attr(self):
         """Test if the get_entry_by_attr method works for device attr"""
         for device in ('sda', 'sdb', 'sdc', ):
-            assert_is_not(self.fstab.get_entry_by_attr('device',
-                                                       '/dev/%s' % device),
-                          None)
+            self.assertIsNot(self.fstab.get_entry_by_attr('device',
+                                                          '/dev/%s' % device),
+                             None)
 
     def test_get_entry_by_mountpoint_attr(self):
         """Test if the get_entry_by_attr method works for mountpoint attr"""
         for mnt in ('sda', 'sdb', 'sdc', ):
-            assert_is_not(self.fstab.get_entry_by_attr('mountpoint',
-                                                       '/mnt/%s' % mnt), None)
+            self.assertIsNot(
+                self.fstab.get_entry_by_attr('mountpoint', '/mnt/%s' % mnt),
+                None
+            )
 
     def test_add_entry(self):
         """Test if add_entry works for a new entry"""
         for device in ('sdf', 'sdg', 'sdh'):
             entry = Fstab.Entry('/dev/%s' % device, '/mnt/%s' % device, 'ext3',
                                 None)
-            assert_is_not(self.fstab.add_entry(entry), None)
-            assert_is_not(self.fstab.get_entry_by_attr(
-                'device', '/dev/%s' % device), None)
+            self.assertIsNot(self.fstab.add_entry(entry), None)
+            self.assertIsNot(
+                self.fstab.get_entry_by_attr('device', '/dev/%s' % device),
+                None
+            )
 
-        assert_is(self.fstab.add_entry(entry), False,
-                  "Check if adding an existing entry returns false")
+        self.assertIs(self.fstab.add_entry(entry), False,
+                      "Check if adding an existing entry returns false")
 
     def test_remove_entry(self):
         """Test if remove entry works for already existing entries"""
         for entry in self.fstab.entries:
-            assert_is(self.fstab.remove_entry(entry), True)
+            self.assertIs(self.fstab.remove_entry(entry), True)
 
-        assert_equal(len([entry for entry in self.fstab.entries]), 0)
-        assert_equal(self.fstab.add_entry(entry), entry)
-        assert_equal(len([entry for entry in self.fstab.entries]), 1)
+        self.assertEqual(len([entry for entry in self.fstab.entries]), 0)
+        self.assertEqual(self.fstab.add_entry(entry), entry)
+        self.assertEqual(len([entry for entry in self.fstab.entries]), 1)
 
     def test_assert_remove_add_all(self):
         """Test if removing/adding all the entries works"""
         for entry in self.fstab.entries:
-            assert_is(self.fstab.remove_entry(entry), True)
+            self.assertIs(self.fstab.remove_entry(entry), True)
 
         for device in ('sda', 'sdb', 'sdc', ):
             self.fstab.add_entry(
@@ -89,5 +90,5 @@ class FstabTest(unittest.TestCase):
             'UUID=3af44368-c50b-4768-8e58-aff003cef8be',
             '/', 'ext4', 'errors=remount-ro', 0, 1))
 
-        assert_equal(sorted(GENERATED_FSTAB_FILE.splitlines()),
-                     sorted(str(entry) for entry in self.fstab.entries))
+        self.assertEqual(sorted(GENERATED_FSTAB_FILE.splitlines()),
+                         sorted(str(entry) for entry in self.fstab.entries))

--- a/tests/fetch/python/test_debug.py
+++ b/tests/fetch/python/test_debug.py
@@ -49,6 +49,8 @@ class DebugTestCase(TestCase):
     def test_debug_set_trace_ex(self):
         """Check if set_trace raises exception
         """
+        set_trace = mock.MagicMock()
+        set_trace.return_value = Exception()
+        self.Rpdb.return_value = set_trace()
         self.set_trace()
-        self.Rpdb.set_trace.side_effect = Exception()
         self.assertTrue(self._error.called)

--- a/tests/fetch/test_giturl.py
+++ b/tests/fetch/test_giturl.py
@@ -48,7 +48,7 @@ class GitUrlFetchHandlerTest(TestCase):
     @patch.object(giturl, 'check_output')
     def test_clone(self, check_output):
         dest_path = "/destination/path"
-        branch = "master"
+        branch = "main"
         for url in self.valid_urls:
             self.fh.remote_branch = MagicMock()
             self.fh.load_plugins = MagicMock()
@@ -69,7 +69,8 @@ class GitUrlFetchHandlerTest(TestCase):
         try:
             src = tempfile.mkdtemp()
             with chdir(src):
-                subprocess.check_output(['git', 'init'])
+                subprocess.check_output(['git', 'init',
+                                         '--initial-branch', 'main'])
                 subprocess.check_output(['git', 'config', 'user.name', 'Joe'])
                 subprocess.check_output(
                     ['git', 'config', 'user.email', 'joe@test.com'])
@@ -78,9 +79,9 @@ class GitUrlFetchHandlerTest(TestCase):
                 subprocess.check_output(['git', 'commit', '-m', 'test'])
             dst = tempfile.mkdtemp()
             os.rmdir(dst)
-            self.fh.clone(src, dst)
+            self.fh.clone(src, dst, "main")
             assert os.path.exists(os.path.join(dst, '.git'))
-            self.fh.clone(src, dst)  # idempotent
+            self.fh.clone(src, dst, "main")  # idempotent
             assert os.path.exists(os.path.join(dst, '.git'))
         finally:
             if src:

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,11 @@ deps = -r{toxinidir}/test-requirements.txt
 basepython = python3.8
 deps = -r{toxinidir}/test-requirements.txt
 
+[testenv:py310]
+basepython = python3.10
+deps = -r{toxinidir}/test-requirements.txt
+commands = nose2 {posargs} --with-coverage -s tests/
+
 [testenv:pep8]
 basepython = python3
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
This pull requests introduces python 3.10 in tox and github actions, since this version of python doesn't support nose, it uses nose2 as a replace for `python_version >= 3.10`.

Some tests had to be tweaked to drop the use of `nose` module in favor of `unittest` primitives, for example drop `nose.tools.assert_is(...)` in favor of `self.assertIsNot(...)`