### PR TITLE
Don't filter the proxy settings being passed to curl

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -591,7 +591,7 @@ def _get_key_by_keyid(keyid):
     curl_cmd = ['curl', keyserver_url.format(keyid)]
     # use proxy server settings in order to retrieve the key
     return subprocess.check_output(curl_cmd,
-                                   env=env_proxy_settings(['https']))
+                                   env=env_proxy_settings())
 
 
 def _dearmor_gpg_key(key_asc):


### PR DESCRIPTION
env_proxy_settings() DTRT by default with no arguments.  Passing 'https' as an argument just causes it to FAIL to honor no_proxy in the environment which it should.