### PR TITLE
Add -S option when calling add-apt-repository for a line starting with deb

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -769,13 +769,13 @@ def _add_apt_repository(spec):
     if '{series}' in spec:
         spec = spec.replace('{series}', series)
     cmd = ['add-apt-repository', '--yes']
-    if (spec.strip().startswith('deb')
-            and CompareHostReleases(series) >= 'jammy'):
+    if (spec.strip().startswith('deb') and
+            CompareHostReleases(series) >= 'jammy'):
         # if starts with deb, just add the source.list as per lp:2017014, only
         # in jammy or newer
         cmd.append('-S')
     cmd.append(spec)
-    _run_with_retries(['add-apt-repository', '--yes', spec],
+    _run_with_retries(cmd,
                       cmd_env=env_proxy_settings(['https', 'http', 'no_proxy'])
                       )
 


### PR DESCRIPTION
This is only for jammy or newer, and it just bypass any custom ppa logic in add-apt-repository by passing `-S` if the source line starts with deb.
fixes #770 