### PR TITLE
Add try/except block for distutils ImportError

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -25,7 +25,10 @@ import socket
 import time
 
 from base64 import b64decode
-from distutils.version import LooseVersion
+try:
+    from distutils.version import LooseVersion
+except ImportError:
+    from looseversion import LooseVersion
 from subprocess import (
     check_call,
     check_output,


### PR DESCRIPTION
Python 3.12 deprecated distutils so this commit adds a try/except block to use looseversion in place of distutils when not found.