### PR TITLE
Handle stopstart in get_deferred_restarts()

### DIFF
--- a/charmhelpers/contrib/openstack/deferred_events.py
+++ b/charmhelpers/contrib/openstack/deferred_events.py
@@ -242,7 +242,8 @@ def get_deferred_restarts():
     :returns: List of deferred restarts
     :rtype: List[ServiceEvent]
     """
-    return [e for e in get_deferred_events() if e.action == 'restart']
+    return [e for e in get_deferred_events() if (e.action == 'restart' or
+                                                 e.action == 'stop')]
 
 
 def clear_deferred_restarts(services):


### PR DESCRIPTION
This handles situations like the following when stopstart=True has been used for restart_on_change():

$ cat /var/lib/policy-rc.d/charm-ovn-chassis-<uuid>.deferred action: stop
policy_requestor_name: ovn-chassis
policy_requestor_type: charm
reason: Package update
service: ovs-vswitchd.service
timestamp: 1679507800

Closes-Bug: #2012553