### PR TITLE
ns_query: capture NoNameservers exception. (#698) [victoria backport]

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -477,7 +477,7 @@ def ns_query(address):
 
     try:
         answers = dns.resolver.query(address, rtype)
-    except dns.resolver.NXDOMAIN:
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers):
         return None
 
     if answers:

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -721,6 +721,11 @@ class IPTest(unittest.TestCase):
         self.assertEquals(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
+    def test_ns_query_loopup_fail_real_implementation(self, apt_install):
+        self.assertEqual(net_ip.ns_query('nonexistant'), None)
+        apt_install.assert_not_called()
+
+    @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_ip(self, apt_install):
         fake_dns = FakeDNS('www.ubuntu.com')
         with patch(builtin_import, side_effect=[fake_dns, fake_dns]):


### PR DESCRIPTION
When all the servers configured in the system failed to answer the query the exception `dns.resolver.NoNameservers` is raised while NXDOMAIN is only for when the name was not found.

(cherry picked from commit 91ee22fbe3c6fbe8b3b2b60371b43ad0a3c67f92)