### PR TITLE
Update method for checking endpoint protocol [antelope]

### DIFF
--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -221,6 +221,13 @@ def https():
         return True
     if config_get('ssl_cert') and config_get('ssl_key'):
         return True
+    # Local import to avoid ciruclar dependency.
+    import charmhelpers.contrib.openstack.cert_utils as cert_utils
+    if (
+        cert_utils.get_certificate_request() and not
+        cert_utils.get_requests_for_local_unit("certificates")
+    ):
+        return False
     for r_id in relation_ids('certificates'):
         for unit in relation_list(r_id):
             ca = relation_get('ca', rid=r_id, unit=unit)

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -231,8 +231,11 @@ class ClusterUtilsTests(TestCase):
         ]
         self.assertTrue(cluster_utils.https())
 
-    def test_https_cert_key_in_identity_relation(self):
+    @patch('charmhelpers.contrib.openstack.cert_utils')
+    def test_https_cert_key_in_identity_relation(self, cert_utils):
         '''It determines https is available if cert in identity-service'''
+        cert_utils.get_certificate_request.return_value = False
+        cert_utils.get_requests_for_local_unit.return_value = {}
         self.config_get.return_value = False
         self.relation_ids.return_value = 'identity-service:0'
         self.relation_list.return_value = 'keystone/0'
@@ -244,8 +247,27 @@ class ClusterUtilsTests(TestCase):
         ]
         self.assertTrue(cluster_utils.https())
 
-    def test_https_cert_key_incomplete_identity_relation(self):
+    @patch('charmhelpers.contrib.openstack.cert_utils')
+    def test_https_cert_req_pending(self, cert_utils):
+        '''It determines https is available if cert in identity-service'''
+        cert_utils.get_certificate_request.return_value = True
+        cert_utils.get_requests_for_local_unit.return_value = {}
+        self.config_get.return_value = False
+        self.relation_ids.return_value = 'identity-service:0'
+        self.relation_list.return_value = 'keystone/0'
+        self.relation_get.side_effect = [
+            'yes',  # relation_get('https_keystone')
+            'cert',  # relation_get('ssl_cert')
+            'key',  # relation_get('ssl_key')
+            'ca_cert',  # relation_get('ca_cert')
+        ]
+        self.assertFalse(cluster_utils.https())
+
+    @patch('charmhelpers.contrib.openstack.cert_utils')
+    def test_https_cert_key_incomplete_identity_relation(self, cert_utils):
         '''It determines https unavailable if cert not in identity-service'''
+        cert_utils.get_certificate_request.return_value = False
+        cert_utils.get_requests_for_local_unit.return_value = {}
         self.config_get.return_value = False
         self.relation_ids.return_value = 'identity-service:0'
         self.relation_list.return_value = 'keystone/0'


### PR DESCRIPTION
Update method for checking endpoint protocol

The `https` method is used to check if an endpoint is expected to be http or https. One of the checks it performs is to examine the the certificates relation. If the relation is present then it looks for the existance of a CA. However the OpenStack charms do not switch to https until a certificate is provided via the certificates relation. This means there can be a disconnect if the certificate provider has provided a CA but has not yet provided the unit specific certificates. If this happens then the payload will still be using http but the `https` method will return True.

This patch updates the `https` method to return False if an unfilled certificate request exists.

(cherry picked from commit 6064a34627882d1c8acf74644c48d05db67ee3b4)