### PR TITLE
Fix the spelling error in UBUNTU_OPENSTACK_RELEASE noble

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -317,7 +317,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
     ('kinetic', 'zed'),
     ('lunar', 'antelope'),
     ('mantic', 'bobcat'),
-    ('noble', 'caracal'),
+    ('nobel', 'caracal'),
 ])
 
 


### PR DESCRIPTION
Where noble shoule be nobel.
