### PR TITLE
Drop use of get_os_version_codename_swift [yoga backport]

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -410,17 +410,6 @@ def get_os_version_codename(codename, version_map=OPENSTACK_CODENAMES):
     error_out(e)
 
 
-def get_os_version_codename_swift(codename):
-    '''Determine OpenStack version number of swift from codename.'''
-    # for k, v in six.iteritems(SWIFT_CODENAMES):
-    for k, v in SWIFT_CODENAMES.items():
-        if k == codename:
-            return v[-1]
-    e = 'Could not derive swift version for '\
-        'codename: %s' % codename
-    error_out(e)
-
-
 def get_swift_codename(version):
     '''Determine OpenStack codename that corresponds to swift version.'''
     codenames = [k for k, v in SWIFT_CODENAMES.items() if version in v]
@@ -841,14 +830,10 @@ def openstack_upgrade_available(package):
     if not cur_vers:
         # The package has not been installed yet do not attempt upgrade
         return False
-    if "swift" in package:
-        codename = get_os_codename_install_source(src)
-        avail_vers = get_os_version_codename_swift(codename)
-    else:
-        try:
-            avail_vers = get_os_version_install_source(src)
-        except Exception:
-            avail_vers = cur_vers
+    try:
+        avail_vers = get_os_version_install_source(src)
+    except Exception:
+        avail_vers = cur_vers
     apt.init()
     return apt.version_compare(avail_vers, cur_vers) >= 1
 

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -280,20 +280,8 @@ class OpenStackHelpersTestCase(TestCase):
         expected_err = 'Could not derive OpenStack version for codename: foo'
         mocked_error.assert_called_with(expected_err)
 
-    def test_os_version_swift_from_codename(self):
-        """Test mapping a swift codename to numerical version"""
-        self.assertEquals(openstack.get_os_version_codename_swift('liberty'),
-                          '2.5.0')
-
     def test_get_swift_codename_single_version_kilo(self):
         self.assertEquals(openstack.get_swift_codename('2.2.2'), 'kilo')
-
-    @patch('charmhelpers.contrib.openstack.utils.error_out')
-    def test_os_version_swift_from_bad_codename(self, mocked_error):
-        """Test mapping a bad swift codename to numerical version"""
-        openstack.get_os_version_codename_swift('foo')
-        expected_err = 'Could not derive swift version for codename: foo'
-        mocked_error.assert_called_with(expected_err)
 
     def test_get_swift_codename_multiple_versions_liberty(self):
         with patch('subprocess.check_output') as _subp:
@@ -730,10 +718,8 @@ class OpenStackHelpersTestCase(TestCase):
 
     @patch.object(openstack, 'lsb_release')
     @patch.object(openstack, 'get_os_version_package')
-    @patch.object(openstack, 'get_os_version_codename_swift')
     @patch.object(openstack, 'config')
-    def test_openstack_upgrade_detection_true(self, config, vers_swift,
-                                              vers_pkg, lsb):
+    def test_openstack_upgrade_detection_true(self, config, vers_pkg, lsb):
         """Test it detects when an openstack package has available upgrade"""
         lsb.return_value = FAKE_RELEASE
         config.return_value = 'cloud:precise-havana'
@@ -743,10 +729,8 @@ class OpenStackHelpersTestCase(TestCase):
         vers_pkg.return_value = '2013.2~b1'
         self.assertTrue(openstack.openstack_upgrade_available('nova-common'))
         vers_pkg.return_value = '1.9.0'
-        vers_swift.return_value = '2.5.0'
         self.assertTrue(openstack.openstack_upgrade_available('swift-proxy'))
         vers_pkg.return_value = '2.5.0'
-        vers_swift.return_value = '2.10.0'
         self.assertTrue(openstack.openstack_upgrade_available('swift-proxy'))
 
     @patch.object(openstack, 'lsb_release')
@@ -762,8 +746,8 @@ class OpenStackHelpersTestCase(TestCase):
         vers_pkg.return_value = '2013.1~b1'
         self.assertFalse(openstack.openstack_upgrade_available('nova-common'))
         # ugly duckling testing
-        config.return_value = 'cloud:precise-havana'
-        vers_pkg.return_value = '1.10.0'
+        config.return_value = 'cloud:focal-wallaby'
+        vers_pkg.return_value = '2021.1'
         self.assertFalse(openstack.openstack_upgrade_available('swift-proxy'))
 
     @patch.object(openstack, 'is_block_device')


### PR DESCRIPTION
Swift payload upgrades to wallaby or later currently fail because this code is unable to determine the version for wallaby+. For example:

FATAL ERROR: Could not derive swift version for codename: wallaby

We stopped maintaining the SWIFT_CODENAMES and PACKAGE_CODENAMES as of wallaby because the openstack-release package was introduced in wallaby.

We could update the SWIFT_CODENAMES map, but really this map no longer needs to be used. There was a time when the same swift package version existed in two different OpenStack releases, but that is no longer the case [1]. Therefore we can use the same comparison used for OpenStack packages which essentially checks current release (based on the openstack-release package) vs the installation source release.

[1] Current swift versions in Ubuntu are:
2.32.0 bobcat
2.31.1 antelope
2.30.1 zed
2.29.2 yoga
2.28.1 xena
2.27.0 wallaby
2.26.0 victoria
2.25.2 ussuri

Closes-Bug: #2040606
(cherry picked from commit b604d56223772c36f934c199abb849d5d020fdc8)