### PR TITLE
Update method for checking endpoint protocol

### DIFF
--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -32,7 +32,6 @@ import time
 
 from socket import gethostname as get_unit_hostname
 
-import charmhelpers.contrib.openstack.cert_utils as cert_utils
 from charmhelpers.core.hookenv import (
     log,
     relation_ids,
@@ -107,8 +106,6 @@ def is_elected_leader(resource):
     return True
 
 
-# This has been copied into charmhelpers/contrib/openstack/ip.py. If it is
-# updated please copy and update there too.
 def is_clustered():
     for r_id in (relation_ids('ha') or []):
         for unit in (relation_list(r_id) or []):
@@ -224,6 +221,8 @@ def https():
         return True
     if config_get('ssl_cert') and config_get('ssl_key'):
         return True
+    # Local import to avoid ciruclar dependency.
+    import charmhelpers.contrib.openstack.cert_utils as cert_utils
     if (
         cert_utils.get_certificate_request() and not
         cert_utils.get_requests_for_local_unit("certificates")

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -32,6 +32,7 @@ import time
 
 from socket import gethostname as get_unit_hostname
 
+import charmhelpers.contrib.openstack.cert_utils as cert_utils
 from charmhelpers.core.hookenv import (
     log,
     relation_ids,
@@ -106,6 +107,8 @@ def is_elected_leader(resource):
     return True
 
 
+# This has been copied into charmhelpers/contrib/openstack/ip.py. If it is
+# updated please copy and update there too.
 def is_clustered():
     for r_id in (relation_ids('ha') or []):
         for unit in (relation_list(r_id) or []):
@@ -221,6 +224,11 @@ def https():
         return True
     if config_get('ssl_cert') and config_get('ssl_key'):
         return True
+    if (
+        cert_utils.get_certificate_request() and not
+        cert_utils.get_requests_for_local_unit("certificates")
+    ):
+        return False
     for r_id in relation_ids('certificates'):
         for unit in relation_list(r_id):
             ca = relation_get('ca', rid=r_id, unit=unit)

--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -18,6 +18,9 @@ from charmhelpers.core.hookenv import (
     unit_get,
     service_name,
     network_get_primary_address,
+    relation_ids,
+    related_units as relation_list,
+    relation_get,
 )
 from charmhelpers.contrib.network.ip import (
     get_address_in_network,
@@ -27,7 +30,6 @@ from charmhelpers.contrib.network.ip import (
     resolve_network_cidr,
     get_iface_for_address
 )
-from charmhelpers.contrib.hahelpers.cluster import is_clustered
 
 PUBLIC = 'public'
 INTERNAL = 'int'
@@ -69,6 +71,21 @@ ADDRESS_MAP = {
         'override': 'os-internal-hostname',
     },
 }
+
+
+# The authoratative copy of is_clustered is in
+# charmhelpers/contrib/hahelpers/cluster.py. To avoid circular dependacy
+# it is copied here. If an update is needed please update the other copy
+# and copy any changes back here.
+def is_clustered():
+    for r_id in (relation_ids('ha') or []):
+        for unit in (relation_list(r_id) or []):
+            clustered = relation_get('clustered',
+                                     rid=r_id,
+                                     unit=unit)
+            if clustered:
+                return True
+    return False
 
 
 def canonical_url(configs, endpoint_type=PUBLIC):

--- a/charmhelpers/contrib/openstack/ip.py
+++ b/charmhelpers/contrib/openstack/ip.py
@@ -18,9 +18,6 @@ from charmhelpers.core.hookenv import (
     unit_get,
     service_name,
     network_get_primary_address,
-    relation_ids,
-    related_units as relation_list,
-    relation_get,
 )
 from charmhelpers.contrib.network.ip import (
     get_address_in_network,
@@ -30,6 +27,7 @@ from charmhelpers.contrib.network.ip import (
     resolve_network_cidr,
     get_iface_for_address
 )
+from charmhelpers.contrib.hahelpers.cluster import is_clustered
 
 PUBLIC = 'public'
 INTERNAL = 'int'
@@ -71,21 +69,6 @@ ADDRESS_MAP = {
         'override': 'os-internal-hostname',
     },
 }
-
-
-# The authoratative copy of is_clustered is in
-# charmhelpers/contrib/hahelpers/cluster.py. To avoid circular dependacy
-# it is copied here. If an update is needed please update the other copy
-# and copy any changes back here.
-def is_clustered():
-    for r_id in (relation_ids('ha') or []):
-        for unit in (relation_list(r_id) or []):
-            clustered = relation_get('clustered',
-                                     rid=r_id,
-                                     unit=unit)
-            if clustered:
-                return True
-    return False
 
 
 def canonical_url(configs, endpoint_type=PUBLIC):

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -261,7 +261,7 @@ class ClusterUtilsTests(TestCase):
             'key',  # relation_get('ssl_key')
             'ca_cert',  # relation_get('ca_cert')
         ]
-        self.assertTrue(cluster_utils.https())
+        self.assertFalse(cluster_utils.https())
 
     @patch('charmhelpers.contrib.openstack.cert_utils')
     def test_https_cert_key_incomplete_identity_relation(self, cert_utils):


### PR DESCRIPTION
The `https` method is used to check if an endpoint is expected to be http or https. One of the checks it performs is to examine the the certificates relation. If the relation is present then it looks for the existance of a CA. However the OpenStack charms do not switch to https until a certificate is provided via the certificates relation. This means there can be a disconnect if the certificate provider has provided a CA but has not yet provided the unit specific certificates. If this happens then the payload will still be using http but the `https` method will return True.

This patch updates the `https` method to return False if an unfilled certificate request exists.

https://bugs.launchpad.net/charm-keystone/+bug/2015103