### PR TITLE
Add configuration for use of service tokens

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -493,6 +493,7 @@ class IdentityServiceContext(OSContextGenerator):
                 int_host = format_ipv6_addr(int_host) or int_host
                 svc_protocol = rdata.get('service_protocol') or 'http'
                 auth_protocol = rdata.get('auth_protocol') or 'http'
+                admin_role = rdata.get('admin_role') or 'Admin'
                 int_protocol = rdata.get('internal_protocol') or 'http'
                 api_version = rdata.get('api_version') or '2.0'
                 ctxt.update({'service_port': rdata.get('service_port'),
@@ -504,6 +505,7 @@ class IdentityServiceContext(OSContextGenerator):
                              'admin_tenant_name': rdata.get('service_tenant'),
                              'admin_user': rdata.get('service_username'),
                              'admin_password': rdata.get('service_password'),
+                             'admin_role': admin_role,
                              'service_protocol': svc_protocol,
                              'auth_protocol': auth_protocol,
                              'internal_protocol': int_protocol,

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
@@ -12,4 +12,6 @@ signing_dir = {{ signing_dir }}
 {% if service_type -%}
 service_type = {{ service_type }}
 {% endif -%}
+service_token_roles = {{ admin_role }}
+service_token_roles_required = True
 {% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -22,6 +22,4 @@ signing_dir = {{ signing_dir }}
 {% if use_memcache == true %}
 memcached_servers = {{ memcache_url }}
 {% endif -%}
-service_token_roles = Admin
-service_token_roles_required = True
 {% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-service-user
+++ b/charmhelpers/contrib/openstack/templates/section-service-user
@@ -1,16 +1,12 @@
 {% if auth_host -%}
-[keystone_authtoken]
+[service_user]
+send_service_user_token = true
 auth_type = password
 {% if api_version == "3" -%}
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v3
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
 project_domain_name = {{ admin_domain_name }}
 user_domain_name = {{ admin_domain_name }}
-{% if service_type -%}
-service_type = {{ service_type }}
-{% endif -%}
 {% else -%}
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
 project_domain_name = default
 user_domain_name = default
@@ -18,10 +14,4 @@ user_domain_name = default
 project_name = {{ admin_tenant_name }}
 username = {{ admin_user }}
 password = {{ admin_password }}
-signing_dir = {{ signing_dir }}
-{% if use_memcache == true %}
-memcached_servers = {{ memcache_url }}
-{% endif -%}
-service_token_roles = Admin
-service_token_roles_required = True
 {% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-service-user
+++ b/charmhelpers/contrib/openstack/templates/section-service-user
@@ -2,15 +2,9 @@
 [service_user]
 send_service_user_token = true
 auth_type = password
-{% if api_version == "3" -%}
-auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
-project_domain_name = {{ admin_domain_name }}
-user_domain_name = {{ admin_domain_name }}
-{% else -%}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
-project_domain_name = default
-user_domain_name = default
-{% endif -%}
+project_domain_id = default
+user_domain_id = default
 project_name = {{ admin_tenant_name }}
 username = {{ admin_user }}
 password = {{ admin_password }}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -254,6 +254,11 @@ IDENTITY_SERVICE_RELATION_VERSIONED = {
 }
 IDENTITY_SERVICE_RELATION_VERSIONED.update(IDENTITY_SERVICE_RELATION_HTTPS)
 
+IDENTITY_SERVICE_RELATION_ADMIN_ROLE = {
+    'admin_role': 'Role',
+}
+IDENTITY_SERVICE_RELATION_ADMIN_ROLE.update(IDENTITY_SERVICE_RELATION_HTTPS)
+
 IDENTITY_CREDENTIALS_RELATION_VERSIONED = {
     'api_version': '3',
     'service_tenant_id': 'svc-proj-id',
@@ -1340,6 +1345,36 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'https',
             'api_version': '3',
+        }
+        result.pop('keystone_authtoken')
+        self.assertEquals(result, expected)
+
+    @patch.object(context, 'filter_installed_packages', return_value=[])
+    def test_identity_service_context_with_admin_role(self, *args):
+        '''Test shared-db context with admin role supplied from keystone'''
+        relation = FakeRelation(
+            relation_data=IDENTITY_SERVICE_RELATION_ADMIN_ROLE)
+        self.relation_get.side_effect = relation.get
+        identity_service = context.IdentityServiceContext()
+        result = identity_service()
+        expected = {
+            'admin_password': 'foo',
+            'admin_role': 'Role',
+            'admin_tenant_name': 'admin',
+            'admin_tenant_id': None,
+            'admin_domain_id': None,
+            'admin_user': 'adam',
+            'auth_host': 'keystone-host.local',
+            'auth_port': '35357',
+            'auth_protocol': 'https',
+            'service_host': 'keystonehost.local',
+            'service_port': '5000',
+            'service_protocol': 'https',
+            'service_type': 'volume',
+            'internal_host': 'keystone-internal.local',
+            'internal_port': '5000',
+            'internal_protocol': 'https',
+            'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1350,6 +1350,7 @@ class ContextTests(unittest.TestCase):
         self.assertEquals(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
+    @patch.object(context, 'os_release', return_value='rocky')
     def test_identity_service_context_with_admin_role(self, *args):
         '''Test shared-db context with admin role supplied from keystone'''
         relation = FakeRelation(

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1285,6 +1285,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_domain_name': 'admin_domain',
             'admin_tenant_name': 'services',
             'admin_tenant_id': 'svc-proj-id',

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -1062,6 +1062,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
             'admin_domain_id': None,
@@ -1118,6 +1119,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
             'admin_domain_id': None,
@@ -1149,6 +1151,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
             'admin_domain_id': None,
@@ -1179,6 +1182,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': '123456',
             'admin_domain_id': None,
@@ -1208,6 +1212,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': None,
             'admin_domain_id': None,
@@ -1238,6 +1243,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_domain_name': 'admin_domain',
             'admin_tenant_name': 'services',
             'admin_tenant_id': 'svc-proj-id',
@@ -1273,6 +1279,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_domain_name': 'admin_domain',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': 'svc-proj-id',
@@ -1331,6 +1338,7 @@ class ContextTests(unittest.TestCase):
         result = identity_service()
         expected = {
             'admin_password': 'foo',
+            'admin_role': 'Admin',
             'admin_tenant_name': 'admin',
             'admin_tenant_id': '123456',
             'admin_domain_id': None,


### PR DESCRIPTION
Add a new template to configure the `service_user` ini file section and also add two parameters in `keystone_authtoken` configuration. These last two parameters are needed for service tokens to work properly.