### PR TITLE
c/network/ip: return false when no address given

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -134,6 +134,8 @@ def get_address_in_network(network, fallback=None, fatal=False):
 
 def is_ipv6(address):
     """Determine whether provided address is IPv6 or not."""
+    if not address:
+        return False
     try:
         address = netaddr.IPAddress(address)
     except netaddr.AddrFormatError:

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -296,6 +296,8 @@ class IPTest(unittest.TestCase):
     def test_is_ipv6(self):
         self.assertFalse(net_ip.is_ipv6('myhost'))
         self.assertFalse(net_ip.is_ipv6('172.4.5.5'))
+        self.assertFalse(net_ip.is_ipv6(None))
+        self.assertFalse(net_ip.is_ipv6(""))
         self.assertTrue(net_ip.is_ipv6('2a01:348:2f4:0:685e:5748:ae62:209f'))
 
     @patch.object(netifaces, 'ifaddresses')


### PR DESCRIPTION
Since netaddr 1.2.0 [0], netaddr fails to parse an IPv6 if the given ipv6 is None. Consider a falsy address as not an IPv6 address.

This code used to return False when given a falsy ipaddress.

0: https://github.com/netaddr/netaddr/commit/d39b7d12428006b2ca1e260f92da2b66948b0d6d

Closes: #920