### PR TITLE
Run CI on stable branches [train]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
-          - python-version: 2.7
-            env: pep8,py27
-          - python-version: 3.4
-            env: pep8,py34
-          - python-version: 3.5
-            env: pep8,py35
           - python-version: 3.6
             env: pep8,py36
           - python-version: 3.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: charm-helpers CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'stable/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'stable/**'
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -52,28 +52,15 @@ userinstall:
 	.venv3/bin/pip install -I -r test-requirements.txt
 
 # Note we don't even attempt to run tests if lint isn't passing.
-test: lint test2 test3
+test: lint test-py3
 	@echo OK
 
-test2:
-	@echo Starting Py2 tests...
-	.venv/bin/nosetests -s --nologcapture tests/
-
-test3:
+test-py3:
 	@echo Starting Py3 tests...
-	.venv3/bin/nosetests -s --nologcapture tests/
+	tox -e py3
 
-ftest: lint
-	@echo Starting fast tests...
-	.venv/bin/nosetests --attr '!slow' --nologcapture tests/
-	.venv3/bin/nosetests --attr '!slow' --nologcapture tests/
-
-lint: .venv .venv3
-	@echo Checking for Python syntax...
-	@.venv/bin/flake8 --ignore=E402,E501,W504 $(PROJECT) $(TESTS) tools/ \
-	    && echo Py2 OK
-	@.venv3/bin/flake8 --ignore=E402,E501,W504 $(PROJECT) $(TESTS) tools/ \
-	    && echo Py3 OK
+lint:
+	tox -e pep8
 
 docs:
 	- [ -z "`dpkg -l | grep python-sphinx`" ] && sudo apt-get install python-sphinx -y

--- a/charmhelpers/contrib/hahelpers/cluster.py
+++ b/charmhelpers/contrib/hahelpers/cluster.py
@@ -327,7 +327,7 @@ def valid_hacluster_config():
     '''
     vip = config_get('vip')
     dns = config_get('dns-ha')
-    if not(bool(vip) ^ bool(dns)):
+    if not (bool(vip) ^ bool(dns)):
         msg = ('HA: Either vip or dns-ha must be set but not both in order to '
                'use high availability')
         status_set('blocked', msg)

--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -552,7 +552,7 @@ def port_has_listener(address, port):
     """
     cmd = ['nc', '-z', address, str(port)]
     result = subprocess.call(cmd)
-    return not(bool(result))
+    return not (bool(result))
 
 
 def assert_charm_supports_ipv6():

--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -652,7 +652,7 @@ def patch_ports_on_bridge(bridge):
                     uuid_for_port(
                         interface['options']['peer'])),
                     interface['options']['peer'])
-                yield(Patch(this_end, other_end))
+                yield Patch(this_end, other_end)
             # We expect one result and it is ok if it turns out to be a port
             # for a different bridge. However we need a break here to satisfy
             # the for/else check which is in place to detect interface referring

--- a/charmhelpers/contrib/network/ovs/ovsdb.py
+++ b/charmhelpers/contrib/network/ovs/ovsdb.py
@@ -199,7 +199,7 @@ class SimpleOVSDB(object):
                         decoded_set = []
                         for el in data[1]:
                             decoded_set.append(self._deserialize_ovsdb(el))
-                        return(decoded_set)
+                        return decoded_set
                     # fall back to normal processing below
                     break
 

--- a/charmhelpers/contrib/openstack/ssh_migrations.py
+++ b/charmhelpers/contrib/openstack/ssh_migrations.py
@@ -310,7 +310,7 @@ def ssh_known_hosts_lines(application_name, user=None):
         for hosts_line in hosts:
             if hosts_line.rstrip():
                 known_hosts_list.append(hosts_line.rstrip())
-    return(known_hosts_list)
+    return known_hosts_list
 
 
 def ssh_authorized_keys_lines(application_name, user=None):
@@ -327,7 +327,7 @@ def ssh_authorized_keys_lines(application_name, user=None):
         for authkey_line in keys:
             if authkey_line.rstrip():
                 authorized_keys_list.append(authkey_line.rstrip())
-    return(authorized_keys_list)
+    return authorized_keys_list
 
 
 def ssh_compute_remove(public_key, application_name, user=None):

--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -1325,7 +1325,7 @@ def _check_listening_on_services_ports(services, test=False):
     @param test: default=False, if False, test for closed, otherwise open.
     @returns OrderedDict(service: [port-not-open, ...]...), [boolean]
     """
-    test = not(not(test))  # ensure test is True or False
+    test = not (not (test))  # ensure test is True or False
     all_ports = list(itertools.chain(*services.values()))
     ports_states = [port_has_listener('0.0.0.0', p) for p in all_ports]
     map_ports = OrderedDict()
@@ -1549,7 +1549,7 @@ def is_unit_paused_set():
         with unitdata.HookData()() as t:
             kv = t[0]
             # transform something truth-y into a Boolean.
-            return not(not(kv.get('unit-paused')))
+            return not (not (kv.get('unit-paused')))
     except Exception:
         return False
 
@@ -2148,7 +2148,7 @@ def is_unit_upgrading_set():
         with unitdata.HookData()() as t:
             kv = t[0]
             # transform something truth-y into a Boolean.
-            return not(not(kv.get('unit-upgrading')))
+            return not (not (kv.get('unit-upgrading')))
     except Exception:
         return False
 

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -926,7 +926,7 @@ def pwgen(length=None):
     random_generator = random.SystemRandom()
     random_chars = [
         random_generator.choice(alphanumeric_chars) for _ in range(length)]
-    return(''.join(random_chars))
+    return ''.join(random_chars)
 
 
 def is_phy_iface(interface):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,4 +32,5 @@ Jinja2;      python_version >= '3.6'                             # py36 and on
 netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.
 psutil==1.2.1      # trusty
 python-keystoneclient==2.3.2 # xenial
-dnspython==1.11.1  # trusty
+dnspython==1.15.0 ; python_version<='3.7'  # bionic
+dnspython==1.16.0 ; python_version=='3.8'  # focal

--- a/tests/contrib/openstack/test_deferred_events.py
+++ b/tests/contrib/openstack/test_deferred_events.py
@@ -158,7 +158,7 @@ class DeferredCharmServiceEventsTestCase(tests.utils.BaseTestCase):
         get_event_record_file.return_value = test_file
         deferred_events.save_event(self.exp_event_a)
         with open(test_file, 'r') as f:
-            contents = yaml.load(f)
+            contents = yaml.safe_load(f)
         self.assertEqual(contents, vars(self.exp_event_a))
 
     @patch.object(deferred_events.os, "remove")

--- a/tests/contrib/openstack/test_policy_rcd.py
+++ b/tests/contrib/openstack/test_policy_rcd.py
@@ -48,7 +48,7 @@ class PolicyRCDTests(unittest.TestCase):
         with tempfile.NamedTemporaryFile('w') as ftmp:
             policy_rcd.write_policy_file(ftmp.name, TEST_POLICY)
             with open(ftmp.name, 'r') as f:
-                policy = yaml.load(f)
+                policy = yaml.safe_load(f)
             self.assertEqual(policy, TEST_POLICY)
 
     @mock.patch.object(policy_rcd.os, "remove")


### PR DESCRIPTION
This PR is a series of patches that allow running the CI on this stable branch successfully.

Summary of changes:
- Migrate the runner from 18.04 to 20.04
- Drop testing of python<3.6, Bionic runs python-3.6 which it's the older we support.
- Pep8 fixes merged in PR #729
- Pin dnspython on the versions shipped by Ubuntu
- Replace `yaml.load()` with `yaml.safe_load()`