### PR TITLE
Support HAproxy https health checks (#662)

### DIFF
--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -82,7 +82,11 @@ backend {{ service }}_{{ frontend }}
     {% endif -%}
     {% endif -%}
     {% for unit, address in frontends[frontend]['backends'].items() -%}
+    {% if https -%}
+    server {{ unit }} {{ address }}:{{ ports[1] }} check check-ssl verify none
+    {% else -%}
     server {{ unit }} {{ address }}:{{ ports[1] }} check
+    {% endif -%}
     {% endfor %}
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
This change adds the option of running HTTPS health checks. It is proposed in the context of LP: #1946280 where the backend radosgw server can be configured to run in https mode.
We disable certificate verification because we are only interested in the health of the service.


Related ceph-radosgw change:
* https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/817582

Co-authored-by: Cornellius Metto <ckmmetto@gmail.com>

The patch in https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/817582 requires this patch to work. This patch was merged into charm-ceph-radosgw here: https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/828099.

This adds new behavior when the https variable is set and the patch in 817582 sets that variable when https is used.
I need to backport this to octopus so I need to incorporate this change in the ussuri branch before backporting 817582. That is why I'm merging to victoria first.

The original commit for this in charm-helpers is here: https://github.com/juju/charm-helpers/commit/c0c9bedb9cf7b4eee43568d4bc7876048c3fbd1a