### PR TITLE
[stable/ussuri] Add support for OVN UCA pocket

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -224,6 +224,10 @@ CLOUD_ARCHIVE_POCKETS = {
     'yoga/proposed': 'focal-proposed/yoga',
     'focal-yoga/proposed': 'focal-proposed/yoga',
     'focal-proposed/yoga': 'focal-proposed/yoga',
+
+    # OVN
+    'focal-ovn-22.03': 'focal-updates/ovn-22.03',
+    'focal-ovn-22.03/proposed': 'focal-proposed/ovn-22.03',
 }
 
 
@@ -683,6 +687,7 @@ def add_source(source, key=None, fail_invalid=False):
         (r"^cloud-archive:(.*)$", _add_apt_repository),
         (r"^((?:deb |http:|https:|ppa:).*)$", _add_apt_repository),
         (r"^cloud:(.*)-(.*)\/staging$", _add_cloud_staging),
+        (r"^cloud:(.*)-(ovn-.*)$", _add_cloud_distro_check),
         (r"^cloud:(.*)-(.*)$", _add_cloud_distro_check),
         (r"^cloud:(.*)$", _add_cloud_pocket),
         (r"^snap:.*-(.*)-(.*)$", _add_cloud_distro_check),
@@ -746,6 +751,11 @@ def _add_apt_repository(spec):
                       )
 
 
+def __write_sources_list_d_actual_pocket(file, actual_pocket):
+    with open('/etc/apt/sources.list.d/{}'.format(file), 'w') as apt:
+        apt.write(CLOUD_ARCHIVE.format(actual_pocket))
+
+
 def _add_cloud_pocket(pocket):
     """Add a cloud pocket as /etc/apt/sources.d/cloud-archive.list
 
@@ -765,8 +775,9 @@ def _add_cloud_pocket(pocket):
             'Unsupported cloud: source option %s' %
             pocket)
     actual_pocket = CLOUD_ARCHIVE_POCKETS[pocket]
-    with open('/etc/apt/sources.list.d/cloud-archive.list', 'w') as apt:
-        apt.write(CLOUD_ARCHIVE.format(actual_pocket))
+    __write_sources_list_d_actual_pocket(
+        'cloud-archive{}.list'.format('' if 'ovn' not in pocket else '-ovn'),
+        actual_pocket)
 
 
 def _add_cloud_staging(cloud_archive_release, openstack_release):

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -531,6 +531,8 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
         with patch_open() as (mock_open, mock_file):
             fetch.add_source(source=source)
             mock_file.write.assert_called_with(result)
+            mock_open.assert_called_once_with(
+                '/etc/apt/sources.list.d/cloud-archive.list', 'w')
         filter_pkg.assert_called_with(['ubuntu-cloud-keyring'])
 
     @patch('charmhelpers.fetch.ubuntu.log')
@@ -547,6 +549,8 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
         with patch_open() as (mock_open, mock_file):
             fetch.add_source(source=source)
             mock_file.write.assert_called_with(result)
+            mock_open.assert_called_once_with(
+                '/etc/apt/sources.list.d/cloud-archive.list', 'w')
         filter_pkg.assert_called_with(['ubuntu-cloud-keyring'])
 
     @patch('charmhelpers.fetch.ubuntu.log')
@@ -561,6 +565,8 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
         with patch_open() as (mock_open, mock_file):
             fetch.add_source(source=source)
             mock_file.write.assert_called_with(result)
+            mock_open.assert_called_once_with(
+                '/etc/apt/sources.list.d/cloud-archive.list', 'w')
         filter_pkg.assert_called_with(['ubuntu-cloud-keyring'])
 
     @patch('charmhelpers.fetch.ubuntu.log')
@@ -665,6 +671,34 @@ uid:-::::1232306042::52FE92E6867B4C099AA1A1877A804A965F41A98C::ppa::::::::::0:
                            '&exact=on&search=0x{}').format(PGP_KEY_ID)],
                  env=None),
         ])
+
+    @patch('charmhelpers.fetch.ubuntu.log')
+    @patch.object(fetch, 'filter_installed_packages')
+    @patch.object(fetch, 'apt_install')
+    @patch.object(fetch, 'get_distrib_codename')
+    def test_add_source_cloud_ovn(self, get_distrib_codename, apt_install,
+                                  filter_pkg, log):
+        source = "cloud:focal-ovn-22.03"
+        get_distrib_codename.return_value = 'focal'
+        result = ('# Ubuntu Cloud Archive\n'
+                  'deb http://ubuntu-cloud.archive.canonical.com/ubuntu'
+                  ' focal-updates/ovn-22.03 main\n')
+        with patch_open() as (mock_open, mock_file):
+            fetch.add_source(source=source)
+            mock_file.write.assert_called_with(result)
+            mock_open.assert_called_once_with(
+                '/etc/apt/sources.list.d/cloud-archive-ovn.list', 'w')
+        filter_pkg.assert_called_with(['ubuntu-cloud-keyring'])
+
+        source = "cloud:focal-ovn-22.03/proposed"
+        result = ('# Ubuntu Cloud Archive\n'
+                  'deb http://ubuntu-cloud.archive.canonical.com/ubuntu'
+                  ' focal-proposed/ovn-22.03 main\n')
+        with patch_open() as (mock_open, mock_file):
+            fetch.add_source(source=source)
+            mock_file.write.assert_called_with(result)
+            mock_open.assert_called_once_with(
+                '/etc/apt/sources.list.d/cloud-archive-ovn.list', 'w')
 
     @patch('charmhelpers.fetch.ubuntu.log')
     def test_configure_bad_install_source(self, log):


### PR DESCRIPTION
Backport of #738 to allow `neutron-api-plugin-ovn` to use OVN UCA pockets in focal-ussuri. Rest of the backporting effort:

-  #804 
-  #805 
-  #806 

 Original PR message below:


The OVN UCA pocket will be used as an overlay repository in addition to any regular UCA pocket and the charms are expected to expose configuration of it as a separate source configuration option.

Add pocket names and allow for writing any OVN UCA configuration to a separate sources.list.d file.