### PR TITLE
Suppress YAMLLoadWarning

### DIFF
--- a/charmhelpers/contrib/templating/contexts.py
+++ b/charmhelpers/contrib/templating/contexts.py
@@ -118,7 +118,8 @@ def juju_state_to_yaml(yaml_path, namespace_separator=':',
 
     if os.path.exists(yaml_path):
         with open(yaml_path, "r") as existing_vars_file:
-            existing_vars = yaml.load(existing_vars_file.read())
+            existing_vars = yaml.load(existing_vars_file.read(),
+                                      Loader=yaml.FullLoader)
     else:
         with open(yaml_path, "w+"):
             pass

--- a/charmhelpers/contrib/templating/contexts.py
+++ b/charmhelpers/contrib/templating/contexts.py
@@ -118,8 +118,7 @@ def juju_state_to_yaml(yaml_path, namespace_separator=':',
 
     if os.path.exists(yaml_path):
         with open(yaml_path, "r") as existing_vars_file:
-            existing_vars = yaml.load(existing_vars_file.read(),
-                                      Loader=yaml.FullLoader)
+            existing_vars = yaml.safe_load(existing_vars_file.read())
     else:
         with open(yaml_path, "w+"):
             pass

--- a/tools/charm_helpers_sync/charm_helpers_sync.py
+++ b/tools/charm_helpers_sync/charm_helpers_sync.py
@@ -34,7 +34,7 @@ def parse_config(conf_file):
     if not os.path.isfile(conf_file):
         logging.error('Invalid config file: %s.' % conf_file)
         return False
-    return yaml.load(open(conf_file).read())
+    return yaml.load(open(conf_file).read(), Loader=yaml.FullLoader)
 
 
 def clone_helpers(work_dir, repo):

--- a/tools/charm_helpers_sync/charm_helpers_sync.py
+++ b/tools/charm_helpers_sync/charm_helpers_sync.py
@@ -34,7 +34,7 @@ def parse_config(conf_file):
     if not os.path.isfile(conf_file):
         logging.error('Invalid config file: %s.' % conf_file)
         return False
-    return yaml.load(open(conf_file).read(), Loader=yaml.FullLoader)
+    return yaml.safe_load(open(conf_file).read())
 
 
 def clone_helpers(work_dir, repo):


### PR DESCRIPTION
This patch suppress the `YAMLLoadWarning`  when using `yaml.load()` without specifying `Loader`. By default, `yaml.load()` uses `FullLoader`. 