### PR TITLE
ns_query: capture NoNameservers exception.

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -467,7 +467,7 @@ def ns_query(address):
 
     try:
         answers = dns.resolver.query(address, rtype)
-    except dns.resolver.NXDOMAIN:
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers):
         return None
 
     if answers:

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -709,6 +709,11 @@ class IPTest(unittest.TestCase):
         self.assertEquals(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
+    def test_ns_query_loopup_fail_real_implementation(self, apt_install):
+        self.assertEqual(net_ip.ns_query('nonexistant'), None)
+        apt_install.assert_not_called()
+
+    @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_ip(self, apt_install):
         fake_dns = FakeDNS('www.ubuntu.com')
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):


### PR DESCRIPTION
When all the servers configured in the system failed to answer the query
the exception `dns.resolver.NoNameservers` is raised while NXDOMAIN is
only for when the name was not found.

This issue was found in a lab environment where nova-cloud-controller
charm failed to find the IP address associated to the reverse dns.

```
ubuntu@juju-e91b0e-0-lxd-2:~$ host 10.13.3.6
6.3.13.10.in-addr.arpa domain name pointer 10-13-3-6.internal.
ubuntu@juju-e91b0e-0-lxd-2:~$ host 10-13-3-6
Host 10-13-3-6 not found: 2(SERVFAIL)
```

Stacktrace:
```
   ...
   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 1321, in query
     return resolve(qname, rdtype, rdclass, tcp, source,
   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 1305, in resolve
     return get_default_resolver().resolve(qname, rdtype, rdclass, tcp, source,
   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 1173, in resolve
     (nameserver, port, tcp, backoff) = resolution.next_nameserver()
   File "/usr/lib/python3/dist-packages/dns/resolver.py", line 626, in next_nameserver
     raise NoNameservers(request=self.request, errors=self.errors)
 dns.resolver.NoNameservers: All nameservers failed to answer the query 10-13-3-6. IN A: Server 127.0.0.53 UDP port 53 answered SERVFAIL
```