### PR TITLE
Use looseversion in place of distutils

### DIFF
--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -18,7 +18,10 @@
 #  Charm Helpers Developers <juju@lists.ubuntu.com>
 
 import copy
-from distutils.version import LooseVersion
+try:
+    from distutils.version import LooseVersion
+except ImportError:
+    from looseversion import LooseVersion
 from enum import Enum
 from functools import wraps
 from collections import namedtuple, UserDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Jinja2
 netaddr
 
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
+
+looseversion;python_version >= '3.12'


### PR DESCRIPTION
Fixes https://github.com/juju/charm-helpers/issues/701:

```
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/test_content_cache.py:25: in <module>
    from reactive import content_cache  # NOQA: E402
reactive/content_cache.py:13: in <module>
    from charms import reactive
.tox/unit/lib/python3.12/site-packages/charms/reactive/__init__.py:20: in <module>
    from .flags import *  # noqa
.tox/unit/lib/python3.12/site-packages/charms/reactive/flags.py:2: in <module>
    from charmhelpers.core import hookenv
.tox/unit/lib/python3.12/site-packages/charmhelpers/core/hookenv.py:21: in <module>
    from distutils.version import LooseVersion
E   ModuleNotFoundError: No module named 'distutils'
```