### PR TITLE
Allow non-dynamic addresses for ipv6 relation_ips

### DIFF
--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -618,7 +618,7 @@ def get_relation_ip(interface, cidr_network=None):
         # Currently IPv6 has priority, eventually we want IPv6 to just be
         # another network space.
         assert_charm_supports_ipv6()
-        return get_ipv6_addr()[0]
+        return get_ipv6_addr(dynamic_only=False)[0]
     elif cidr_network:
         # If a specific CIDR network is passed get the address from that
         # network.


### PR DESCRIPTION
When looking for relation IP addresses, the current code filters for only dynamic addresses. This doesn't work on MAAS where it assigns fixed-address6 for the dhcpd6 configuration - e.g.

host 5c-ed-8c-e8-d5-b4 {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 5c:ed:8c:e8:d5:b4;
   fixed-address6 fc00:1:1::2;
}

This causes the local node to not have the address as dynamic. Change the default option to set dynamic_only=False



(cherry picked from commit 040d4f69e1ddf73bdfd3573edb762c8a7fae944a)