### PR TITLE
Fix openstack release comparison wrap (#768)

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -957,7 +957,7 @@ def os_requires_version(ostack_release, pkg):
     def wrap(f):
         @wraps(f)
         def wrapped_f(*args):
-            if os_release(pkg) < ostack_release:
+            if CompareOpenStackReleases(os_release(pkg)) < ostack_release:
                 raise Exception("This hook is not supported on releases"
                                 " before %s" % ostack_release)
             f(*args)


### PR DESCRIPTION
Fix OpenStack release comparison wrap in os_requires_version() to ensure, for example, that 'antelope' is > 'zed'.

(cherry picked from commit 6ae6d7adde8ce500d77bac6f08edff4a676dcc03)