### PR TITLE
openstack: add keystone audit middleware support

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -554,6 +554,9 @@ class IdentityServiceContext(OSContextGenerator):
                             ctxt, keystonemiddleware_os_release)
 
                 if self.context_complete(ctxt):
+
+                    ctxt['audit_middleware'] = config('audit-middleware') or False
+
                     # NOTE(jamespage) this is required for >= icehouse
                     # so a missing value just indicates keystone needs
                     # upgrading
@@ -599,6 +602,7 @@ class IdentityCredentialsContext(IdentityServiceContext):
                 ctxt.update({
                     'service_port': rdata.get('credentials_port'),
                     'service_host': credentials_host,
+                    'service': self.service,
                     'auth_host': auth_host,
                     'auth_port': rdata.get('auth_port'),
                     'admin_tenant_name': rdata.get('credentials_project'),

--- a/charmhelpers/contrib/openstack/templates/section-audit-middleware-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-audit-middleware-notifications
@@ -1,0 +1,8 @@
+{% if audit_middleware and transport_url-%}
+[audit_middleware_notifications]
+driver = {{ oslo_messaging_driver }}
+transport_url = {{ transport_url }}
+{% if send_notifications_to_logs %}
+driver = log
+{% endif %}
+{% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-filter-audit
+++ b/charmhelpers/contrib/openstack/templates/section-filter-audit
@@ -1,0 +1,5 @@
+{% if audit_middleware -%}
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/{{ service }}/api_audit_map.conf
+{% endif %}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -181,6 +181,7 @@ IDENTITY_SERVICE_RELATION_APP_HTTP = {
     'service-user-id': 'svc-user-id',
     'service-user-name': 'svc-user-name',
     'service-type': 'volume',
+    'audit_middleware': False,
 }
 
 IDENTITY_SERVICE_RELATION_UNSET = {
@@ -209,6 +210,7 @@ IDENTITY_CREDENTIALS_RELATION_UNSET = {
     'credentials_username': 'adam',
     'credentials_protocol': 'https',
     'service_type': 'volume',
+    'audit_middleware': False,
 }
 
 
@@ -245,6 +247,7 @@ IDENTITY_SERVICE_RELATION_HTTPS = {
     'service_type': 'volume',
     'auth_protocol': 'https',
     'internal_protocol': 'https',
+    'audit_middleware': False,
 }
 
 IDENTITY_SERVICE_RELATION_VERSIONED = {
@@ -1062,6 +1065,7 @@ class ContextTests(unittest.TestCase):
     def test_identity_service_context_with_data(self, *args):
         '''Test shared-db context with all required data'''
         relation = FakeRelation(relation_data=IDENTITY_SERVICE_RELATION_UNSET)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1082,6 +1086,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'http',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1089,8 +1094,9 @@ class ContextTests(unittest.TestCase):
     def test_identity_credentials_context_with_data(self):
         '''Test identity-credentials context with all required data'''
         relation = FakeRelation(relation_data=IDENTITY_CREDENTIALS_RELATION_UNSET)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
-        identity_credentials = context.IdentityCredentialsContext()
+        identity_credentials = context.IdentityCredentialsContext(service='cinder')
         result = identity_credentials()
         expected = {
             'admin_password': 'foo',
@@ -1100,6 +1106,7 @@ class ContextTests(unittest.TestCase):
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
             'auth_protocol': 'https',
+            'service': 'cinder',
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_type': 'volume',
@@ -1115,6 +1122,7 @@ class ContextTests(unittest.TestCase):
         relation = FakeRelation(
             relation_data=APIIDENTITY_SERVICE_RELATION_UNSET
         )
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         self.relation_ids.return_value = ['neutron-plugin-api:0']
         self.related_units.return_value = ['neutron-api/0']
@@ -1140,6 +1148,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'http',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1149,6 +1158,7 @@ class ContextTests(unittest.TestCase):
     def test_identity_service_context_with_cache(self, *args):
         '''Test shared-db context with signing cache info'''
         relation = FakeRelation(relation_data=IDENTITY_SERVICE_RELATION_UNSET)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         svc = 'cinder'
         identity_service = context.IdentityServiceContext(service=svc,
@@ -1172,6 +1182,7 @@ class ContextTests(unittest.TestCase):
             'internal_protocol': 'http',
             'signing_dir': '/var/cache/cinder',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         self.assertTrue(self.mkdir.called)
         result.pop('keystone_authtoken')
@@ -1182,6 +1193,7 @@ class ContextTests(unittest.TestCase):
     def test_identity_service_context_with_data_http(self, *args):
         '''Test shared-db context with all required data'''
         relation = FakeRelation(relation_data=IDENTITY_SERVICE_RELATION_HTTP)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1203,6 +1215,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'http',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1212,6 +1225,7 @@ class ContextTests(unittest.TestCase):
     def test_identity_service_context_with_data_https(self, *args):
         '''Test shared-db context with all required data'''
         relation = FakeRelation(relation_data=IDENTITY_SERVICE_RELATION_HTTPS)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1233,6 +1247,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'https',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1243,6 +1258,7 @@ class ContextTests(unittest.TestCase):
         '''Test identity-service context for forwards compatibility'''
         relation = FakeRelation(app_data=IDENTITY_SERVICE_RELATION_APP_HTTP,
                                 relation_data=IDENTITY_SERVICE_RELATION_HTTPS)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1269,6 +1285,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '3',
             'public_auth_url': 'http://keystonepublic.local:80/keystone',
             'internal_auth_url': 'http://keystoneinternal.local:80/keystone',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1283,6 +1300,7 @@ class ContextTests(unittest.TestCase):
         app_data = IDENTITY_SERVICE_RELATION_APP_HTTP.copy()
         app_data['service-user-name'] = None
         app_data['service-host'] = None
+        self.config.return_value = None
         relation = FakeRelation(app_data=app_data,
                                 relation_data=IDENTITY_SERVICE_RELATION_HTTPS)
         self.relation_get.side_effect = relation.get
@@ -1311,9 +1329,25 @@ class ContextTests(unittest.TestCase):
             'api_version': '3',
             'public_auth_url': 'http://keystonepublic.local:80/keystone',
             'internal_auth_url': 'http://keystoneinternal.local:80/keystone',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
+
+    @patch.object(context, 'filter_installed_packages', return_value=[])
+    @patch.object(context, 'os_release', return_value='rocky')
+    def test_identity_service_context_audit_middleware(self, *args):
+        '''Test shared-db context with api version supplied from keystone'''
+        relation = FakeRelation(
+            relation_data=IDENTITY_SERVICE_RELATION_VERSIONED)
+        self.relation_get.side_effect = relation.get
+        identity_service = context.IdentityServiceContext()
+        self.config.return_value = True
+        self.assertTrue(identity_service()['audit_middleware'])
+        self.config.return_value = False
+        self.assertFalse(identity_service()['audit_middleware'])
+        self.config.return_value = None
+        self.assertFalse(identity_service()['audit_middleware'])
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1321,6 +1355,7 @@ class ContextTests(unittest.TestCase):
         '''Test shared-db context with api version supplied from keystone'''
         relation = FakeRelation(
             relation_data=IDENTITY_SERVICE_RELATION_VERSIONED)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1345,6 +1380,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'https',
             'api_version': '3',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1355,6 +1391,7 @@ class ContextTests(unittest.TestCase):
         '''Test shared-db context with admin role supplied from keystone'''
         relation = FakeRelation(
             relation_data=IDENTITY_SERVICE_RELATION_ADMIN_ROLE)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1376,6 +1413,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'https',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)
@@ -1384,8 +1422,9 @@ class ContextTests(unittest.TestCase):
         '''Test identity-credentials context with api version supplied from keystone'''
         relation = FakeRelation(
             relation_data=IDENTITY_CREDENTIALS_RELATION_VERSIONED)
+        self.config.return_value = None
         self.relation_get.side_effect = relation.get
-        identity_credentials = context.IdentityCredentialsContext()
+        identity_credentials = context.IdentityCredentialsContext(service='cinder')
         result = identity_credentials()
         expected = {
             'admin_password': 'foo',
@@ -1396,6 +1435,7 @@ class ContextTests(unittest.TestCase):
             'auth_host': 'keystone-host.local',
             'auth_port': '35357',
             'auth_protocol': 'https',
+            'service': 'cinder',
             'service_host': 'keystonehost.local',
             'service_port': '5000',
             'service_protocol': 'https',
@@ -1411,6 +1451,7 @@ class ContextTests(unittest.TestCase):
         '''Test identity-service context with ipv6'''
         relation = FakeRelation(relation_data=IDENTITY_SERVICE_RELATION_HTTP)
         self.relation_get.side_effect = relation.get
+        self.config.return_value = None
         format_ipv6_addr.return_value = '[2001:db8:1::1]'
         identity_service = context.IdentityServiceContext()
         result = identity_service()
@@ -1432,6 +1473,7 @@ class ContextTests(unittest.TestCase):
             'internal_port': '5000',
             'internal_protocol': 'http',
             'api_version': '2.0',
+            'audit_middleware': False,
         }
         result.pop('keystone_authtoken')
         self.assertEquals(result, expected)


### PR DESCRIPTION
This PR is in preparation to fulfil  the audit middleware specification as documented in

 https://specs.openstack.org/openstack/charm-specs/specs/2023.1/backlog/audit-middleware.html

First review for nova-cloud-controller charm

https://review.opendev.org/c/openstack/charm-nova-cloud-controller/+/887213

Once this is merged, we can then do the rest of the charms in [LP#1856555](https://bugs.launchpad.net/charm-keystone/+bug/1856555)