### PR TITLE
Fixed serveral trivial bugs or typos on CalledProcessError() usage

### DIFF
--- a/charmhelpers/contrib/ansible/__init__.py
+++ b/charmhelpers/contrib/ansible/__init__.py
@@ -220,7 +220,7 @@ def apply_playbook(playbook, tags=None, extra_vars=None):
         charmhelpers.core.hookenv.log("Ansible playbook failed with {} "
                                       "Stdout: {}".format(e, e.output),
                                       level="ERROR")
-        raise subprocess.CalledProcessError(e)
+        raise e
 
 
 class AnsibleHooks(charmhelpers.core.hookenv.Hooks):

--- a/charmhelpers/contrib/ansible/__init__.py
+++ b/charmhelpers/contrib/ansible/__init__.py
@@ -217,8 +217,11 @@ def apply_playbook(playbook, tags=None, extra_vars=None):
     try:
         subprocess.check_output(call, env=env)
     except subprocess.CalledProcessError as e:
-        charmhelpers.core.hookenv.log("Ansible playbook failed with {} "
-                                      "Stdout: {}".format(e, e.output),
+        err_msg = e.output.decode().strip()
+        charmhelpers.core.hookenv.log("Ansible playbook failed with "
+                                      "{}".format(e),
+                                      level="ERROR")
+        charmhelpers.core.hookenv.log("Stdout: {}".format(err_msg),
                                       level="ERROR")
         raise e
 

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -389,7 +389,7 @@ class IPTest(unittest.TestCase):
         # If the syscall returns an error, then return True
 
         def fake_check_call(*args, **kwargs):
-            raise subprocess.CalledProcessError(['called'], 1)
+            raise subprocess.CalledProcessError(1, ['called'])
         mock_check_output.side_effect = fake_check_call
         self.assertTrue(net_ip.is_ipv6_disabled())
 

--- a/tests/contrib/storage/test_linux_storage_lvm.py
+++ b/tests/contrib/storage/test_linux_storage_lvm.py
@@ -93,7 +93,7 @@ class LVMStorageUtilsTests(unittest.TestCase):
     def test_is_not_physical_volume(self):
         """It properly reports block dev is an LVM PV"""
         with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
-            check_output.side_effect = subprocess.CalledProcessError('cmd', 2)
+            check_output.side_effect = subprocess.CalledProcessError(2, 'cmd')
             self.assertFalse(lvm.is_lvm_physical_volume('/dev/loop0'))
 
     def test_pvcreate(self):


### PR DESCRIPTION
This patch fixed serveral trivial bugs or typos on the `subprocess.CalledProcessError()` usage. Typically, they swapped the `returncode` and `cmd` positional_arguments. It also improved the readability of the CalledProcessError's output so that it is easier for human to read the error.