### PR TITLE
auth_uri is deprecated from group keystone_authtoken

### DIFF
--- a/charmhelpers/contrib/openstack/audits/openstack_security_guide.py
+++ b/charmhelpers/contrib/openstack/audits/openstack_security_guide.py
@@ -256,7 +256,7 @@ def validate_uses_tls_for_keystone(audit_options):
     section = _config_section(audit_options, 'keystone_authtoken')
     assert section is not None, "Missing section 'keystone_authtoken'"
     assert not section.get('insecure') and \
-        "https://" in section.get("auth_uri"), \
+        "https://" in section.get("www_authenticate_uri"), \
         "TLS is not used for Keystone"
 
 

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
@@ -1,6 +1,6 @@
 {% if auth_host -%}
 [keystone_authtoken]
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
+www_authenticate_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
 auth_plugin = password
 project_domain_id = default

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -2,7 +2,7 @@
 [keystone_authtoken]
 auth_type = password
 {% if api_version == "3" -%}
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v3
+www_authenticate_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v3
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/v3
 project_domain_name = {{ admin_domain_name }}
 user_domain_name = {{ admin_domain_name }}
@@ -10,7 +10,7 @@ user_domain_name = {{ admin_domain_name }}
 service_type = {{ service_type }}
 {% endif -%}
 {% else -%}
-auth_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
+www_authenticate_uri = {{ service_protocol }}://{{ service_host }}:{{ service_port }}
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
 project_domain_name = default
 user_domain_name = default

--- a/tests/contrib/openstack/test_audits.py
+++ b/tests/contrib/openstack/test_audits.py
@@ -336,7 +336,7 @@ class OpenstackSecurityGuideTestCase(TestCase):
            '.openstack_security_guide._config_section')
     def test_validate_uses_tls_for_keystone(self, _config_section):
         _config_section.return_value = {
-            'auth_uri': 'https://10.10.10.10',
+            'www_authenticate_uri': 'https://10.10.10.10',
         }
         guide.validate_uses_tls_for_keystone({})
         _config_section.assert_called_with({}, 'keystone_authtoken')


### PR DESCRIPTION
The option "auth_uri" from group "keystone_authtoken" is deprecated for removal. The auth_uri token is deprecated in favor of www_authenticate_uri. This commit changes the use of auth_uri to www_authenticate_uri correctly.

Fixes #749