### PR TITLE
[stable/yoga] Fix pep8 error in assert type comparison

### DIFF
--- a/charmhelpers/fetch/snap.py
+++ b/charmhelpers/fetch/snap.py
@@ -52,7 +52,7 @@ def _snap_exec(commands):
     :param commands: List commands
     :return: Integer exit code
     """
-    assert type(commands) == list
+    assert type(commands) is list
 
     retry_count = 0
     return_code = None


### PR DESCRIPTION
charmhelpers/fetch/snap.py:55:12: E721 do not compare types, for exact checks use `is` / `is not`,
for instance checks use `isinstance()`

(cherry picked from commit 5b0a3e6aa3e3141d70120aad7dd2c321595d7225)
(cherry picked from commit 452988fad4a5833d6946fd92906c57bee0b37fe7)