### PR TITLE
contrib/db/mysql: add group replication cache support

### DIFF
--- a/charmhelpers/contrib/database/mysql.py
+++ b/charmhelpers/contrib/database/mysql.py
@@ -648,6 +648,17 @@ class MySQLConfigHelper(object):
 
         return innodb_buffer_pool_size
 
+    def get_group_replication_message_cache_size(self):
+        """Get value for group_replication_message_cache_size.
+
+        :returns: Numeric value for group_replication_message_cache_size
+                  None if not set.
+        :rtype: Union[None, int]
+        """
+        gr_message_cache_size = config_get('group-replication-message-cache-size')
+        if gr_message_cache_size:
+            return self.human_to_bytes(gr_message_cache_size)
+
 
 class PerconaClusterHelper(MySQLConfigHelper):
     """Percona-cluster specific configuration helper."""

--- a/tests/contrib/database/test_mysql.py
+++ b/tests/contrib/database/test_mysql.py
@@ -594,6 +594,21 @@ class MySQLConfigHelperTests(unittest.TestCase):
 
         self.assertTrue(helper.get_innodb_change_buffering() is None)
 
+    @mock.patch.object(mysql.MySQLConfigHelper, 'get_mem_total')
+    @mock.patch.object(mysql, 'log')
+    def test_get_group_replication_message_cache_size(self, mog, mem):
+        mem.return_value = "512M"
+        self.config_data = {
+            'group-replication-message-cache-size': '256M',
+        }
+
+        helper = mysql.MySQLConfigHelper()
+
+        self.assertEqual(
+            helper.get_group_replication_message_cache_size(),
+            268435456
+        )
+
 
 class PerconaTests(unittest.TestCase):
 


### PR DESCRIPTION
I am adding this helper method as part of the implementation of [LP #1977500](https://bugs.launchpad.net/charm-mysql-innodb-cluster/+bug/1977500)