### PR TITLE
Run CI on stable branches [antelope]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: charm-helpers CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'stable/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'stable/**'
 
 jobs:
   build:


### PR DESCRIPTION
Charm-helpers has stable git branches that need to run the CI (github actions workflow) too.

(cherry picked from commit b26627541bfb62e5f5a1e747715b315b835e3d88)