### PR TITLE
Restart deferred stopped events in restart_services_action()

### DIFF
--- a/charmhelpers/contrib/openstack/deferred_events.py
+++ b/charmhelpers/contrib/openstack/deferred_events.py
@@ -245,6 +245,15 @@ def get_deferred_restarts():
     return [e for e in get_deferred_events() if e.action == 'restart']
 
 
+def get_deferred_stops():
+    """List of deferred stop events requested by the charm and packages.
+
+    :returns: List of deferred stops
+    :rtype: List[ServiceEvent]
+    """
+    return [e for e in get_deferred_events() if e.action == 'stop']
+
+
 def clear_deferred_restarts(services):
     """Clear deferred restart events targeted at `services`.
 

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1786,7 +1786,7 @@ def restart_services_action(services=None, when_all_stopped_func=None,
                                   stopped.
     :type when_all_stopped_func: Callable[]
     :param model_name: Only restart services which have a deferred restart
-                       event.
+                       or stop event.
     :type model_name: bool
     """
     if services and deferred_only:
@@ -1794,7 +1794,9 @@ def restart_services_action(services=None, when_all_stopped_func=None,
             "services and deferred_only are mutually exclusive")
     if deferred_only:
         services = list(set(
-            [a.service for a in deferred_events.get_deferred_restarts()]))
+            [a.service for a in (
+                deferred_events.get_deferred_restarts() +
+                deferred_events.get_deferred_stops())]))
     _, messages = manage_payload_services(
         'stop',
         services=services,


### PR DESCRIPTION
This change updates restart_services_action() to restart deferred 'stop' events, in addition to the already existing restart of 'restart' events.

Some services get stopped, and not restarted, when dpkg-reconfigure is called. For example: ovsdb-server, ovs-vswitchd, and ovs-record-hostname from the openvswitch package in kinetic+ are defined to behave this way. This results in a deferred event such as:

$ cat /var/lib/policy-rc.d/charm-ovn-chassis-<uuid>.deferred action: stop
policy_requestor_name: ovn-chassis
policy_requestor_type: charm
reason: Package update
service: ovs-vswitchd.service
timestamp: 1679507800

Closes-Bug: #2012553