### PR TITLE
IndentityServiceContext app data fixes

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -485,10 +485,6 @@ class IdentityServiceContext(OSContextGenerator):
                     # Re-map some keys for backwards compatibility
                     for target, source in self._forward_compat_remaps.items():
                         adata[target] = _adata.get(source)
-                # else:
-                    # # No app data bag presented - fallback
-                    # # to legacy unit based relation data
-                    # rdata = relation_get(rid=rid, unit=unit)
                 # Now preferentially get data from the app data bag, but if
                 # it's not available, get it from the legacy based relation
                 # data.

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -469,66 +469,82 @@ class IdentityServiceContext(OSContextGenerator):
                 # forwards compat with application data
                 # bag driven approach to relation.
                 _adata = relation_get(rid=rid, app=remote_service_name(rid))
+                adata = {}
+                # if no app data bag presented - fallback
+                # to legacy unit based relation data
+                rdata = relation_get(rid=rid, unit=unit)
                 if _adata:
                     # New app data bag uses - instead of _
                     # in key names - remap for compat with
                     # existing relation data keys
                     for key, value in _adata.items():
                         if key == 'api-version':
-                            rdata[key.replace('-', '_')] = value.strip('v')
+                            adata[key.replace('-', '_')] = value.strip('v')
                         else:
-                            rdata[key.replace('-', '_')] = value
+                            adata[key.replace('-', '_')] = value
                     # Re-map some keys for backwards compatibility
                     for target, source in self._forward_compat_remaps.items():
-                        rdata[target] = _adata.get(source)
-                else:
-                    # No app data bag presented - fallback
-                    # to legacy unit based relation data
-                    rdata = relation_get(rid=rid, unit=unit)
-                serv_host = rdata.get('service_host')
+                        adata[target] = _adata.get(source)
+                # else:
+                    # # No app data bag presented - fallback
+                    # # to legacy unit based relation data
+                    # rdata = relation_get(rid=rid, unit=unit)
+                # Now preferentially get data from the app data bag, but if
+                # it's not available, get it from the legacy based relation
+                # data.
+
+                def _resolve(key):
+                    return adata.get(key) or rdata.get(key)
+
+                serv_host = _resolve('service_host')
                 serv_host = format_ipv6_addr(serv_host) or serv_host
-                auth_host = rdata.get('auth_host')
+                auth_host = _resolve('auth_host')
                 auth_host = format_ipv6_addr(auth_host) or auth_host
-                int_host = rdata.get('internal_host')
+                int_host = _resolve('internal_host',)
                 int_host = format_ipv6_addr(int_host) or int_host
-                svc_protocol = rdata.get('service_protocol') or 'http'
-                auth_protocol = rdata.get('auth_protocol') or 'http'
-                int_protocol = rdata.get('internal_protocol') or 'http'
-                api_version = rdata.get('api_version') or '2.0'
-                ctxt.update({'service_port': rdata.get('service_port'),
+                svc_protocol = _resolve('service_protocol') or 'http'
+                auth_protocol = _resolve('auth_protocol') or 'http'
+                int_protocol = _resolve('internal_protocol') or 'http'
+                api_version = _resolve('api_version') or '2.0'
+                ctxt.update({'service_port': _resolve('service_port'),
                              'service_host': serv_host,
                              'auth_host': auth_host,
-                             'auth_port': rdata.get('auth_port'),
+                             'auth_port': _resolve('auth_port'),
                              'internal_host': int_host,
-                             'internal_port': rdata.get('internal_port'),
-                             'admin_tenant_name': rdata.get('service_tenant'),
-                             'admin_user': rdata.get('service_username'),
-                             'admin_password': rdata.get('service_password'),
+                             'internal_port': _resolve('internal_port'),
+                             'admin_tenant_name': _resolve('service_tenant'),
+                             'admin_user': _resolve('service_username'),
+                             'admin_password': _resolve('service_password'),
                              'service_protocol': svc_protocol,
                              'auth_protocol': auth_protocol,
                              'internal_protocol': int_protocol,
                              'api_version': api_version})
 
-                if rdata.get('service_type'):
-                    ctxt['service_type'] = rdata.get('service_type')
+                service_type = _resolve('service_type')
+                if service_type:
+                    ctxt['service_type'] = service_type
 
                 if float(api_version) > 2:
                     ctxt.update({
-                        'admin_domain_name': rdata.get('service_domain'),
-                        'service_project_id': rdata.get('service_tenant_id'),
-                        'service_domain_id': rdata.get('service_domain_id')})
+                        'admin_domain_name': _resolve('service_domain'),
+                        'service_project_id': _resolve('service_tenant_id'),
+                        'service_domain_id': _resolve('service_domain_id')})
 
                 # NOTE:
                 # keystone-k8s operator presents full URLS
                 # for all three endpoints - public and internal are
                 # externally addressable for machine based charm
-                if 'public_auth_url' in rdata:
+                public_auth_url = _resolve('public_auth_url')
+                # if 'public_auth_url' in rdata:
+                if public_auth_url:
                     ctxt.update({
-                        'public_auth_url': rdata.get('public_auth_url'),
+                        'public_auth_url': public_auth_url,
                     })
-                if 'internal_auth_url' in rdata:
+                internal_auth_url = _resolve('internal_auth_url')
+                # if 'internal_auth_url' in rdata:
+                if internal_auth_url:
                     ctxt.update({
-                        'internal_auth_url': rdata.get('internal_auth_url'),
+                        'internal_auth_url': internal_auth_url,
                     })
 
                 # we keep all veriables in ctxt for compatibility and
@@ -543,8 +559,8 @@ class IdentityServiceContext(OSContextGenerator):
                     # NOTE(jamespage) this is required for >= icehouse
                     # so a missing value just indicates keystone needs
                     # upgrading
-                    ctxt['admin_tenant_id'] = rdata.get('service_tenant_id')
-                    ctxt['admin_domain_id'] = rdata.get('service_domain_id')
+                    ctxt['admin_tenant_id'] = _resolve('service_tenant_id')
+                    ctxt['admin_domain_id'] = _resolve('service_domain_id')
                     return ctxt
 
         return {}


### PR DESCRIPTION
The IdentityServiceContext was recently updated to add the application data bag.  Unfortunately, they keystone charm uses *both* the regular relation data primarily, but the updates for endpoints are on both the application database and the regular relation data.  The IdentityServiceContext used the app data bag exclusively if there were any keys available, which leads to it ignoring the existing relation data entirely; this results in 'identity relation not ready' with missing data items.

This patch changes the functionality of the IdentityServiceContext so that it preferentially selects keys from the application data bag *unless* they are None, in which case it tries for those keys on the existing relation data.  e.g. it will stitch the two relations together with the app data bag taking priority.  This allows the (e.g.) nova-cloud-controller charm to correctly access the identity relation data and form a complete context.