### PR TITLE
pep8: Use isinstance()

### DIFF
--- a/charmhelpers/fetch/snap.py
+++ b/charmhelpers/fetch/snap.py
@@ -52,7 +52,7 @@ def _snap_exec(commands):
     :param commands: List commands
     :return: Integer exit code
     """
-    assert type(commands) == list
+    assert isinstance(commands, list)
 
     retry_count = 0
     return_code = None


### PR DESCRIPTION
Rule E721 requires the use of isinstance() instead of "type() == SomeType".

https://www.flake8rules.com/rules/E721.html