### PR TITLE
Allow users to disable wsgi socket rotation

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1748,6 +1748,9 @@ class WSGIWorkerConfigContext(WorkerConfigContext):
 
     def __call__(self):
         total_processes = _calculate_workers()
+        enable_wsgi_rotation = config('wsgi-rotation')
+        if enable_wsgi_rotation is None:
+            enable_wsgi_rotation = True
         ctxt = {
             "service_name": self.service_name,
             "user": self.user,
@@ -1761,6 +1764,7 @@ class WSGIWorkerConfigContext(WorkerConfigContext):
             "public_processes": int(math.ceil(self.public_process_weight *
                                               total_processes)),
             "threads": 1,
+            "wsgi_rotation": enable_wsgi_rotation,
         }
         return ctxt
 

--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -12,6 +12,12 @@ Listen {{ admin_port }}
 Listen {{ public_port }}
 {% endif -%}
 
+{% if wsgi_rotation -%}
+WSGISocketRotation On
+{% else -%}
+WSGISocketRotation Off
+{% endif -%}
+
 {% if port -%}
 <VirtualHost *:{{ port }}>
     WSGIDaemonProcess {{ service_name }} processes={{ processes }} threads={{ threads }} user={{ user }} group={{ group }} \

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3569,7 +3569,9 @@ class ContextTests(unittest.TestCase):
     @patch.object(context, '_calculate_workers')
     def test_wsgi_worker_config_context(self,
                                         _calculate_workers):
-        self.config.return_value = 2  # worker-multiplier=2
+        self.config.side_effect = fake_config({
+            'worker-multiplier': 2, 'non-defined-wsgi-rotation': True
+        })
         _calculate_workers.return_value = 8
         service_name = 'service-name'
         script = '/usr/bin/script'
@@ -3586,13 +3588,16 @@ class ContextTests(unittest.TestCase):
             "admin_processes": 2,
             "public_processes": 6,
             "threads": 1,
+            "wsgi_rotation": True,
         }
         self.assertEqual(expect, ctxt())
 
     @patch.object(context, '_calculate_workers')
     def test_wsgi_worker_config_context_user_and_group(self,
                                                        _calculate_workers):
-        self.config.return_value = 1
+        self.config.side_effect = fake_config({
+            'worker-multiplier': 1, 'wsgi-rotation': False
+        })
         _calculate_workers.return_value = 1
         service_name = 'service-name'
         script = '/usr/bin/script'
@@ -3613,6 +3618,7 @@ class ContextTests(unittest.TestCase):
             "admin_processes": 1,
             "public_processes": 1,
             "threads": 1,
+            "wsgi_rotation": False,
         }
         self.assertEqual(expect, ctxt())
 


### PR DESCRIPTION
The lp bug 1863232 introduced a new configuration option called WSGISocketRotation which allows users to disable wsgi socket rotation on the apache side. This patch will also allow setting this option on the charm side.

Partial-Bug: 2021550