### PR TITLE
Fix `openstack_upgrade_available` failing on unconventional source

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -386,9 +386,9 @@ def get_os_codename_install_source(src):
                 return v
 
 
-def get_os_version_install_source(src):
+def get_os_version_install_source(src, raise_exception=False):
     codename = get_os_codename_install_source(src)
-    return get_os_version_codename(codename)
+    return get_os_version_codename(codename, raise_exception=raise_exception)
 
 
 def get_os_codename_version(vers):
@@ -849,7 +849,8 @@ def openstack_upgrade_available(package):
         avail_vers = get_os_version_codename_swift(codename)
     else:
         try:
-            avail_vers = get_os_version_install_source(src)
+            avail_vers = get_os_version_install_source(src,
+                                                       raise_exception=True)
         except Exception:
             avail_vers = cur_vers
     apt.init()

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -239,7 +239,7 @@ class OpenStackHelpersTestCase(TestCase):
     def test_os_version_from_install_source(self, codename, version):
         codename.return_value = 'grizzly'
         openstack.get_os_version_install_source('cloud:precise-grizzly')
-        version.assert_called_with('grizzly')
+        version.assert_called_with('grizzly', raise_exception=False)
 
     @patch('charmhelpers.contrib.openstack.utils.lsb_release')
     def test_os_codename_from_bad_install_source(self, mocked_lsb):


### PR DESCRIPTION
An unfortunate follow-up to #688 after digging up [a relevant comment](https://review.opendev.org/c/openstack/charm-keystone/+/835087/1/charmhelpers/contrib/openstack/utils.py#407) clarifying reasons being the previous PR.

Fixes `openstack_upgrade_available` calls unexpectedly `sys.exit(1)`ing, while expecting to be thrown an exception, whenever the package source specification does not contain an Openstack release codename.

Related change: https://review.opendev.org/c/openstack/charm-keystone/+/835087
Related: LP#1965966