### PR TITLE
Set service_user_id from keystone relation

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -525,6 +525,7 @@ class IdentityServiceContext(OSContextGenerator):
                 if float(api_version) > 2:
                     ctxt.update({
                         'admin_domain_name': _resolve('service_domain'),
+                        'service_user_id': _resolve('service_user_id'),
                         'service_project_id': _resolve('service_tenant_id'),
                         'service_domain_id': _resolve('service_domain_id')})
 
@@ -557,6 +558,7 @@ class IdentityServiceContext(OSContextGenerator):
                     # NOTE(jamespage) this is required for >= icehouse
                     # so a missing value just indicates keystone needs
                     # upgrading
+                    ctxt['admin_user_id'] = _resolve('service_user_id')
                     ctxt['admin_tenant_id'] = _resolve('service_tenant_id')
                     ctxt['admin_domain_id'] = _resolve('service_domain_id')
                     return ctxt


### PR DESCRIPTION
This is necessary so we can avoid ambiguities (by using the id vs name) when me want to use the service user.