### PR TITLE
Add function for retrieving subordinate services (#643)

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -2604,6 +2604,23 @@ def get_subordinate_release_packages(os_release, package_type='deb'):
     return SubordinatePackages(install, purge)
 
 
+def get_subordinate_services():
+    """Iterate over subordinate relations and get service information.
+
+    In a similar fashion as with get_subordinate_release_packages(),
+    principle charms can retrieve a list of services advertised by their
+    subordinate charms. This is useful to know about subordinate services when
+    pausing, resuming or upgrading a principle unit.
+
+    :returns: Name of all services advertised by all subordinates
+    :rtype: Set[str]
+    """
+    services = set()
+    for rdata in container_scoped_relation_get('services'):
+        services |= set(json.loads(rdata or '[]'))
+    return services
+
+
 os_restart_on_change = partial(
     pausable_restart_on_change,
     can_restart_now_f=deferred_events.check_and_record_restart_request,

--- a/charmhelpers/fetch/snap.py
+++ b/charmhelpers/fetch/snap.py
@@ -52,7 +52,7 @@ def _snap_exec(commands):
     :param commands: List commands
     :return: Integer exit code
     """
-    assert type(commands) == list
+    assert isinstance(commands, list)
 
     retry_count = 0
     return_code = None


### PR DESCRIPTION
https://bugs.launchpad.net/charm-ceilometer-agent/+bug/1927277 (cherry picked from commit 5ed3500dc9797523c77aa57fa18ba81d091878f4)