### PR TITLE
Allow non-dynamic addresses for ipv6 relation_ips [antelope]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,44 +3,41 @@ name: charm-helpers CI
 on:
   push:
     branches:
-      - master
       - 'stable/**'
   pull_request:
     branches:
-      - master
       - 'stable/**'
 
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            env: pep8,py36
-          - python-version: 3.7
-            env: pep8,py37
-          - python-version: 3.8
+          - python-version: "3.8"
             env: pep8,py38
           - python-version: "3.10"
             env: pep8,py310
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v4
     - name: Install juju
       run: |
         sudo snap install juju --classic
     - name: Install packages
+      env:
+        PYVERSION: ${{ matrix.python-version }}
       run: |
+        PKG="libapt-pkg-dev bzr rustc cargo python3-dev tox"
+        if [ "$PYVERSION" != "3.10" ]; then
+          sudo add-apt-repository --yes ppa:deadsnakes/ppa
+          PKG="$PKG python$PYVERSION-dev"
+          if [ "$PYVERSION" = "3.8" ]; then
+            PKG="$PKG python3.8-distutils"
+          fi
+        fi
         sudo apt -qq update
-        sudo apt install --yes libapt-pkg-dev # For python-apt wheel build
-        sudo apt install --yes bzr
-    - name: Install tox
-      run: pip install tox
+        sudo apt install --yes $PKG
     - name: Test
       run: tox -c tox.ini -e ${{ matrix.env }}

--- a/charmhelpers/contrib/network/ip.py
+++ b/charmhelpers/contrib/network/ip.py
@@ -618,7 +618,7 @@ def get_relation_ip(interface, cidr_network=None):
         # Currently IPv6 has priority, eventually we want IPv6 to just be
         # another network space.
         assert_charm_supports_ipv6()
-        return get_ipv6_addr()[0]
+        return get_ipv6_addr(dynamic_only=False)[0]
     elif cidr_network:
         # If a specific CIDR network is passed get the address from that
         # network.

--- a/tox.ini
+++ b/tox.ini
@@ -56,4 +56,4 @@ deps = -r{toxinidir}/test-requirements.txt
 commands = flake8 -v {posargs} charmhelpers tests tools
 
 [flake8]
-ignore = E402,E501,E741,E722,W504
+ignore = E402,E501,E741,E722,W504,F824


### PR DESCRIPTION
When looking for relation IP addresses, the current code filters for only dynamic addresses. This doesn't work on MAAS where it assigns fixed-address6 for the dhcpd6 configuration - e.g.

```
host 5c-ed-8c-e8-d5-b4 {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 5c:ed:8c:e8:d5:b4;
   fixed-address6 fc00:1:1::2;
}
```

This causes the local node to not have the address as dynamic. Change the default option to set dynamic_only=False



(cherry picked from commit 040d4f69e1ddf73bdfd3573edb762c8a7fae944a)