### PR TITLE
Update Makefile to be consistent with CI [zed]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
-          - python-version: 3.5
-            env: pep8,py35
           - python-version: 3.6
             env: pep8,py36
           - python-version: 3.7

--- a/Makefile
+++ b/Makefile
@@ -44,21 +44,15 @@ userinstall:
 	.venv3/bin/pip install -I -r test-requirements.txt
 
 # Note we don't even attempt to run tests if lint isn't passing.
-test: lint test3
+test: lint test-py3
 	@echo OK
 
-test3:
+test-py3:
 	@echo Starting Py3 tests...
-	.venv3/bin/nosetests -s --nologcapture tests/
+	tox -e py3
 
-ftest: lint
-	@echo Starting fast tests...
-	.venv3/bin/nosetests --attr '!slow' --nologcapture tests/
-
-lint: .venv3
-	@echo Checking for Python syntax...
-	@.venv3/bin/flake8 --ignore=E402,E501,W504 $(PROJECT) $(TESTS) tools/ \
-	    && echo Py3 OK
+lint:
+	tox -e pep8
 
 docs:
 	- [ -z "`dpkg -l | grep python3-sphinx`" ] && sudo apt-get install python-sphinx -y


### PR DESCRIPTION
Also remove python3.5 from the CI build,
because that is no longer supported in charm-helpers, and use a supported runs-on ubuntu version for github CI.

(cherry picked from commit 59f134b7d8b0b918ac71cbac8aa641e21babbdee)