### PR TITLE
Remove f-strings, fix pep8 error, and py311 to matrix

### DIFF
--- a/charmhelpers/core/unitdata.py
+++ b/charmhelpers/core/unitdata.py
@@ -529,7 +529,8 @@ def kv():
 
     env_var = os.environ.get("CHARM_HELPERS_TESTMODE", "auto").lower()
     if env_var not in ["auto", "no", "yes"]:
-        logging.warning(f"Unknown value for CHARM_HELPERS_TESTMODE '{env_var}', assuming 'no'")
+        logging.warning("Unknown value for CHARM_HELPERS_TESTMODE '%s'"
+                        ", assuming 'no'", env_var)
         env_var = "no"
 
     if env_var == "no":

--- a/charmhelpers/fetch/snap.py
+++ b/charmhelpers/fetch/snap.py
@@ -52,7 +52,7 @@ def _snap_exec(commands):
     :param commands: List commands
     :return: Integer exit code
     """
-    assert type(commands) == list
+    assert isinstance(commands, list)
 
     retry_count = 0
     return_code = None

--- a/tests/core/kvstore_testmode/test_kwstore_testmode.py
+++ b/tests/core/kvstore_testmode/test_kwstore_testmode.py
@@ -49,11 +49,13 @@ class ConcurrencyBase(unittest.TestCase):
         try:
             outs, errs = self.locking_proc.communicate(b"done\n", timeout=3)
             if self.locking_proc.returncode != 0:
-                print(f"Subprocess failed\nstdout={outs}\nstderr={errs}")
+                print("Subprocess failed\nstdout={outs}\nstderr={errs}"
+                      .format(outs=outs, errs=errs))
         except subprocess.TimeoutExpired:
             self.locking_proc.kill()
             outs, errs = self.locking_proc.communicate()
-            print(f"Had to kill subprocess\nstdout={outs}\nstderr={errs}")
+            print("Had to kill subprocess\nstdout={outs}\nstderr={errs}"
+                  .format(outs=outs, errs=errs))
         self.assertEqual(self.locking_proc.returncode, 0)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,11 @@ basepython = python3.10
 deps = -r{toxinidir}/test-requirements.txt
 commands = nose2 {posargs} --with-coverage -s tests/
 
+[testenv:py311]
+basepython = python3.11
+deps = -r{toxinidir}/test-requirements.txt
+commands = nose2 {posargs} --with-coverage -s tests/
+
 [testenv:pep8]
 basepython = python3
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
- Remove the f-strings; this caused problems with py3.5 which the
  library sort-of still supports.
- Fix the newest pep8 error.
- Add py311 testing the tox; not quite ready for github in this PR.
