### PR TITLE
Remove test requirement python-distutils-extra

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 # Test-only dependencies are unpinned.
 #
-git+https://git.launchpad.net/ubuntu/+source/python-distutils-extra
 pip
 coverage>=3.6
 mock>=1.0.1,<1.1.0


### PR DESCRIPTION
Remove test requirement python-distutils-extra as it no longer seems to be needed and is breaking python3.5 tests.