### PR TITLE
[stable/wallaby] Use service_domain in [service_user] section

### DIFF
--- a/charmhelpers/contrib/openstack/templates/section-service-user
+++ b/charmhelpers/contrib/openstack/templates/section-service-user
@@ -3,8 +3,8 @@
 send_service_user_token = true
 auth_type = password
 auth_url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}
-project_domain_id = default
-user_domain_id = default
+project_domain_name = service_domain
+user_domain_name = service_domain
 project_name = {{ admin_tenant_name }}
 username = {{ admin_user }}
 password = {{ admin_password }}


### PR DESCRIPTION
The keystone charm currently creates two service users, one for the service domain (for v3 authentication), and the other for the default domain (for v2 authentication).

This patch updates the [service_user] config to use the service domain.

Closes-Bug: #2026202
(cherry picked from commit 3ed0675a763a32a5ecd89c448a2b7e8e3a9f63b3)