### PR TITLE
Validate certificate chain for apache2 ssl

### DIFF
--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -67,10 +67,9 @@ def get_cert(cn=None):
     return (cert, key)
 
 
-def validate_cert(cert, key, ca):
+def validate_cert(cert, ca):
     """
     cert (bytes): PEM armored cert chain
-    key (bytes): private key for leaf cert
     ca (Optional[bytes]): an optional PEM armored root CA chain
 
     returns: None if all ok, otherwise return a string error message

--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -35,6 +35,7 @@ from charmhelpers.core.hookenv import (
     related_units as relation_list,
     log,
     INFO,
+    ERROR,
     status_set,
     WORKLOAD_STATES,
 )
@@ -87,6 +88,8 @@ def validate_cert(cert, key, ca):
     try:
         certs = list(map(lambda x: x[2], pem.unarmor(cert, multiple=True)))
     except Exception as e:
+        log("Failed to read certificates: {}".format(e),
+            level=ERROR)
         status_set(WORKLOAD_STATES.BLOCKED, str(e))
         return False
 
@@ -95,6 +98,8 @@ def validate_cert(cert, key, ca):
     try:
         validator.validate_usage({"digital_signature"}, {"server_auth"})
     except Exception as e:
+        log("Failed to validate certificates: {}".format(e),
+            level=ERROR)
         status_set(WORKLOAD_STATES.BLOCKED, str(e))
         return False
 

--- a/charmhelpers/contrib/hahelpers/apache.py
+++ b/charmhelpers/contrib/hahelpers/apache.py
@@ -79,7 +79,11 @@ def validate_cert(cert, key, ca):
 
     context = None
     if ca:
-        context = ValidationContext(trust_roots=[ca])
+        try:
+            cas = list(map(lambda x: x[2], pem.unarmor(ca, multiple=True)))
+        except Exception as e:
+            return "[processing root ca chain] {}".format(e)
+        context = ValidationContext(extra_trust_roots=cas)
 
     # split certs so we can pass intermediate certs separately to the validator
     try:

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1119,9 +1119,8 @@ class ApacheSSLContext(OSContextGenerator):
         cert, key = get_cert(cn)
         if cert and key:
             cert = b64decode(cert)
-            key = b64decode(key)
             ca = config('ssl_ca')
-            err = validate_cert(cert, key, b64decode(ca) if ca else None)
+            err = validate_cert(cert, b64decode(ca) if ca else None)
             if err:
                 log("failed to validate certs for apache2: {}".format(err),
                     level=WARNING)
@@ -1137,7 +1136,7 @@ class ApacheSSLContext(OSContextGenerator):
                        content=cert, owner=self.user,
                        group=self.group, perms=0o640)
             write_file(path=os.path.join(ssl_dir, key_filename),
-                       content=key, owner=self.user,
+                       content=b64decode(key), owner=self.user,
                        group=self.group, perms=0o640)
 
     def configure_ca(self):

--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1121,9 +1121,10 @@ class ApacheSSLContext(OSContextGenerator):
             cert = b64decode(cert)
             key = b64decode(key)
             ca = config('ssl_ca')
-            ca = b64decode(ca) if ca else None
-            if not validate_cert(cert, key, ca):
-                return
+            err = validate_cert(cert, key, b64decode(ca) if ca else None)
+            if err:
+                log("failed to validate certs for apache2: {}".format(err),
+                    level=WARNING)
 
             if cn:
                 cert_filename = 'cert_{}'.format(cn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Jinja2
 netaddr
 
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
+
+git+https://github.com/wbond/certvalidator@fc82b7975f61fc1b2d1cf7ac77b2e4b2964aedb1#egg=certvalidator

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,6 +22,8 @@ PyYAML
 # https://jinja.palletsprojects.com/en/2.11.x/changelog/
 Jinja2
 
+git+https://github.com/wbond/certvalidator@fc82b7975f61fc1b2d1cf7ac77b2e4b2964aedb1#egg=certvalidator
+
 ##############################################################
 
 netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -131,3 +131,138 @@ class ApacheUtilsTests(TestCase):
                 apache_utils.retrieve_ca_cert('mycertfile'),
                 None)
             self.assertFalse(_open.called)
+
+    def test_validate_cert_valid(self):
+        # cert expires 2122-05-20
+        cert = '''subject=CN = localhost
+issuer=O = Localhost, CN = Localhost Intermediate CA
+-----BEGIN CERTIFICATE-----
+MIICKzCCAdGgAwIBAgIQDu9nmqq7TySlielnl9X2qDAKBggqhkjOPQQDAjA4MRIw
+EAYDVQQKEwlMb2NhbGhvc3QxIjAgBgNVBAMTGUxvY2FsaG9zdCBJbnRlcm1lZGlh
+dGUgQ0EwIBcNMjIwNjIwMDA1MjI4WhgPMjEyMjA1MjcwMDUzMjhaMBQxEjAQBgNV
+BAMTCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDJKOnlpvbrl
+ToLS7sRfC2GNwZcYaGcpPzbIewnz73GBRT6M+m9lDWv+PITtAxp+NLIgH5Yk6vxc
+dYZTBEGkMPKjgd4wgdswDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUF
+BwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQU891hm3lJefB/j9WqEkUkEPdZiuEwHwYD
+VR0jBBgwFoAUsKxbbbDR5TWBI1Cqr4p5z1Uf/lAwFAYDVR0RBA0wC4IJbG9jYWxo
+b3N0MFQGDCsGAQQBgqRkxihAAQREMEICAQEEEHRlc3RAZXhhbXBsZS5jb20EK2RU
+R1QteDVLcnB6UTdTN1ZyMUlaZzFYeHFUbkYtSDZpdzNZajFWaEtScVkwCgYIKoZI
+zj0EAwIDSAAwRQIgHMtwTB0ILYUTuUCnwqZ3RBt5XG9aYiw/r/oXvqacXcgCIQCf
+w77wpNDWWhqJ2llaArJ1UUyszw96mm6imG9ItK09oQ==
+-----END CERTIFICATE-----
+subject=O = Localhost, CN = Localhost Intermediate CA
+issuer=O = Localhost, CN = Localhost Root CA
+-----BEGIN CERTIFICATE-----
+MIIBzTCCAXKgAwIBAgIQcT2oOYh7TNlbbto/RdvZGTAKBggqhkjOPQQDAjAwMRIw
+EAYDVQQKEwlMb2NhbGhvc3QxGjAYBgNVBAMTEUxvY2FsaG9zdCBSb290IENBMB4X
+DTIyMDYxNTIzMzg0N1oXDTMyMDYxMjIzMzg0N1owODESMBAGA1UEChMJTG9jYWxo
+b3N0MSIwIAYDVQQDExlMb2NhbGhvc3QgSW50ZXJtZWRpYXRlIENBMFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEKpD0lYmyDLX+guoi2WQupkRpYydpkT0fihJ9Asqp
+bQ0j8SK6XOgG17wIIynR/PchZPBnTew8poi1TOV6Sf195KNmMGQwDgYDVR0PAQH/
+BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFLCsW22w0eU1gSNQ
+qq+Kec9VH/5QMB8GA1UdIwQYMBaAFL7pE7+4bPZwOYJeDceK/B2Ev4iSMAoGCCqG
+SM49BAMCA0kAMEYCIQC3NxTe3PxTiF0W1L39xrHvPvFCIHkI65ThQWM+upgNIAIh
+AJD2IG2GS7MCxD5EiG4Y3cMcPjye4qud4OduSbnA8UO4
+-----END CERTIFICATE-----
+'''.encode()
+        key = '''
+'''.encode()
+        ca = '''-----BEGIN CERTIFICATE-----
+MIIBpDCCAUqgAwIBAgIRAKgqR8IPdlS4dCQT+578QkwwCgYIKoZIzj0EAwIwMDES
+MBAGA1UEChMJTG9jYWxob3N0MRowGAYDVQQDExFMb2NhbGhvc3QgUm9vdCBDQTAe
+Fw0yMjA2MTUyMzM4NDZaFw0zMjA2MTIyMzM4NDZaMDAxEjAQBgNVBAoTCUxvY2Fs
+aG9zdDEaMBgGA1UEAxMRTG9jYWxob3N0IFJvb3QgQ0EwWTATBgcqhkjOPQIBBggq
+hkjOPQMBBwNCAARoyoMN62AqZ2E3qE8fPYL0sdWDZkkkccGcHwdGD98qCMasFcno
+VYvk7kAwcxAdhGNLq3CIzBJJbUQYJ/782t+Wo0UwQzAOBgNVHQ8BAf8EBAMCAQYw
+EgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUvukTv7hs9nA5gl4Nx4r8HYS/
+iJIwCgYIKoZIzj0EAwIDSAAwRQIgIxrw1XB6VpqCVNsqF/SEdjGbt6ROHxRBeYU6
+au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
+-----END CERTIFICATE-----
+'''.encode()
+        self.assertTrue(apache_utils.validate_cert(cert, key, ca))
+
+    def test_validate_cert_invalid_missing_intermediate(self):
+        # test the case where leaf cert is provided
+        # signed by a private intermediate CA,
+        # but intermediate CA is missing in ssl_cert
+        # cert expires 2122-05-20
+        cert = '''subject=CN = localhost
+issuer=O = Localhost, CN = Localhost Intermediate CA
+-----BEGIN CERTIFICATE-----
+MIICKzCCAdGgAwIBAgIQDu9nmqq7TySlielnl9X2qDAKBggqhkjOPQQDAjA4MRIw
+EAYDVQQKEwlMb2NhbGhvc3QxIjAgBgNVBAMTGUxvY2FsaG9zdCBJbnRlcm1lZGlh
+dGUgQ0EwIBcNMjIwNjIwMDA1MjI4WhgPMjEyMjA1MjcwMDUzMjhaMBQxEjAQBgNV
+BAMTCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDJKOnlpvbrl
+ToLS7sRfC2GNwZcYaGcpPzbIewnz73GBRT6M+m9lDWv+PITtAxp+NLIgH5Yk6vxc
+dYZTBEGkMPKjgd4wgdswDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUF
+BwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQU891hm3lJefB/j9WqEkUkEPdZiuEwHwYD
+VR0jBBgwFoAUsKxbbbDR5TWBI1Cqr4p5z1Uf/lAwFAYDVR0RBA0wC4IJbG9jYWxo
+b3N0MFQGDCsGAQQBgqRkxihAAQREMEICAQEEEHRlc3RAZXhhbXBsZS5jb20EK2RU
+R1QteDVLcnB6UTdTN1ZyMUlaZzFYeHFUbkYtSDZpdzNZajFWaEtScVkwCgYIKoZI
+zj0EAwIDSAAwRQIgHMtwTB0ILYUTuUCnwqZ3RBt5XG9aYiw/r/oXvqacXcgCIQCf
+w77wpNDWWhqJ2llaArJ1UUyszw96mm6imG9ItK09oQ==
+-----END CERTIFICATE-----
+'''.encode()
+        key = '''-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBY4oZdsiyjO/KteXtyThQU1nLfhS0MJYHzQrBzKVvU1oAoGCCqGSM49
+AwEHoUQDQgAExkWwyfOpgiAhoClU2ETkZ+C2Q5FD81f4nk6IDRCZ0JEhXl6b5t1z
+02F0+aA3FZRkmlJBuGv9Oi+vAJ8R2Yh1BQ==
+-----END EC PRIVATE KEY-----
+'''.encode()
+        ca = '''-----BEGIN CERTIFICATE-----
+MIIBpDCCAUqgAwIBAgIRAKgqR8IPdlS4dCQT+578QkwwCgYIKoZIzj0EAwIwMDES
+MBAGA1UEChMJTG9jYWxob3N0MRowGAYDVQQDExFMb2NhbGhvc3QgUm9vdCBDQTAe
+Fw0yMjA2MTUyMzM4NDZaFw0zMjA2MTIyMzM4NDZaMDAxEjAQBgNVBAoTCUxvY2Fs
+aG9zdDEaMBgGA1UEAxMRTG9jYWxob3N0IFJvb3QgQ0EwWTATBgcqhkjOPQIBBggq
+hkjOPQMBBwNCAARoyoMN62AqZ2E3qE8fPYL0sdWDZkkkccGcHwdGD98qCMasFcno
+VYvk7kAwcxAdhGNLq3CIzBJJbUQYJ/782t+Wo0UwQzAOBgNVHQ8BAf8EBAMCAQYw
+EgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUvukTv7hs9nA5gl4Nx4r8HYS/
+iJIwCgYIKoZIzj0EAwIDSAAwRQIgIxrw1XB6VpqCVNsqF/SEdjGbt6ROHxRBeYU6
+au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
+-----END CERTIFICATE-----
+'''.encode()
+        self.assertFalse(apache_utils.validate_cert(cert, key, ca))
+
+    def test_validate_cert_invalid_missing_ca(self):
+        # test the case where leaf cert signed by a private CA,
+        # but the private CA cert is not provided via ssl_ca
+        # cert expires 2122-05-20
+        cert = '''subject=CN = localhost
+issuer=O = Localhost, CN = Localhost Intermediate CA
+-----BEGIN CERTIFICATE-----
+MIICKzCCAdGgAwIBAgIQDu9nmqq7TySlielnl9X2qDAKBggqhkjOPQQDAjA4MRIw
+EAYDVQQKEwlMb2NhbGhvc3QxIjAgBgNVBAMTGUxvY2FsaG9zdCBJbnRlcm1lZGlh
+dGUgQ0EwIBcNMjIwNjIwMDA1MjI4WhgPMjEyMjA1MjcwMDUzMjhaMBQxEjAQBgNV
+BAMTCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDJKOnlpvbrl
+ToLS7sRfC2GNwZcYaGcpPzbIewnz73GBRT6M+m9lDWv+PITtAxp+NLIgH5Yk6vxc
+dYZTBEGkMPKjgd4wgdswDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUF
+BwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQU891hm3lJefB/j9WqEkUkEPdZiuEwHwYD
+VR0jBBgwFoAUsKxbbbDR5TWBI1Cqr4p5z1Uf/lAwFAYDVR0RBA0wC4IJbG9jYWxo
+b3N0MFQGDCsGAQQBgqRkxihAAQREMEICAQEEEHRlc3RAZXhhbXBsZS5jb20EK2RU
+R1QteDVLcnB6UTdTN1ZyMUlaZzFYeHFUbkYtSDZpdzNZajFWaEtScVkwCgYIKoZI
+zj0EAwIDSAAwRQIgHMtwTB0ILYUTuUCnwqZ3RBt5XG9aYiw/r/oXvqacXcgCIQCf
+w77wpNDWWhqJ2llaArJ1UUyszw96mm6imG9ItK09oQ==
+-----END CERTIFICATE-----
+subject=O = Localhost, CN = Localhost Intermediate CA
+issuer=O = Localhost, CN = Localhost Root CA
+-----BEGIN CERTIFICATE-----
+MIIBzTCCAXKgAwIBAgIQcT2oOYh7TNlbbto/RdvZGTAKBggqhkjOPQQDAjAwMRIw
+EAYDVQQKEwlMb2NhbGhvc3QxGjAYBgNVBAMTEUxvY2FsaG9zdCBSb290IENBMB4X
+DTIyMDYxNTIzMzg0N1oXDTMyMDYxMjIzMzg0N1owODESMBAGA1UEChMJTG9jYWxo
+b3N0MSIwIAYDVQQDExlMb2NhbGhvc3QgSW50ZXJtZWRpYXRlIENBMFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEKpD0lYmyDLX+guoi2WQupkRpYydpkT0fihJ9Asqp
+bQ0j8SK6XOgG17wIIynR/PchZPBnTew8poi1TOV6Sf195KNmMGQwDgYDVR0PAQH/
+BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFLCsW22w0eU1gSNQ
+qq+Kec9VH/5QMB8GA1UdIwQYMBaAFL7pE7+4bPZwOYJeDceK/B2Ev4iSMAoGCCqG
+SM49BAMCA0kAMEYCIQC3NxTe3PxTiF0W1L39xrHvPvFCIHkI65ThQWM+upgNIAIh
+AJD2IG2GS7MCxD5EiG4Y3cMcPjye4qud4OduSbnA8UO4
+-----END CERTIFICATE-----
+'''.encode()
+        key = '''-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBY4oZdsiyjO/KteXtyThQU1nLfhS0MJYHzQrBzKVvU1oAoGCCqGSM49
+AwEHoUQDQgAExkWwyfOpgiAhoClU2ETkZ+C2Q5FD81f4nk6IDRCZ0JEhXl6b5t1z
+02F0+aA3FZRkmlJBuGv9Oi+vAJ8R2Yh1BQ==
+-----END EC PRIVATE KEY-----
+'''.encode()
+        ca = None
+        self.assertFalse(apache_utils.validate_cert(cert, key, ca))

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -179,7 +179,7 @@ iJIwCgYIKoZIzj0EAwIDSAAwRQIgIxrw1XB6VpqCVNsqF/SEdjGbt6ROHxRBeYU6
 au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
 -----END CERTIFICATE-----
 '''.encode()
-        self.assertTrue(apache_utils.validate_cert(cert, key, ca))
+        self.assertIsNone(apache_utils.validate_cert(cert, key, ca))
 
     def test_validate_cert_invalid_missing_intermediate(self):
         # test the case where leaf cert is provided
@@ -221,7 +221,8 @@ iJIwCgYIKoZIzj0EAwIDSAAwRQIgIxrw1XB6VpqCVNsqF/SEdjGbt6ROHxRBeYU6
 au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
 -----END CERTIFICATE-----
 '''.encode()
-        self.assertFalse(apache_utils.validate_cert(cert, key, ca))
+        self.assertIn("Unable to build a validation path",
+                      apache_utils.validate_cert(cert, key, ca))
 
     def test_validate_cert_invalid_missing_ca(self):
         # test the case where leaf cert signed by a private CA,
@@ -265,4 +266,5 @@ AwEHoUQDQgAExkWwyfOpgiAhoClU2ETkZ+C2Q5FD81f4nk6IDRCZ0JEhXl6b5t1z
 -----END EC PRIVATE KEY-----
 '''.encode()
         ca = None
-        self.assertFalse(apache_utils.validate_cert(cert, key, ca))
+        self.assertIn("Unable to build a validation path",
+                      apache_utils.validate_cert(cert, key, ca))

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -165,7 +165,12 @@ SM49BAMCA0kAMEYCIQC3NxTe3PxTiF0W1L39xrHvPvFCIHkI65ThQWM+upgNIAIh
 AJD2IG2GS7MCxD5EiG4Y3cMcPjye4qud4OduSbnA8UO4
 -----END CERTIFICATE-----
 '''.encode()
-        key = '''
+        # key currently isn't used, but saving it here for later use
+        _ = '''-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJTQPjqPsCOLEhfS9EuM0uz6iO+jMlJUA65ZB4vyXcjSoAoGCCqGSM49
+AwEHoUQDQgAEMko6eWm9uuVOgtLuxF8LYY3BlxhoZyk/Nsh7CfPvcYFFPoz6b2UN
+a/48hO0DGn40siAfliTq/Fx1hlMEQaQw8g==
+-----END EC PRIVATE KEY-----
 '''.encode()
         ca = '''-----BEGIN CERTIFICATE-----
 MIIBpDCCAUqgAwIBAgIRAKgqR8IPdlS4dCQT+578QkwwCgYIKoZIzj0EAwIwMDES
@@ -179,7 +184,7 @@ iJIwCgYIKoZIzj0EAwIDSAAwRQIgIxrw1XB6VpqCVNsqF/SEdjGbt6ROHxRBeYU6
 au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
 -----END CERTIFICATE-----
 '''.encode()
-        self.assertIsNone(apache_utils.validate_cert(cert, key, ca))
+        self.assertIsNone(apache_utils.validate_cert(cert, ca))
 
     def test_validate_cert_invalid_missing_intermediate(self):
         # test the case where leaf cert is provided
@@ -203,10 +208,11 @@ zj0EAwIDSAAwRQIgHMtwTB0ILYUTuUCnwqZ3RBt5XG9aYiw/r/oXvqacXcgCIQCf
 w77wpNDWWhqJ2llaArJ1UUyszw96mm6imG9ItK09oQ==
 -----END CERTIFICATE-----
 '''.encode()
-        key = '''-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIBY4oZdsiyjO/KteXtyThQU1nLfhS0MJYHzQrBzKVvU1oAoGCCqGSM49
-AwEHoUQDQgAExkWwyfOpgiAhoClU2ETkZ+C2Q5FD81f4nk6IDRCZ0JEhXl6b5t1z
-02F0+aA3FZRkmlJBuGv9Oi+vAJ8R2Yh1BQ==
+        # key currently isn't used, but saving it here for later use
+        _ = '''-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJTQPjqPsCOLEhfS9EuM0uz6iO+jMlJUA65ZB4vyXcjSoAoGCCqGSM49
+AwEHoUQDQgAEMko6eWm9uuVOgtLuxF8LYY3BlxhoZyk/Nsh7CfPvcYFFPoz6b2UN
+a/48hO0DGn40siAfliTq/Fx1hlMEQaQw8g==
 -----END EC PRIVATE KEY-----
 '''.encode()
         ca = '''-----BEGIN CERTIFICATE-----
@@ -222,7 +228,7 @@ au6zf6sCIQCCdEBjpb2IuQibAbQZVd3NaxWnqBxH87ci3Guq7IaPNw==
 -----END CERTIFICATE-----
 '''.encode()
         self.assertIn("Unable to build a validation path",
-                      apache_utils.validate_cert(cert, key, ca))
+                      apache_utils.validate_cert(cert, ca))
 
     def test_validate_cert_invalid_missing_ca(self):
         # test the case where leaf cert signed by a private CA,
@@ -259,12 +265,13 @@ SM49BAMCA0kAMEYCIQC3NxTe3PxTiF0W1L39xrHvPvFCIHkI65ThQWM+upgNIAIh
 AJD2IG2GS7MCxD5EiG4Y3cMcPjye4qud4OduSbnA8UO4
 -----END CERTIFICATE-----
 '''.encode()
-        key = '''-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIBY4oZdsiyjO/KteXtyThQU1nLfhS0MJYHzQrBzKVvU1oAoGCCqGSM49
-AwEHoUQDQgAExkWwyfOpgiAhoClU2ETkZ+C2Q5FD81f4nk6IDRCZ0JEhXl6b5t1z
-02F0+aA3FZRkmlJBuGv9Oi+vAJ8R2Yh1BQ==
+        # key currently isn't used, but saving it here for later use
+        _ = '''-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJTQPjqPsCOLEhfS9EuM0uz6iO+jMlJUA65ZB4vyXcjSoAoGCCqGSM49
+AwEHoUQDQgAEMko6eWm9uuVOgtLuxF8LYY3BlxhoZyk/Nsh7CfPvcYFFPoz6b2UN
+a/48hO0DGn40siAfliTq/Fx1hlMEQaQw8g==
 -----END EC PRIVATE KEY-----
 '''.encode()
         ca = None
         self.assertIn("Unable to build a validation path",
-                      apache_utils.validate_cert(cert, key, ca))
+                      apache_utils.validate_cert(cert, ca))

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -739,6 +739,7 @@ TO_PATCH = [
     'is_ipv6_disabled',
     'get_installed_version',
     'remote_service_name',
+    'validate_cert',
 ]
 
 
@@ -3003,6 +3004,8 @@ class ContextTests(unittest.TestCase):
 
     def test_https_configure_cert(self):
         # Test apache2 properly installs certs and keys to disk
+        self.validate_cert.return_value = True
+        self.config.side_effect = fake_config({'ssl_ca': ''})
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = [b'SSL_CERT', b'SSL_KEY']
         apache = context.ApacheSSLContext()
@@ -3024,6 +3027,8 @@ class ContextTests(unittest.TestCase):
 
     def test_https_configure_cert_deprecated(self):
         # Test apache2 properly installs certs and keys to disk
+        self.validate_cert.return_value = True
+        self.config.side_effect = fake_config({'ssl_ca': ''})
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = ['SSL_CERT', 'SSL_KEY']
         apache = context.ApacheSSLContext()

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -3004,7 +3004,7 @@ class ContextTests(unittest.TestCase):
 
     def test_https_configure_cert(self):
         # Test apache2 properly installs certs and keys to disk
-        self.validate_cert.return_value = True
+        self.validate_cert.return_value = None
         self.config.side_effect = fake_config({'ssl_ca': ''})
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = [b'SSL_CERT', b'SSL_KEY']
@@ -3027,7 +3027,7 @@ class ContextTests(unittest.TestCase):
 
     def test_https_configure_cert_deprecated(self):
         # Test apache2 properly installs certs and keys to disk
-        self.validate_cert.return_value = True
+        self.validate_cert.return_value = None
         self.config.side_effect = fake_config({'ssl_ca': ''})
         self.get_cert.return_value = ('SSL_CERT', 'SSL_KEY')
         self.b64decode.side_effect = ['SSL_CERT', 'SSL_KEY']

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,10 @@ deps = -r{toxinidir}/test-requirements.txt
 basepython = python3.8
 deps = -r{toxinidir}/test-requirements.txt
 
+[testenv:py39]
+basepython = python3.9
+deps = -r{toxinidir}/test-requirements.txt
+
 [testenv:py310]
 basepython = python3.10
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
https://bugs.launchpad.net/charm-helpers/+bug/1978902

Add certificate validation during the process to configure certificates for apache. The certificates are the values provided to the well-known charm config keys (ssl_ca, ssl_cert, ssl_key). This should catch issues with certificates earlier, provide more friendly error messages, and help with debugging certificate issues.

