### PR TITLE
Changes to the default inode size

### DIFF
--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -15,6 +15,10 @@
 import os
 import re
 from stat import S_ISBLK
+from charmhelpers.core.hookenv import (
+    log,
+    WARNING
+)
 
 from subprocess import (
     CalledProcessError,
@@ -118,12 +122,16 @@ def mkfs_xfs(device, force=False, inode_size=1024):
     :ptype device: tr
     :param force: Force operation
     :ptype: force: boolean
-    :param inode_size: XFS inode size in bytes
+    :param inode_size: XFS inode size in bytes; if set to 0 or None,
+        the value used will be the XFS system default
     :ptype inode_size: int"""
     cmd = ['mkfs.xfs']
     if force:
         cmd.append("-f")
-    if inode_size:
+    if inode_size >= 256 and inode_size <= 2048:
         cmd += ['-i', "size={}".format(inode_size)]
+    elif inode_size != 0:
+        log("Config value xfs-inode-size={} is invalid. Using system default.".format(inode_size), level=WARNING)
+
     cmd += [device]
     check_call(cmd)

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -15,10 +15,6 @@
 import os
 import re
 from stat import S_ISBLK
-from charmhelpers.core.hookenv import (
-    log,
-    WARNING
-)
 
 from subprocess import (
     CalledProcessError,
@@ -132,8 +128,6 @@ def mkfs_xfs(device, force=False, inode_size=None):
     if inode_size:
         if inode_size >= 256 and inode_size <= 2048:
             cmd += ['-i', "size={}".format(inode_size)]
-        elif inode_size != 0:
-            log("Config value xfs-inode-size={} is invalid. Using system default.".format(inode_size), level=WARNING)
 
     cmd += [device]
     check_call(cmd)

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -114,7 +114,7 @@ def is_device_mounted(device):
     return bool(re.search(r'MOUNTPOINT=".+"', out))
 
 
-def mkfs_xfs(device, force=False, inode_size=1024):
+def mkfs_xfs(device, force=False, inode_size=None):
     """Format device with XFS filesystem.
 
     By default this should fail if the device already has a filesystem on it.

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -128,10 +128,12 @@ def mkfs_xfs(device, force=False, inode_size=1024):
     cmd = ['mkfs.xfs']
     if force:
         cmd.append("-f")
-    if inode_size >= 256 and inode_size <= 2048:
-        cmd += ['-i', "size={}".format(inode_size)]
-    elif inode_size != 0:
-        log("Config value xfs-inode-size={} is invalid. Using system default.".format(inode_size), level=WARNING)
+
+    if inode_size:
+        if inode_size >= 256 and inode_size <= 2048:
+            cmd += ['-i', "size={}".format(inode_size)]
+        elif inode_size != 0:
+            log("Config value xfs-inode-size={} is invalid. Using system default.".format(inode_size), level=WARNING)
 
     cmd += [device]
     check_call(cmd)

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -23,6 +23,11 @@ from subprocess import (
     call
 )
 
+from charmhelpers.core.hookenv import (
+    log,
+    WARNING
+)
+
 
 def _luks_uuid(dev):
     """
@@ -128,6 +133,8 @@ def mkfs_xfs(device, force=False, inode_size=None):
     if inode_size:
         if inode_size >= 256 and inode_size <= 2048:
             cmd += ['-i', "size={}".format(inode_size)]
+    else:
+        log("Config value xfs-inode-size={} is invalid. Using system default.".format(inode_size), level=WARNING)
 
     cmd += [device]
     check_call(cmd)

--- a/charmhelpers/contrib/storage/linux/utils.py
+++ b/charmhelpers/contrib/storage/linux/utils.py
@@ -123,6 +123,7 @@ def mkfs_xfs(device, force=False, inode_size=1024):
     cmd = ['mkfs.xfs']
     if force:
         cmd.append("-f")
-
-    cmd += ['-i', "size={}".format(inode_size), device]
+    if inode_size:
+        cmd += ['-i', "size={}".format(inode_size)]
+    cmd += [device]
     check_call(cmd)

--- a/tests/contrib/storage/test_linux_storage_utils.py
+++ b/tests/contrib/storage/test_linux_storage_utils.py
@@ -120,8 +120,15 @@ class MiscStorageUtilsTests(unittest.TestCase):
         )
 
     @patch(STORAGE_LINUX_UTILS + '.check_call')
-    def test_mkfs_xfs_default_size(self, check_call):
+    def test_mkfs_xfs_inode_size_0(self, check_call):
         storage_utils.mkfs_xfs('/dev/sdb', inode_size=0)
+        check_call.assert_called_with(
+            ['mkfs.xfs', '/dev/sdb']
+        )
+
+    @patch(STORAGE_LINUX_UTILS + '.check_call')
+    def test_mkfs_xfs_inode_size_none(self, check_call):
+        storage_utils.mkfs_xfs('/dev/sdb', inode_size=None)
         check_call.assert_called_with(
             ['mkfs.xfs', '/dev/sdb']
         )

--- a/tests/contrib/storage/test_linux_storage_utils.py
+++ b/tests/contrib/storage/test_linux_storage_utils.py
@@ -116,7 +116,7 @@ class MiscStorageUtilsTests(unittest.TestCase):
     def test_mkfs_xfs(self, check_call):
         storage_utils.mkfs_xfs('/dev/sdb')
         check_call.assert_called_with(
-            ['mkfs.xfs', '-i', 'size=1024', '/dev/sdb']
+            ['mkfs.xfs', '/dev/sdb']
         )
 
     @patch(STORAGE_LINUX_UTILS + '.check_call')
@@ -137,7 +137,7 @@ class MiscStorageUtilsTests(unittest.TestCase):
     def test_mkfs_xfs_force(self, check_call):
         storage_utils.mkfs_xfs('/dev/sdb', force=True)
         check_call.assert_called_with(
-            ['mkfs.xfs', '-f', '-i', 'size=1024', '/dev/sdb']
+            ['mkfs.xfs', '-f', '/dev/sdb']
         )
 
     @patch(STORAGE_LINUX_UTILS + '.check_call')

--- a/tests/contrib/storage/test_linux_storage_utils.py
+++ b/tests/contrib/storage/test_linux_storage_utils.py
@@ -120,6 +120,13 @@ class MiscStorageUtilsTests(unittest.TestCase):
         )
 
     @patch(STORAGE_LINUX_UTILS + '.check_call')
+    def test_mkfs_xfs(self, check_call):
+        storage_utils.mkfs_xfs('/dev/sdb',inode_size=0)
+        check_call.assert_called_with(
+            ['mkfs.xfs', '/dev/sdb']
+        )
+
+    @patch(STORAGE_LINUX_UTILS + '.check_call')
     def test_mkfs_xfs_force(self, check_call):
         storage_utils.mkfs_xfs('/dev/sdb', force=True)
         check_call.assert_called_with(

--- a/tests/contrib/storage/test_linux_storage_utils.py
+++ b/tests/contrib/storage/test_linux_storage_utils.py
@@ -120,8 +120,8 @@ class MiscStorageUtilsTests(unittest.TestCase):
         )
 
     @patch(STORAGE_LINUX_UTILS + '.check_call')
-    def test_mkfs_xfs(self, check_call):
-        storage_utils.mkfs_xfs('/dev/sdb',inode_size=0)
+    def test_mkfs_xfs_default_size(self, check_call):
+        storage_utils.mkfs_xfs('/dev/sdb', inode_size=0)
         check_call.assert_called_with(
             ['mkfs.xfs', '/dev/sdb']
         )


### PR DESCRIPTION
The inode size default value is in contradiction with the current upstream advice.
This patch removes the default value and accept the filesystem defaults for mkfs.xfs inode sizes.

Related Bug #1879423