### PR TITLE
Improve detection of debian systems

### DIFF
--- a/charmhelpers/osplatform.py
+++ b/charmhelpers/osplatform.py
@@ -21,7 +21,7 @@ def get_platform():
         return "ubuntu"
     elif "CentOS" in current_platform:
         return "centos"
-    elif "debian" in current_platform:
+    elif "debian" in current_platform.lower():
         # Stock Python does not detect Ubuntu and instead returns debian.
         # Or at least it does in some build environments like Travis CI
         return "ubuntu"


### PR DESCRIPTION
It appears, from reading osplatform.py, that Debian should be supported,
however, it's been observed in python3.11 on debian bookworm,
that it raises an error about no debian support (in a zuul test run):

```
debian-bookworm |   File "/home/zuul/src/opendev.org/openstack/charm-ceph-iscsi/.tox/py311/lib/python3.11/site-packages/charmhelpers/osplatform.py", line 35, in get_platform
debian-bookworm |     raise RuntimeError("This module is not supported on {}."
debian-bookworm | RuntimeError: This module is not supported on Debian GNU/Linux.
```

Improve detection by comparing in a case insensitive manner.

Fixes bug https://bugs.launchpad.net/charm-helpers/+bug/2040958