### PR TITLE
[stable/yoga] Add helper for dpdk pmd cpu mask

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -2562,14 +2562,18 @@ class OVSDPDKDeviceContext(OSContextGenerator):
         :rtype: List[int]
         """
         cores = []
-        ranges = cpulist.split(',')
-        for cpu_range in ranges:
-            if "-" in cpu_range:
-                cpu_min_max = cpu_range.split('-')
-                cores += range(int(cpu_min_max[0]),
-                               int(cpu_min_max[1]) + 1)
-            else:
-                cores.append(int(cpu_range))
+        if cpulist and re.match(r"^[0-9,\-^]*$", cpulist):
+            ranges = cpulist.split(',')
+            for cpu_range in ranges:
+                if "-" in cpu_range:
+                    cpu_min_max = cpu_range.split('-')
+                    cores += range(int(cpu_min_max[0]),
+                                   int(cpu_min_max[1]) + 1)
+                elif "^" in cpu_range:
+                    cpu_rm = cpu_range.split('^')
+                    cores.remove(int(cpu_rm[1]))
+                else:
+                    cores.append(int(cpu_range))
         return cores
 
     def _numa_node_cores(self):
@@ -2588,36 +2592,32 @@ class OVSDPDKDeviceContext(OSContextGenerator):
 
     def cpu_mask(self):
         """Get hex formatted CPU mask
-
         The mask is based on using the first config:dpdk-socket-cores
         cores of each NUMA node in the unit.
         :returns: hex formatted CPU mask
         :rtype: str
         """
-        return self.cpu_masks()['dpdk_lcore_mask']
-
-    def cpu_masks(self):
-        """Get hex formatted CPU masks
-
-        The mask is based on using the first config:dpdk-socket-cores
-        cores of each NUMA node in the unit, followed by the
-        next config:pmd-socket-cores
-
-        :returns: Dict of hex formatted CPU masks
-        :rtype: Dict[str, str]
-        """
-        num_lcores = config('dpdk-socket-cores')
-        pmd_cores = config('pmd-socket-cores')
-        lcore_mask = 0
-        pmd_mask = 0
+        num_cores = config('dpdk-socket-cores')
+        mask = 0
         for cores in self._numa_node_cores().values():
-            for core in cores[:num_lcores]:
-                lcore_mask = lcore_mask | 1 << core
-            for core in cores[num_lcores:][:pmd_cores]:
-                pmd_mask = pmd_mask | 1 << core
-        return {
-            'pmd_cpu_mask': format(pmd_mask, '#04x'),
-            'dpdk_lcore_mask': format(lcore_mask, '#04x')}
+            for core in cores[:num_cores]:
+                mask = mask | 1 << core
+        return format(mask, '#04x')
+
+    @classmethod
+    def pmd_cpu_mask(cls):
+        """Get hex formatted pmd CPU mask
+
+        The mask is based on config:pmd-cpu-set.
+        :returns: hex formatted CPU mask
+        :rtype: str
+        """
+        mask = 0
+        cpu_list = cls._parse_cpu_list(config('pmd-cpu-set'))
+        if cpu_list:
+            for core in cpu_list:
+                mask = mask | 1 << core
+        return format(mask, '#x')
 
     def socket_memory(self):
         """Formatted list of socket memory configuration per socket.
@@ -2696,6 +2696,7 @@ class OVSDPDKDeviceContext(OSContextGenerator):
             ctxt['device_whitelist'] = self.device_whitelist()
             ctxt['socket_memory'] = self.socket_memory()
             ctxt['cpu_mask'] = self.cpu_mask()
+            ctxt['pmd_cpu_mask'] = self.pmd_cpu_mask()
         return ctxt
 
 

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -4474,6 +4474,10 @@ class MockPCIDevice(object):
 TEST_CPULIST_1 = "0-3"
 TEST_CPULIST_2 = "0-7,16-23"
 TEST_CPULIST_3 = "0,4,8,12,16,20,24"
