### PR TITLE
Drop use of SWIFT_CODENAMES when determining currently installed Swift version

### DIFF
--- a/charmhelpers/contrib/openstack/utils.py
+++ b/charmhelpers/contrib/openstack/utils.py
@@ -545,16 +545,10 @@ def get_os_version_package(pkg, fatal=True):
     if not codename:
         return None
 
-    if 'swift' in pkg:
-        vers_map = SWIFT_CODENAMES
-        for cname, version in vers_map.items():
-            if cname == codename:
-                return version[-1]
-    else:
-        vers_map = OPENSTACK_CODENAMES
-        for version, cname in vers_map.items():
-            if cname == codename:
-                return version
+    vers_map = OPENSTACK_CODENAMES
+    for version, cname in vers_map.items():
+        if cname == codename:
+            return version
 
 
 def get_installed_os_version():


### PR DESCRIPTION
Since the SWIFT_CODENAMES and PACKAGE_CODENAMES are not maintained as of Wallaby, the currently installed version of Swift should be determined similarly to how it is done for other OpenStack packages: by identifying the current release using the openstack-release package.
The current approach causes Swift upgrades from source versions subsequent to Victoria to fail to be detected.

Fixes: #914