### PR TITLE
Fail and retry on "Some index files failed to download"

### DIFF
--- a/charmhelpers/fetch/ubuntu.py
+++ b/charmhelpers/fetch/ubuntu.py
@@ -321,7 +321,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
 ])
 
 
-APT_NO_LOCK = 100  # The return code for "couldn't acquire lock" in APT.
+APT_ERROR_CODE = 100  # The return code for APT errors.
 CMD_RETRY_DELAY = 10  # Wait 10 seconds between command retries.
 CMD_RETRY_COUNT = 10  # Retry a failing fatal command X times.
 
@@ -444,6 +444,8 @@ def apt_upgrade(options=None, fatal=False, dist=False):
 def apt_update(fatal=False):
     """Update local apt cache."""
     cmd = ['apt-get', 'update']
+    if fatal:
+        cmd.append("--error-on=any")
     _run_apt_command(cmd, fatal)
 
 
@@ -1001,8 +1003,7 @@ def _run_apt_command(cmd, fatal=False, quiet=False):
     """
     if fatal:
         _run_with_retries(
-            cmd, retry_exitcodes=(1, APT_NO_LOCK,),
-            retry_message="Couldn't acquire DPKG lock",
+            cmd, retry_exitcodes=(1, APT_ERROR_CODE,),
             quiet=quiet)
     else:
         kwargs = {}

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -1073,7 +1073,7 @@ class AptTests(TestCase):
     def test_apt_update_fatal(self, check_call):
         fetch.apt_update(fatal=True)
         check_call.assert_called_with(
-            ['apt-get', 'update'],
+            ['apt-get', 'update', '--error-on=any'],
             env={})
 
     @patch('subprocess.call')


### PR DESCRIPTION
APT doesn't error out even in the following case since it's a warning instead of an error. And it allows charms to move on without having a proper APT index and let them install unwanted versions of software for example. The apt_update part should fail if it's marked as fatal in such cases so that it can be retried or charm can raise it as an error to users appropriately.

"--error-on=any" is supported for >= bionic.
https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1693900

Closes: #910

[w/o "--error-on=any"]
```
$ sudo apt-get update; echo $?

...

Err:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
  Could not connect to squid-deb-proxy.lxd:8000 (10.0.8.2).
    - connect (113: No route to host)
Err:1 http://archive.ubuntu.com/ubuntu jammy InRelease
  Could not connect to squid-deb-proxy.lxd:8000 (10.0.8.2).
    - connect (113: No route to host)
Err:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
  Unable to connect to squid-deb-proxy.lxd:8000:
Err:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
  Unable to connect to squid-deb-proxy.lxd:8000:
Reading package lists... Done
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
  Could not connect to squid-deb-proxy.lxd:8000 (10.0.8.2).
    - connect (113: No route to host)
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease
  Unable to connect to squid-deb-proxy.lxd:8000:

...

W: Some index files failed to download. They have been ignored, or old ones used instead.
```
-> 0

[w/ "--error-on=any"]
```
$ sudo apt-get --error-on=any update; echo $?

...

E: Some index files failed to download. They have been ignored, or old ones used instead.
```
-> 100