### PR TITLE
Update github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,16 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            env: pep8,py36
-          - python-version: 3.7
-            env: pep8,py37
           - python-version: 3.8
             env: pep8,py38
           - python-version: "3.10"
             env: pep8,py310
+          - python-version: "3.12"
+            env: pep8,py312
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Use ubuntu-22.04 as a base - https://github.com/actions/runner-images/issues/11101
- Drop python 3.6 and 3.7 from the testing matrix
- Add python 3.12 to the testing matrix