### PR TITLE
[stable/yoga] Add support for keystone audit middleware

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -198,6 +198,21 @@ class OSContextGenerator(object):
             return self.related
 
 
+class KeystoneAuditMiddleware(OSContextGenerator):
+    def __init__(self, service: str) -> None:
+        self.service_name = service
+
+    def __call__(self):
+        """Return context dictionary containing configuration status of
+        audit-middleware and the charm service name.
+        """
+        ctxt = {
+            'audit_middleware': config('audit-middleware') or False,
+            'service_name': self.service_name
+        }
+        return ctxt
+
+
 class SharedDBContext(OSContextGenerator):
     interfaces = ['shared-db']
 

--- a/charmhelpers/contrib/openstack/templates/section-audit-middleware-notifications
+++ b/charmhelpers/contrib/openstack/templates/section-audit-middleware-notifications
@@ -1,0 +1,4 @@
+{% if audit_middleware -%}
+[audit_middleware_notifications]
+driver = log
+{% endif -%}

--- a/charmhelpers/contrib/openstack/templates/section-filter-audit
+++ b/charmhelpers/contrib/openstack/templates/section-filter-audit
@@ -1,0 +1,6 @@
+{% if audit_middleware and service_name -%}
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/{{ service_name }}/api_audit_map.conf
+service_name = {{ service_name }}
+{% endif -%}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -784,6 +784,30 @@ class ContextTests(unittest.TestCase):
         }
         self.assertEquals(result, expected)
 
+    @patch.object(context, 'config')
+    def test_keystone_audit_middleware_ctxt_enabled(self, mock_config):
+        '''Test KeystoneAuditMiddleware ctxt contents when enabled'''
+        mock_config.return_value = True
+        audit_middleware = context.KeystoneAuditMiddleware(service='cinder')
+        ctxt = audit_middleware()
+        expected_ctxt = {
+            'audit_middleware': True,
+            'service_name': 'cinder'
+        }
+        self.assertEqual(ctxt, expected_ctxt)
+
+    @patch.object(context, 'config')
+    def test_keystone_audit_middleware_ctxt_disabled(self, mock_config):
+        '''Test KeystoneAuditMiddleware ctxt contents when disabled'''
+        mock_config.return_value = False
+        audit_middleware = context.KeystoneAuditMiddleware(service='cinder')
+        ctxt = audit_middleware()
+        expected_ctxt = {
+            'audit_middleware': False,
+            'service_name': 'cinder'
+        }
+        self.assertEqual(ctxt, expected_ctxt)
+
     def test_shared_db_context_with_data_and_access_net_mismatch(self):
         """Mismatch between hostname and hostname for access net - defers
         execution"""


### PR DESCRIPTION
Created a context for enabling keystone audit middleware as per https://bugs.launchpad.net/charm-helpers/+bug/1856555 along with two unit tests.

(cherry picked from commit 12afd333aab69461186fe43316f200ca8b167e89)