### PR TITLE
Add support for executing systemctl command without service name argument

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -277,7 +277,7 @@ def service_resume(service_name, init_dir="/etc/init",
     return started
 
 
-def service(action, service_name, **kwargs):
+def service(action, service_name=None, **kwargs):
     """Control a system service.
 
     :param action: the action to take on the service
@@ -286,7 +286,9 @@ def service(action, service_name, **kwargs):
                     the form of key=value.
     """
     if init_is_systemd(service_name=service_name):
-        cmd = ['systemctl', action, service_name]
+        cmd = ['systemctl', action]
+        if service_name is not None:
+            cmd.append(service_name)
     else:
         cmd = ['service', service_name, action]
         for key, value in kwargs.items():

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -136,7 +136,7 @@ class HelpersTest(TestCase):
 
     @patch.object(host, 'init_is_systemd')
     @patch('subprocess.call')
-    def test_runs_systemctl_action(self, mock_call, systemd):
+    def test_runs_systemctl_action_on_service(self, mock_call, systemd):
         """Ensure that service calls under systemd call 'systemctl'."""
         systemd.return_value = True
         mock_call.return_value = 0
@@ -147,6 +147,19 @@ class HelpersTest(TestCase):
 
         self.assertTrue(result)
         mock_call.assert_called_with(['systemctl', action, service_name])
+
+    @patch.object(host, 'init_is_systemd')
+    @patch('subprocess.call')
+    def test_runs_systemctl_action(self, mock_call, systemd):
+        """Ensure that service calls under systemd call 'systemctl' when no service name is specified."""
+        systemd.return_value = True
+        mock_call.return_value = 0
+        action = 'some-action'
+
+        result = host.service(action)
+
+        self.assertTrue(result)
+        mock_call.assert_called_with(['systemctl', action])
 
     @patch.object(host, 'init_is_systemd')
     @patch('subprocess.call')


### PR DESCRIPTION
…ce name

Add support to run systemctl commands without a service name argument such as 'systemctl daemon-reload'