### PR TITLE
Issue#743: fetch.ubuntu._run_with_retries raises on unexpected exitco…

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -945,10 +945,14 @@ def _run_with_retries(cmd, max_retries=CMD_RETRY_COUNT, retry_exitcodes=(1,),
         try:
             result = subprocess.check_call(cmd, env=env, **kwargs)
         except subprocess.CalledProcessError as e:
-            retry_count = retry_count + 1
-            if retry_count > max_retries:
-                raise
             result = e.returncode
+            if result not in retry_results:
+                # a non-retriable exitcode was produced
+                raise
+            retry_count += 1
+            if retry_count > max_retries:
+                # a retriable exitcode was produced more than {max_retries} times
+                raise
             log(retry_message)
             time.sleep(CMD_RETRY_DELAY)
 

--- a/tests/contrib/openstack/test_deferred_events.py
+++ b/tests/contrib/openstack/test_deferred_events.py
@@ -304,10 +304,13 @@ class DeferredCharmServiceEventsTestCase(tests.utils.BaseTestCase):
     def test_check_restart_timestamps(self, get_service_start_time, log,
                                       clear_deferred_restarts,
                                       get_deferred_restarts):
+        request_time = '2021-02-02 10:19:55'
+        timestamp = datetime.datetime.strptime(
+            'Tue ' + request_time + ' UTC',
+            '%a %Y-%m-%d %H:%M:%S %Z').timestamp()
         deferred_restarts = [
-            # 'Tue 2021-02-02 10:19:55 UTC'
             deferred_events.ServiceEvent(
-                timestamp=1612261195.0,
+                timestamp=timestamp,
                 service='svcA',
                 reason='ReasonA',
                 action='restart')]
@@ -326,8 +329,7 @@ class DeferredCharmServiceEventsTestCase(tests.utils.BaseTestCase):
         self.assertFalse(clear_deferred_restarts.called)
         log.assert_called_once_with(
             ('Restart still required, svcA was started at 2021-02-02 10:10:55,'
-             ' restart was requested after that at {}'.format(
-                 datetime.datetime.fromtimestamp(1612261195.0))),
+             ' restart was requested after that at {}'.format(request_time)),
             level='DEBUG')
 
     def test_set_deferred_hook(self):


### PR DESCRIPTION
…de (#744)

* Issue#743: fetch.ubuntu._run_with_retries raises on unexpected exitcode

* Address `test_check_restart_timestamps` issues in py3.10

* apply appropriate mocks during test_service unit tests

(cherry picked from commit 0f7ca5396edd6a932aada59385b90bd95739b30c)