### PR TITLE
Drop @cached decorator from openstack_release()

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -585,7 +585,6 @@ def get_installed_os_version():
     return openstack_release().get('OPENSTACK_CODENAME')
 
 
-@cached
 def openstack_release():
     """Return /etc/os-release in a dict."""
     d = {}


### PR DESCRIPTION
The openstack_release() function is typically called (indirectly) by os_release() which already does caching. The caching of openstack_release() was preventing updates to the value during upgrading to a new release of openstack.

Closes-Bug: #2037751