+TEST_CPULIST_4 = "0-7,^5,16-23,^20,^22"
+TEST_CPULIST_5 = "0-7,^5,16-23,wrong,$;^20,^22"
+TEST_CPULIST_6 = "wrong:format"
+TEST_CPULIST_7 = "0-7;16-23"
 DPDK_DATA_PORTS = (
     "br-phynet3:fe:16:41:df:23:fe "
     "br-phynet1:fe:16:41:df:23:fd "
@@ -4597,6 +4601,15 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
                           16, 17, 18, 19, 20, 21, 22, 23])
         self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_3),
                          [0, 4, 8, 12, 16, 20, 24])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_4),
+                         [0, 1, 2, 3, 4, 6, 7,
+                          16, 17, 18, 19, 21, 23])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_5),
+                         [])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_6),
+                         [])
+        self.assertEqual(self.target._parse_cpu_list(TEST_CPULIST_7),
+                         [])
 
     def test__numa_node_cores(self):
         self.patch_target('_parse_cpu_list')
@@ -4667,16 +4680,22 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
         }.get(x)
         self.assertEqual(self.target.cpu_mask(), '0x33')
 
-    def test_cpu_masks(self):
-        self.patch_target('_numa_node_cores')
-        self._numa_node_cores.return_value = NUMA_CORES_MULTI
+    def test_pmd_cpu_mask(self):
+        """Test generation of hex pmd CPU masks"""
         self.config.side_effect = lambda x: {
-            'dpdk-socket-cores': 1,
-            'pmd-socket-cores': 2,
+            'pmd-cpu-set': None,
         }.get(x)
-        self.assertEqual(
-            self.target.cpu_masks(),
-            {'dpdk_lcore_mask': '0x11', 'pmd_cpu_mask': '0x66'})
+        self.assertEqual(self.target.pmd_cpu_mask(), '0x0')
+
+        self.config.side_effect = lambda x: {
+            'pmd-cpu-set': TEST_CPULIST_4,
+        }.get(x)
+        self.assertEqual(self.target.pmd_cpu_mask(), '0xaf00df')
+
+        self.config.side_effect = lambda x: {
+            'pmd-cpu-set': TEST_CPULIST_5,
+        }.get(x)
+        self.assertEqual(self.target.pmd_cpu_mask(), '0x0')
 
     def test_context_no_devices(self):
         """Ensure that DPDK is disable when no devices detected"""
@@ -4708,7 +4727,34 @@ class TestOVSDPDKDeviceContext(tests.utils.BaseTestCase):
             'cpu_mask': '0x01',
             'device_whitelist': '-w 0000:00:1c.0 -w 0000:00:1d.0',
             'dpdk_enabled': True,
-            'socket_memory': '1024'
+            'socket_memory': '1024',
+            'pmd_cpu_mask': '0x0'
+        })
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 1,
+            'dpdk-socket-memory': 1024,
+            'enable-dpdk': True,
+            'pmd-cpu-set': TEST_CPULIST_4,
+        }.get(x)
+        self.assertEqual(self.target(), {
+            'cpu_mask': '0x01',
+            'device_whitelist': '-w 0000:00:1c.0 -w 0000:00:1d.0',
+            'dpdk_enabled': True,
+            'socket_memory': '1024',
+            'pmd_cpu_mask': '0xaf00df'
+        })
+        self.config.side_effect = lambda x: {
+            'dpdk-socket-cores': 1,
+            'dpdk-socket-memory': 1024,
+            'enable-dpdk': True,
+            'pmd-cpu-set': TEST_CPULIST_5,
+        }.get(x)
+        self.assertEqual(self.target(), {
+            'cpu_mask': '0x01',
+            'device_whitelist': '-w 0000:00:1c.0 -w 0000:00:1d.0',
+            'dpdk_enabled': True,
+            'socket_memory': '1024',
+            'pmd_cpu_mask': '0x0'
         })
 
 


### PR DESCRIPTION
Add helper to convert a cpu set in list format into a hex formatted cpu mask for pmd-cpu-mask and added associated unit test.

Remove previous implementation: 3b7a86420629cc45ced7f78fa3706d99f514448e

Add support for caret operator in _parse_cpu_list(cpulist) and updated associated unit test.

(cherry picked from commit 033d2503de24e0f97c7590f274927fa4a2af65d4)