### PR TITLE
use hvac unwrap api in 1.0.0

### DIFF
--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+from xml.dom.minidom import Attr
 
 import charmhelpers.contrib.openstack.alternatives as alternatives
 import charmhelpers.contrib.openstack.context as context
@@ -173,7 +174,12 @@ def retrieve_secret_id(url, token):
         # hvac < 0.9.2 assumes adapter is an instance, so doesn't instantiate
         if not isinstance(client.adapter, hvac.adapters.Request):
             client.adapter = hvac.adapters.Request(base_uri=url, token=token)
-    response = client._post('/v1/sys/wrapping/unwrap')
+    try:
+        # hvac == 1.0.0 has an API to unwrap with the user token
+        response = client.sys.unwrap()
+    except AttributeError:
+        # fallback to hvac < 1.0.0
+        response = client._post('/v1/sys/wrapping/unwrap')
     if response.status_code == 200:
         data = response.json()
         return data['data']['secret_id']

--- a/charmhelpers/contrib/openstack/vaultlocker.py
+++ b/charmhelpers/contrib/openstack/vaultlocker.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-from xml.dom.minidom import Attr
 
 import charmhelpers.contrib.openstack.alternatives as alternatives
 import charmhelpers.contrib.openstack.context as context


### PR DESCRIPTION
Use the unwrap api when `hvac==1.0.0`

See https://hvac.readthedocs.io/en/stable/usage/auth_methods/token.html
> Wrapping/unwrapping a token: