### PR TITLE
Ensure deferred events limited to current charm

### DIFF
--- a/charmhelpers/contrib/openstack/deferred_events.py
+++ b/charmhelpers/contrib/openstack/deferred_events.py
@@ -127,7 +127,9 @@ def deferred_events():
     """
     events = []
     for defer_file in deferred_events_files():
-        events.append((defer_file, read_event_file(defer_file)))
+        event = read_event_file(defer_file)
+        if event.policy_requestor_name == hookenv.service_name():
+            events.append((defer_file, event))
     return events
 
 


### PR DESCRIPTION
The deferred_events() function was returning all deferred events on the machine, regardless of whether they were deferred for the current charm or not. This changes limits the returned events to those that correspond to the current charm.

Closes-Bug: #2011927