### PR TITLE
Adding send-proxy-v2 to see actual client ip

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1125,7 +1125,7 @@ class ApacheSSLContext(OSContextGenerator):
     user = group = 'root'
 
     def enable_modules(self):
-        cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers']
+        cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers', 'remoteip']
         check_call(cmd)
 
     def configure_cert(self, cn=None):

--- a/charmhelpers/contrib/openstack/templates/haproxy.cfg
+++ b/charmhelpers/contrib/openstack/templates/haproxy.cfg
@@ -88,9 +88,9 @@ backend {{ service }}_{{ frontend }}
     {% endif -%}
     {% for unit, address in frontends[frontend]['backends'].items() -%}
     {% if https -%}
-    server {{ unit }} {{ address }}:{{ ports[1] }} check check-ssl verify none
+    server {{ unit }} {{ address }}:{{ ports[1] }} check check-ssl verify none send-proxy-v2 check-send-proxy
     {% else -%}
-    server {{ unit }} {{ address }}:{{ ports[1] }} check
+    server {{ unit }} {{ address }}:{{ ports[1] }} check send-proxy-v2
     {% endif -%}
     {% endfor %}
 {% endfor -%}

--- a/charmhelpers/contrib/openstack/templates/openstack_https_frontend
+++ b/charmhelpers/contrib/openstack/templates/openstack_https_frontend
@@ -22,6 +22,7 @@ Listen {{ ext_port }}
     ProxyPassReverse / http://localhost:{{ int }}/
     ProxyPreserveHost on
     RequestHeader set X-Forwarded-Proto "https"
+    RemoteIPProxyProtocol On
     KeepAliveTimeout 75
     MaxKeepAliveRequests 1000
 </VirtualHost>


### PR DESCRIPTION
Currently, log shows proxy ip but need actual client ip

This PR suggest to add required module and setup for Apache2 templates
and options for haproxy templates