### PR TITLE
Rotate the request_id on CephBrokerReq with operation changes

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -28,7 +28,6 @@ import os
 import shutil
 import json
 import time
-import uuid
 
 from subprocess import (
     check_call,
@@ -1685,8 +1684,12 @@ class CephBrokerRq(object):
 
         :param api_version: API version for request (default: 1).
         :type api_version: Optional[int]
-        :param request_id: Unique identifier for request.
-                           (default: string representation of generated UUID)
+        :param request_id: Unique identifier for request. The identifier will
+                           be updated as ops are added or removed from the
+                           broker request. This ensures that Ceph will
+                           correctly process requests where operations are
+                           added after the initial request is processed.
+                           (default: sha1 of operations)
         :type request_id: Optional[str]
         :param raw_request_data: JSON-encoded string to build request from.
         :type raw_request_data: Optional[str]
@@ -1695,14 +1698,16 @@ class CephBrokerRq(object):
         if raw_request_data:
             request_data = json.loads(raw_request_data)
             self.api_version = request_data['api-version']
-            self.request_id = request_data['request-id']
             self.set_ops(request_data['ops'])
+            self.request_id = request_data['request-id']
         else:
             self.api_version = api_version
             if request_id:
                 self.request_id = request_id
             else:
-                self.request_id = str(uuid.uuid1())
+                # The below hash is the result of running
+                # `hashlib.sha1('[]'.encode()).hexdigest()`
+                self.request_id = '97d170e1550eee4afc0af065b78cda302a97674c'
             self.ops = []
 
     def add_op(self, op):
@@ -1713,6 +1718,7 @@ class CephBrokerRq(object):
         """
         if op not in self.ops:
             self.ops.append(op)
+            self.request_id = hashlib.sha1(json.dumps(self.ops, sort_keys=True).encode()).hexdigest()
 
     def add_op_request_access_to_group(self, name, namespace=None,
                                        permission=None, key_name=None,
@@ -1991,6 +1997,7 @@ class CephBrokerRq(object):
         to allow comparisons to ensure validity.
         """
         self.ops = ops
+        self.request_id = hashlib.sha1(json.dumps(self.ops, sort_keys=True).encode()).hexdigest()
 
     @property
     def request(self):

--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -1676,6 +1676,10 @@ class CephBrokerRq(object):
     The API is versioned and defaults to version 1.
     """
 
+    # The below hash is the result of running
+    # `hashlib.sha1('[]'.encode()).hexdigest()`
+    EMPTY_LIST_SHA = '97d170e1550eee4afc0af065b78cda302a97674c'
+
     def __init__(self, api_version=1, request_id=None, raw_request_data=None):
         """Initialize CephBrokerRq object.
 
@@ -1705,10 +1709,12 @@ class CephBrokerRq(object):
             if request_id:
                 self.request_id = request_id
             else:
-                # The below hash is the result of running
-                # `hashlib.sha1('[]'.encode()).hexdigest()`
-                self.request_id = '97d170e1550eee4afc0af065b78cda302a97674c'
+                self.request_id = CephBrokerRq.EMPTY_LIST_SHA
             self.ops = []
+
+    def _hash_ops(self):
+        """Return the sha1 of the requested Broker ops."""
+        return hashlib.sha1(json.dumps(self.ops, sort_keys=True).encode()).hexdigest()
 
     def add_op(self, op):
         """Add an op if it is not already in the list.
@@ -1718,7 +1724,7 @@ class CephBrokerRq(object):
         """
         if op not in self.ops:
             self.ops.append(op)
-            self.request_id = hashlib.sha1(json.dumps(self.ops, sort_keys=True).encode()).hexdigest()
+            self.request_id = self._hash_ops()
 
     def add_op_request_access_to_group(self, name, namespace=None,
                                        permission=None, key_name=None,
@@ -1997,7 +2003,7 @@ class CephBrokerRq(object):
         to allow comparisons to ensure validity.
         """
         self.ops = ops
-        self.request_id = hashlib.sha1(json.dumps(self.ops, sort_keys=True).encode()).hexdigest()
+        self.request_id = self._hash_ops()
 
     @property
     def request(self):

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -115,7 +115,7 @@ CEPH_CLIENT_RELATION = {
     'ceph:8': {
         'ceph/0': {
             'auth': 'cephx',
-            'broker-rsp-glance-0': '{"request-id": "0bc7dc54", "exit-code": 0}',
+            'broker-rsp-glance-0': '{"request-id": "a9db5bcaf56ea404403f5a3594ea8d7517377b96", "exit-code": 0}',
             'broker-rsp-glance-1': '{"request-id": "0880e22a", "exit-code": 0}',
             'broker-rsp-glance-2': '{"request-id": "0da543b8", "exit-code": 0}',
             'broker_rsp': '{"request-id": "0da543b8", "exit-code": 0}',
@@ -136,7 +136,15 @@ CEPH_CLIENT_RELATION = {
             'private-address': '10.5.44.105',
         },
         'glance/0': {
-            'broker_req': '{"api-version": 1, "request-id": "0bc7dc54", "ops": [{"replicas": 3, "name": "glance", "op": "create-pool", "rbd-mirroring-mode": "pool"}]}',
+            'broker_req': '{"api-version": 1, "request-id": "a9db5bcaf56ea404403f5a3594ea8d7517377b96", "ops": [{"op": "create-pool", "name": "glance", '
+            '"replicas": 3, "pg_num": null, "crush-profile": null, "app-name": null, '
+            '"compression-algorithm": null, "compression-mode": null, '
+            '"compression-required-ratio": null, "compression-min-blob-size": null, '
+            '"compression-min-blob-size-hdd": null, "compression-min-blob-size-ssd": '
+            'null, "compression-max-blob-size": null, "compression-max-blob-size-hdd": '
+            'null, "compression-max-blob-size-ssd": null, "group": null, "max-bytes": '
+            'null, "max-objects": null, "group-namespace": null, "rbd-mirroring-mode": '
+            '"pool", "weight": null}]}',
             'private-address': '10.5.44.109',
         },
     }
@@ -1562,10 +1570,8 @@ class CephUtilsTests(TestCase):
         ])
 
     @patch.object(ceph_utils, 'service_name')
-    @patch.object(ceph_utils, 'uuid')
-    def test_ceph_broker_rq_class(self, uuid, service_name):
+    def test_ceph_broker_rq_class(self, service_name):
         service_name.return_value = 'service_test'
-        uuid.uuid1.return_value = 'uuid'
         rq = ceph_utils.CephBrokerRq()
         rq.add_op_create_pool('pool1', replica_count=1)
         rq.add_op_create_pool('pool1', replica_count=1)
@@ -1581,7 +1587,7 @@ class CephUtilsTests(TestCase):
             object_prefix_permissions={'rwx': ['prefix1']})
         expected = {
             'api-version': 1,
-            'request-id': 'uuid',
+            'request-id': '0bcb1775aece4b9849d21c4bc2a5f02e2cd47344',
             'ops': [{'op': 'create-pool', 'name': 'pool1', 'replicas': 1},
                     {'op': 'create-pool', 'name': 'pool2', 'replicas': 3},
                     {'op': 'create-pool', 'name': 'pool3', 'replicas': 3, 'group': 'test'},
@@ -1603,10 +1609,8 @@ class CephUtilsTests(TestCase):
                     expected_op[key])
 
     @patch.object(ceph_utils, 'service_name')
-    @patch.object(ceph_utils, 'uuid')
-    def test_ceph_broker_rq_class_test_not_equal(self, uuid, service_name):
+    def test_ceph_broker_rq_class_test_not_equal(self, service_name):
         service_name.return_value = 'service_test'
-        uuid.uuid1.return_value = 'uuid'
         rq1 = ceph_utils.CephBrokerRq()
         rq1.add_op_create_pool('pool1')
         rq1.add_op_request_access_to_group(name='test')
@@ -1651,10 +1655,6 @@ class CephUtilsTests(TestCase):
         self.relation_ids.side_effect = relation.relation_ids
         self.related_units.side_effect = relation.related_units
 
-    #    @patch.object(ceph_utils, 'uuid')
-    #    @patch.object(ceph_utils, 'local_unit')
-    #    def test_get_request_states(self, mlocal_unit, muuid):
-    #        muuid.uuid1.return_value = '0bc7dc54'
     @patch.object(ceph_utils, 'local_unit')
     def test_get_request_states(self, mlocal_unit):
         mlocal_unit.return_value = 'glance/0'
@@ -1746,10 +1746,8 @@ class CephUtilsTests(TestCase):
         rq.add_op_create_pool(name='glance', replica_count=3)
         self.assertTrue(ceph_utils.is_request_sent(rq))
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = '0bc7dc54'
+    def test_is_request_complete(self, mlocal_unit):
         mlocal_unit.return_value = 'glance/0'
         self.setup_client_relation(CEPH_CLIENT_RELATION)
         rq = ceph_utils.CephBrokerRq()
@@ -1828,30 +1826,24 @@ class CephUtilsTests(TestCase):
         rq2.add_op_create_pool(name='glance', replica_count=3)
         self.assertFalse(rq1 == rq2)
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete_for_rid(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = '0bc7dc54'
+    def test_is_request_complete_for_rid(self, mlocal_unit):
         req = ceph_utils.CephBrokerRq()
         req.add_op_create_pool(name='glance', replica_count=3)
         mlocal_unit.return_value = 'glance/0'
         self.setup_client_relation(CEPH_CLIENT_RELATION)
         self.assertTrue(ceph_utils.is_request_complete_for_rid(req, 'ceph:8'))
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete_for_rid_newrq(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = 'a44c0fa6'
+    def test_is_request_complete_for_rid_newrq(self, mlocal_unit):
         req = ceph_utils.CephBrokerRq()
         req.add_op_create_pool(name='glance', replica_count=4)
         mlocal_unit.return_value = 'glance/0'
         self.setup_client_relation(CEPH_CLIENT_RELATION)
         self.assertFalse(ceph_utils.is_request_complete_for_rid(req, 'ceph:8'))
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete_for_rid_failed(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = '0bc7dc54'
+    def test_is_request_complete_for_rid_failed(self, mlocal_unit):
         req = ceph_utils.CephBrokerRq()
         req.add_op_create_pool(name='glance', replica_count=4)
         mlocal_unit.return_value = 'glance/0'
@@ -1860,10 +1852,8 @@ class CephUtilsTests(TestCase):
         self.setup_client_relation(rel)
         self.assertFalse(ceph_utils.is_request_complete_for_rid(req, 'ceph:8'))
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete_for_rid_pending(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = '0bc7dc54'
+    def test_is_request_complete_for_rid_pending(self, mlocal_unit):
         req = ceph_utils.CephBrokerRq()
         req.add_op_create_pool(name='glance', replica_count=4)
         mlocal_unit.return_value = 'glance/0'
@@ -1872,10 +1862,8 @@ class CephUtilsTests(TestCase):
         self.setup_client_relation(rel)
         self.assertFalse(ceph_utils.is_request_complete_for_rid(req, 'ceph:8'))
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_is_request_complete_for_rid_legacy(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = '0bc7dc54'
+    def test_is_request_complete_for_rid_legacy(self, mlocal_unit):
         req = ceph_utils.CephBrokerRq()
         req.add_op_create_pool(name='glance', replica_count=3)
         mlocal_unit.return_value = 'glance/0'
@@ -1896,10 +1884,8 @@ class CephUtilsTests(TestCase):
         ceph_utils.send_request_if_needed(rq)
         self.relation_set.assert_has_calls([])
 
-    @patch.object(ceph_utils, 'uuid')
     @patch.object(ceph_utils, 'local_unit')
-    def test_send_request_if_needed_newrq(self, mlocal_unit, muuid):
-        muuid.uuid1.return_value = 'de67511e'
+    def test_send_request_if_needed_newrq(self, mlocal_unit):
         mlocal_unit.return_value = 'glance/0'
         self.setup_client_relation(CEPH_CLIENT_RELATION)
         rq = ceph_utils.CephBrokerRq()
@@ -1907,7 +1893,7 @@ class CephUtilsTests(TestCase):
         ceph_utils.send_request_if_needed(rq)
         actual = json.loads(self.relation_set.call_args_list[0][1]['broker_req'])
         self.assertEqual(actual['api-version'], 1)
-        self.assertEqual(actual['request-id'], 'de67511e')
+        self.assertEqual(actual['request-id'], '11197d0e76c495f118c6d4c4ff3c7e8dca241cf4')
         self.assertEqual(actual['ops'][0]['replicas'], 4)
         self.assertEqual(actual['ops'][0]['op'], 'create-pool')
         self.assertEqual(actual['ops'][0]['name'], 'glance')
@@ -2227,8 +2213,7 @@ class CephUtilsTests(TestCase):
         self.relation_get.assert_called_once_with(
             attribute='broker_req', rid='aRid', unit=_local_unit())
 
-    @patch.object(ceph_utils, 'uuid')
-    def test_CephBrokerRq__init__(self, _uuid):
+    def test_CephBrokerRq__init__(self):
         raw_request = CEPH_CLIENT_RELATION['ceph:8']['glance/0']['broker_req']
         request = json.loads(raw_request)
         req1 = ceph_utils.CephBrokerRq(api_version=request['api-version'],
@@ -2238,11 +2223,10 @@ class CephUtilsTests(TestCase):
         self.assertDictEqual(
             json.loads(req1.request),
             json.loads(req2.request))
-        _uuid.uuid1.return_value = 'fake-uuid'
         new_req = ceph_utils.CephBrokerRq()
         expect = {
             'api-version': 1,
-            'request-id': 'fake-uuid',
+            'request-id': '97d170e1550eee4afc0af065b78cda302a97674c',
             'ops': [],
         }
         self.assertDictEqual(


### PR DESCRIPTION
When the operations requested change, the request_id must
change as well, kor ceph-mon will not process the newly
added operations.

Closes #714