### PR TITLE
Allow custom shell when creating system users

### DIFF
--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -357,7 +357,7 @@ def init_is_systemd(service_name=None):
     return os.path.isdir(SYSTEMD_SYSTEM)
 
 
-def adduser(username, password=None, shell='/bin/bash',
+def adduser(username, password=None, shell=None,
             system_user=False, primary_group=None,
             secondary_groups=None, uid=None, home_dir=None):
     """Add a user to the system.
@@ -389,13 +389,14 @@ def adduser(username, password=None, shell='/bin/bash',
         if home_dir:
             cmd.extend(['--home', str(home_dir)])
         if system_user or password is None:
-            cmd.append('--system')
-            if shell != adduser.__defaults__[1]:
-                cmd.extend(['--shell', shell])
+            cmd.extend([
+                '--system',
+                '--shell', shell if shell else '/usr/sbin/nologin'
+            ])
         else:
             cmd.extend([
                 '--create-home',
-                '--shell', shell,
+                '--shell', shell if shell else '/bin/bash',
                 '--password', password,
             ])
         if not primary_group:

--- a/charmhelpers/core/host.py
+++ b/charmhelpers/core/host.py
@@ -390,6 +390,8 @@ def adduser(username, password=None, shell='/bin/bash',
             cmd.extend(['--home', str(home_dir)])
         if system_user or password is None:
             cmd.append('--system')
+            if shell != adduser.__defaults__[1]:
+                cmd.extend(['--shell', shell])
         else:
             cmd.extend([
                 '--create-home',

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -794,6 +794,28 @@ class HelpersTest(TestCase):
         getpwnam.assert_called_with(username)
 
     @patch('pwd.getpwnam')
+    @patch('subprocess.check_call')
+    @patch.object(host, 'log')
+    def test_adds_a_systemuser_with_different_shell(self, log, check_call, getpwnam):
+        username = 'johndoe'
+        shell = '/usr/sbin/nologin'
+        existing_user_pwnam = KeyError('user not found')
+        new_user_pwnam = 'some user pwnam'
+
+        getpwnam.side_effect = [existing_user_pwnam, new_user_pwnam]
+
+        result = host.adduser(username, system_user=True, shell=shell)
+
+        self.assertEqual(result, new_user_pwnam)
+        check_call.assert_called_with([
+            'useradd',
+            '--system',
+            '--shell', shell,
+            username
+        ])
+        getpwnam.assert_called_with(username)
+
+    @patch('pwd.getpwnam')
     @patch('pwd.getpwuid')
     @patch('grp.getgrnam')
     @patch('subprocess.check_call')

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -755,6 +755,7 @@ class HelpersTest(TestCase):
     @patch.object(host, 'log')
     def test_adds_a_systemuser(self, log, check_call, getpwnam):
         username = 'johndoe'
+        shell = '/usr/sbin/nologin'
         existing_user_pwnam = KeyError('user not found')
         new_user_pwnam = 'some user pwnam'
 
@@ -766,6 +767,7 @@ class HelpersTest(TestCase):
         check_call.assert_called_with([
             'useradd',
             '--system',
+            '--shell', shell,
             username
         ])
         getpwnam.assert_called_with(username)
@@ -775,6 +777,7 @@ class HelpersTest(TestCase):
     @patch.object(host, 'log')
     def test_adds_a_systemuser_with_home_dir(self, log, check_call, getpwnam):
         username = 'johndoe'
+        shell = '/usr/sbin/nologin'
         existing_user_pwnam = KeyError('user not found')
         new_user_pwnam = 'some user pwnam'
 
@@ -789,6 +792,7 @@ class HelpersTest(TestCase):
             '--home',
             '/var/lib/johndoe',
             '--system',
+            '--shell', shell,
             username
         ])
         getpwnam.assert_called_with(username)
@@ -798,7 +802,7 @@ class HelpersTest(TestCase):
     @patch.object(host, 'log')
     def test_adds_a_systemuser_with_different_shell(self, log, check_call, getpwnam):
         username = 'johndoe'
-        shell = '/usr/sbin/nologin'
+        shell = '/bin/bash'
         existing_user_pwnam = KeyError('user not found')
         new_user_pwnam = 'some user pwnam'
 
@@ -823,6 +827,7 @@ class HelpersTest(TestCase):
     def test_add_user_uid(self, log, check_call, getgrnam, getpwuid, getpwnam):
         user_name = 'james'
         user_id = 1111
+        shell = '/usr/sbin/nologin'
         uid_key_error = KeyError('user not found')
         getpwuid.side_effect = uid_key_error
         host.adduser(user_name, uid=user_id)
@@ -832,6 +837,7 @@ class HelpersTest(TestCase):
             '--uid',
             str(user_id),
             '--system',
+            '--shell', shell,
             '-g',
             user_name,
             user_name


### PR DESCRIPTION
Allow setting the shell when creating system users using adduser()
Changed defaults to `/usr/sbin/nologin` for system users kept `/bin/bash` as default shell for normal users.