### PR TITLE
Support legacy cert requests [antelope]

### DIFF
--- a/charmhelpers/contrib/openstack/cert_utils.py
+++ b/charmhelpers/contrib/openstack/cert_utils.py
@@ -409,6 +409,9 @@ def get_requests_for_local_unit(relation_name=None):
     relation_name = relation_name or 'certificates'
     bundles = []
     for rid in relation_ids(relation_name):
+        sent = relation_get(rid=rid, unit=local_unit())
+        legacy_keys = ['certificate_name', 'common_name']
+        is_legacy_request = set(sent).intersection(legacy_keys)
         for unit in related_units(rid):
             data = relation_get(rid=rid, unit=unit)
             if data.get(raw_certs_key):
@@ -416,6 +419,14 @@ def get_requests_for_local_unit(relation_name=None):
                     'ca': data['ca'],
                     'chain': data.get('chain'),
                     'certs': json.loads(data[raw_certs_key])})
+            elif is_legacy_request:
+                bundles.append({
+                    'ca': data['ca'],
+                    'chain': data.get('chain'),
+                    'certs': {sent['common_name']:
+                              {'cert': data.get(local_name + '.server.cert'),
+                               'key': data.get(local_name + '.server.key')}}})
+
     return bundles
 
 

--- a/tests/contrib/openstack/test_cert_utils.py
+++ b/tests/contrib/openstack/test_cert_utils.py
@@ -580,6 +580,43 @@ class CertUtilsTests(unittest.TestCase):
                 'chain': 'MYCHAIN'}]
         )
 
+    @mock.patch.object(cert_utils, 'local_unit')
+    @mock.patch.object(cert_utils, 'related_units')
+    @mock.patch.object(cert_utils, 'relation_ids')
+    @mock.patch.object(cert_utils, 'relation_get')
+    def test_get_requests_for_local_unit_legacy(self, relation_get,
+                                                relation_ids, related_units,
+                                                local_unit):
+        local_unit.return_value = 'rabbitmq-server/2'
+
+        def fake_relation_get(rid, unit):
+            if unit == 'rabbitmq-server/2':
+                # i.e. legacy request
+                return {'certificate_name':
+                        'eb32103b-27c8-4feb-8771-c7097c7314e8',
+                        'common_name': 'juju-cd4bb3-5.lxd',
+                        'sans': '["10.5.100.11", "10.5.0.32"]'}
+            else:
+                return {
+                    'rabbitmq-server_2.server.cert': 'BASECERT',
+                    'rabbitmq-server_2.server.key': 'BASEKEY',
+                    'chain': 'MYCHAIN',
+                    'ca': 'ROOTCA'}
+
+        relation_ids.return_value = ['certificates:12']
+        related_units.return_value = ['vault/0']
+        relation_get.side_effect = fake_relation_get
+        self.assertEqual(
+            cert_utils.get_requests_for_local_unit(),
+            [{
+                'ca': 'ROOTCA',
+                'certs': {
+                    'juju-cd4bb3-5.lxd': {
+                        'cert': 'BASECERT',
+                        'key': 'BASEKEY'}},
+                'chain': 'MYCHAIN'}]
+        )
+
     @mock.patch.object(cert_utils, 'get_requests_for_local_unit')
     def test_get_bundle_for_cn(self, get_requests_for_local_unit):
         get_requests_for_local_unit.return_value = [{


### PR DESCRIPTION
The tls-certificates interface supports two ways of requesting certs and openstack.cert_utils needs to support both when checking if certificates are ready to be used. Without this it will never declare certificates as ready if they were requested with the old/legacy method.

Closes-Bug: #2022980
(cherry picked from commit 58097330bd15cfd7b539481c55718c6cee8ca124)