### PR TITLE
Fix [keystone_authtoken] section in openstack

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken
@@ -12,6 +12,8 @@ signing_dir = {{ signing_dir }}
 {% if service_type -%}
 service_type = {{ service_type }}
 {% endif -%}
+{% if admin_role -%}
 service_token_roles = {{ admin_role }}
 service_token_roles_required = True
+{% endif -%}
 {% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
+++ b/charmhelpers/contrib/openstack/templates/section-keystone-authtoken-mitaka
@@ -22,6 +22,8 @@ signing_dir = {{ signing_dir }}
 {% if use_memcache == true %}
 memcached_servers = {{ memcache_url }}
 {% endif -%}
+{% if admin_role -%}
 service_token_roles = {{ admin_role }}
 service_token_roles_required = True
+{% endif -%}
 {% endif -%}


### PR DESCRIPTION
Only show service_token_roles parameters when admin_role parameter is present. Otherwise they are not needed.