### PR TITLE
Add name parameter to send_application_name

### DIFF
--- a/charmhelpers/contrib/storage/linux/ceph.py
+++ b/charmhelpers/contrib/storage/linux/ceph.py
@@ -158,15 +158,19 @@ def get_osd_settings(relation_name):
     return _order_dict_by_key(osd_settings)
 
 
-def send_application_name(relid=None):
+def send_application_name(relid=None, app_name=None):
     """Send the application name down the relation.
 
     :param relid: Relation id to set application name in.
     :type relid: str
+    :param app_name: Application name to send in the relation.
+    :type app_name: str
     """
+    if app_name is None:
+        app_name = application_name()
     relation_set(
         relation_id=relid,
-        relation_settings={'application-name': application_name()})
+        relation_settings={'application-name': app_name})
 
 
 def send_osd_settings():

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -293,6 +293,11 @@ class CephUtilsTests(TestCase):
         self.relation_set.assert_called_once_with(
             relation_settings={'application-name': 'client'},
             relation_id='rid:1')
+        self.relation_set.reset_mock()
+        ceph_utils.send_application_name(relid='rid:1', app_name='foo')
+        self.relation_set.assert_called_once_with(
+            relation_settings={'application-name': 'foo'},
+            relation_id='rid:1')
 
     @patch.object(ceph_utils, 'get_osd_settings')
     def test_send_osd_settings(self, _get_osd_settings):


### PR DESCRIPTION
This way, multiple nova-compute applications can
share the same ceph key, as nova can invoke
send_application_name('nova-compute').