### PR TITLE
Add per-client IP rate limiting via Apache mod_qos

### DIFF
--- a/charmhelpers/contrib/openstack/context.py
+++ b/charmhelpers/contrib/openstack/context.py
@@ -1133,6 +1133,83 @@ class ImageServiceContext(OSContextGenerator):
         return {}
 
 
+# Script used with apache mod_qos to copy the real client IP from
+# mod_remoteip into a header
+LUA_QOS_REAL_IP_SCRIPT = '/etc/apache2/qos_real_ip.lua'
+LUA_QOS_REAL_IP_CONTENT = """\
+-- Copy the real client IP (extracted from the PROXY protocol
+-- header by mod_remoteip) into a request header that
+-- mod_qos can read via QS_ClientIpFromHeader.
+function translate(r)
+    r.headers_in['X-Real-Client-IP'] = r.useragent_ip
+    return apache2.DECLINED
+end
+"""
+DEFAULT_RATE_LIMIT_REQUESTS = 200
+DEFAULT_RATE_LIMIT_WINDOW = 60
+
+
+def _get_rate_limit_context():
+    """Return rate-limit template context if the charm has opted in.
+
+    Returns an empty dict when the config option is absent or False.
+    """
+    ctxt = {}
+    try:
+        enabled = config('apache-rate-limit-enabled')
+    except Exception:
+        return ctxt
+    if not enabled:
+        return ctxt
+
+    requests = config('apache-rate-limit-requests')
+    window = config('apache-rate-limit-window')
+    if requests is None or requests <= 0:
+        log("Invalid apache-rate-limit-requests, using default", level=WARNING)
+        requests = DEFAULT_RATE_LIMIT_REQUESTS
+    if window is None or window <= 0:
+        log("Invalid apache-rate-limit-window, using default", level=WARNING)
+        window = DEFAULT_RATE_LIMIT_WINDOW
+    ctxt['apache_rate_limit_enabled'] = True
+    ctxt['apache_rate_limit_requests'] = requests
+    ctxt['apache_rate_limit_window'] = window
+
+    try:
+        proxy_protocol = config('haproxy-enable-proxy-protocol')
+    except Exception:
+        proxy_protocol = False
+
+    if proxy_protocol:
+        write_file(
+            path=LUA_QOS_REAL_IP_SCRIPT,
+            content=LUA_QOS_REAL_IP_CONTENT,
+            owner='root',
+            group='root',
+            perms=0o644,
+        )
+        ctxt['lua_real_ip_script'] = LUA_QOS_REAL_IP_SCRIPT
+
+    # Collect peer IPs to exempt from rate limiting.
+    # Health checks and inter-unit API traffic originate from these
+    # IPs and should not be rate limited.
+    exempt_ips = set()
+    try:
+        local_ip = get_relation_ip('cluster')
+        if local_ip:
+            exempt_ips.add(local_ip)
+    except Exception:
+        pass
+    for rid in relation_ids('cluster'):
+        for unit in related_units(rid):
+            _addr = relation_get('private-address', rid=rid, unit=unit)
+            if _addr:
+                exempt_ips.add(_addr)
+    if exempt_ips:
+        ctxt['rate_limit_exempt_ips'] = sorted(exempt_ips)
+
+    return ctxt
+
+
 class ApacheSSLContext(OSContextGenerator):
     """Generates a context for an apache vhost configuration that configures
     HTTPS reverse proxying for one or many endpoints.  Generated context
@@ -1159,6 +1236,9 @@ class ApacheSSLContext(OSContextGenerator):
         # NOTE(seyeongkim) : remoteip is for proxy protocol
         cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers', 'remoteip']
         check_call(cmd)
+        if config('apache-rate-limit-enabled'):
+            ensure_packages(['libapache2-mod-qos'])
+            check_call(['a2enmod', 'qos', 'lua'])
 
     def configure_cert(self, cn=None):
         ssl_dir = os.path.join('/etc/apache2/ssl/', self.service_namespace)
@@ -1292,6 +1372,7 @@ class ApacheSSLContext(OSContextGenerator):
         ctxt['ext_ports'] = sorted(list(set(ctxt['ext_ports'])))
         if config('haproxy-enable-proxy-protocol'):
             ctxt['haproxy_enable_proxy_protocol'] = True
+        ctxt.update(_get_rate_limit_context())
         return ctxt
 
 
@@ -1804,6 +1885,9 @@ class WSGIWorkerConfigContext(WorkerConfigContext):
         # NOTE(seyeongkim): this is for proxy protocol and non ssl case.
         cmd = ['a2enmod', 'remoteip']
         check_call(cmd)
+        if config('apache-rate-limit-enabled'):
+            ensure_packages(['libapache2-mod-qos'])
+            check_call(['a2enmod', 'qos', 'lua'])
 
     def __call__(self):
         total_processes = _calculate_workers()
@@ -1850,6 +1934,7 @@ class WSGIWorkerConfigContext(WorkerConfigContext):
         }
         if config('haproxy-enable-proxy-protocol'):
             ctxt['haproxy_enable_proxy_protocol'] = True
+        ctxt.update(_get_rate_limit_context())
         return ctxt
 
 

--- a/charmhelpers/contrib/openstack/templates/openstack_https_frontend
+++ b/charmhelpers/contrib/openstack/templates/openstack_https_frontend
@@ -26,10 +26,37 @@ Listen {{ ext_port }}
     RemoteIPProxyProtocol On
     RemoteIPProxyProtocolExceptions 127.0.0.1 ::1
     {% endif -%}
+    {% if lua_real_ip_script -%}
+    <IfModule mod_lua.c>
+        LuaScope thread
+        LuaCodeCache forever
+        LuaHookTranslateName {{ lua_real_ip_script }} translate early
+    </IfModule>
+    {% endif -%}
     KeepAliveTimeout 75
     MaxKeepAliveRequests 1000
+    {% if apache_rate_limit_enabled -%}
+    <IfModule mod_qos.c>
+        SetEnvIf Request_URI "." QS_Limit
+        {% if rate_limit_exempt_ips -%}
+        {% for ip in rate_limit_exempt_ips -%}
+        SetEnvIf Remote_Addr "^{{ ip | replace('.', '\.') }}$" !QS_Limit
+        {% endfor -%}
+        {% endif -%}
+    </IfModule>
+    {% endif -%}
 </VirtualHost>
 {% endfor -%}
+{% if apache_rate_limit_enabled -%}
+<IfModule mod_qos.c>
+    QS_ClientEntries 100000
+    QS_ErrorResponseCode 429
+    QS_ClientEventLimitCount {{ apache_rate_limit_requests }} {{ apache_rate_limit_window }}
+    {% if lua_real_ip_script -%}
+    QS_ClientIpFromHeader X-Real-Client-IP
+    {% endif -%}
+</IfModule>
+{% endif -%}
 <Proxy *>
     Order deny,allow
     Allow from all

--- a/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
+++ b/charmhelpers/contrib/openstack/templates/wsgi-openstack-api.conf
@@ -101,6 +101,23 @@ WSGISocketRotation Off
     RemoteIPProxyProtocol On
     RemoteIPProxyProtocolExceptions 127.0.0.1 ::1
     {% endif -%}
+    {% if lua_real_ip_script -%}
+    <IfModule mod_lua.c>
+        LuaScope thread
+        LuaCodeCache forever
+        LuaHookTranslateName {{ lua_real_ip_script }} translate early
+    </IfModule>
+    {% endif -%}
+    {% if apache_rate_limit_enabled -%}
+    <IfModule mod_qos.c>
+        SetEnvIf Request_URI "." QS_Limit
+        {% if rate_limit_exempt_ips -%}
+        {% for ip in rate_limit_exempt_ips -%}
+        SetEnvIf Remote_Addr "^{{ ip | replace('.', '\.') }}$" !QS_Limit
+        {% endfor -%}
+        {% endif -%}
+    </IfModule>
+    {% endif -%}
 
     <Directory /usr/bin>
         <IfVersion >= 2.4>
@@ -112,4 +129,15 @@ WSGISocketRotation Off
         </IfVersion>
     </Directory>
 </VirtualHost>
+{% endif -%}
+
+{% if apache_rate_limit_enabled -%}
+<IfModule mod_qos.c>
+    QS_ClientEntries 100000
+    QS_ErrorResponseCode 429
+    QS_ClientEventLimitCount {{ apache_rate_limit_requests }} {{ apache_rate_limit_window }}
+    {% if lua_real_ip_script -%}
+    QS_ClientIpFromHeader X-Real-Client-IP
+    {% endif -%}
+</IfModule>
 {% endif -%}

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -9,7 +9,7 @@ from mock import (
     patch,
     Mock,
     MagicMock,
-    call
+    call,
 )
 
 from charmhelpers.fetch.ubuntu_apt_pkg import Version
@@ -707,8 +707,10 @@ ABSENT_MACS = "aa:a5:ae:ae:ab:a4 "
 
 # Imported in contexts.py and needs patching in setUp()
 TO_PATCH = [
+    'apt_install',
     'b64decode',
     'check_call',
+    'filter_installed_packages',
     'get_cert',
     'get_ca_cert',
     'install_ca_cert',
@@ -798,6 +800,7 @@ class ContextTests(unittest.TestCase):
         self.resolve_address.return_value = '10.5.1.50'
         self.maxDiff = None
         self.get_installed_version.return_value = None
+        self.filter_installed_packages.return_value = []
 
     def _patch(self, method):
         _m = patch('charmhelpers.contrib.openstack.context.' + method)
@@ -3137,10 +3140,104 @@ class ContextTests(unittest.TestCase):
 
     def test_https_context_loads_correct_apache_mods(self):
         # Test apache2 context also loads required apache modules
+        self.config.side_effect = fake_config({})
         apache = context.ApacheSSLContext()
         apache.enable_modules()
         ex_cmd = ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers', 'remoteip']
         self.check_call.assert_called_with(ex_cmd)
+
+    @patch.object(context, 'ensure_packages')
+    def test_https_context_loads_rate_limit_mods(self, mock_ensure):
+        # Test apache2 context loads qos and lua when rate limiting enabled
+        self.config.side_effect = fake_config({
+            'apache-rate-limit-enabled': True
+        })
+        apache = context.ApacheSSLContext()
+        apache.enable_modules()
+        self.check_call.assert_any_call(
+            ['a2enmod', 'ssl', 'proxy', 'proxy_http', 'headers', 'remoteip'])
+        mock_ensure.assert_called_with(['libapache2-mod-qos'])
+        self.check_call.assert_any_call(['a2enmod', 'qos', 'lua'])
+
+    @patch.object(context, 'write_file')
+    def test_https_context_rate_limit_with_proxy_protocol(self, mock_write):
+        # Test rate limit + proxy protocol deploys Lua script
+        self.relation_ids.return_value = []
+
+        apache = context.ApacheSSLContext()
+        apache.configure_cert = MagicMock()
+        apache.enable_modules = MagicMock()
+        apache.configure_ca = MagicMock()
+        apache.canonical_names = MagicMock()
+        apache.canonical_names.return_value = ['10.5.1.1']
+        apache.get_network_addresses = MagicMock()
+        apache.get_network_addresses.return_value = [
+            ('10.5.1.100', '10.5.1.1'),
+        ]
+        self.determine_api_port.return_value = 8756
+        self.determine_apache_port.return_value = 8766
+
+        self.config.side_effect = fake_config({
+            'haproxy-enable-proxy-protocol': True,
+            'apache-rate-limit-enabled': True,
+            'apache-rate-limit-requests': 200,
+            'apache-rate-limit-window': 60,
+        })
+        apache.external_ports = '8776'
+        apache.service_namespace = 'cinder'
+
+        result = apache()
+        self.assertTrue(result['apache_rate_limit_enabled'])
+        self.assertTrue(result['haproxy_enable_proxy_protocol'])
+        self.assertEqual(result['lua_real_ip_script'],
+                         '/etc/apache2/qos_real_ip.lua')
+        mock_write.assert_called_with(
+            path='/etc/apache2/qos_real_ip.lua',
+            content=context.LUA_QOS_REAL_IP_CONTENT,
+            owner='root',
+            group='root',
+            perms=0o644,
+        )
+
+    def test_https_context_rate_limit_exempt_ips(self):
+        # Test that peer IPs are collected for exemption
+        self.relation_ids.return_value = ['cluster:0']
+        self.related_units.return_value = ['unit/1', 'unit/2']
+        self.relation_get.side_effect = lambda *args, **kwargs: {
+            'unit/1': '10.0.0.2',
+            'unit/2': '10.0.0.3',
+        }.get(kwargs.get('unit', ''), None)
+        self.get_relation_ip.return_value = '10.0.0.1'
+
+        apache = context.ApacheSSLContext()
+        apache.configure_cert = MagicMock()
+        apache.enable_modules = MagicMock()
+        apache.configure_ca = MagicMock()
+        apache.canonical_names = MagicMock()
+        apache.canonical_names.return_value = ['10.5.1.1']
+        apache.get_network_addresses = MagicMock()
+        apache.get_network_addresses.return_value = [
+            ('10.5.1.100', '10.5.1.1'),
+        ]
+        self.determine_api_port.return_value = 8756
+        self.determine_apache_port.return_value = 8766
+
+        self.config.side_effect = fake_config({
+            'haproxy-enable-proxy-protocol': True,
+            'apache-rate-limit-enabled': True,
+            'apache-rate-limit-requests': 200,
+            'apache-rate-limit-window': 60,
+        })
+        apache.external_ports = '8776'
+        apache.service_namespace = 'cinder'
+
+        result = apache()
+        self.assertIn('rate_limit_exempt_ips', result)
+        exempt = result['rate_limit_exempt_ips']
+        self.assertIn('10.0.0.1', exempt)
+        self.assertIn('10.0.0.2', exempt)
+        self.assertIn('10.0.0.3', exempt)
+        self.assertEqual(len(exempt), 3)
 
     def test_https_configure_cert(self):
         # Test apache2 properly installs certs and keys to disk
@@ -3852,10 +3949,23 @@ class ContextTests(unittest.TestCase):
 
     def test_wsgi_worker_config_context_apache_mods(self):
         # Test apache2 context also loads required apache modules
+        self.config.side_effect = fake_config({})
         apache = context.WSGIWorkerConfigContext()
         apache.enable_modules()
         ex_cmd = ['a2enmod', 'remoteip']
         self.check_call.assert_called_with(ex_cmd)
+
+    @patch.object(context, 'ensure_packages')
+    def test_wsgi_worker_config_context_rate_limit_mods(self, mock_ensure):
+        # Test WSGI context loads qos and lua when rate limiting enabled
+        self.config.side_effect = fake_config({
+            'apache-rate-limit-enabled': True
+        })
+        apache = context.WSGIWorkerConfigContext()
+        apache.enable_modules()
+        self.check_call.assert_any_call(['a2enmod', 'remoteip'])
+        mock_ensure.assert_called_with(['libapache2-mod-qos'])
+        self.check_call.assert_any_call(['a2enmod', 'qos', 'lua'])
 
     @patch.object(context, '_calculate_workers')
     def test_wsgi_worker_config_context_proxy_protocol(self,
@@ -3886,6 +3996,71 @@ class ContextTests(unittest.TestCase):
             "haproxy_enable_proxy_protocol": True
         }
         self.assertEqual(expect, ctxt())
+
+    @patch.object(context, 'write_file')
+    @patch.object(context, '_calculate_workers')
+    def test_wsgi_worker_config_context_rate_limit(self,
+                                                   _calculate_workers,
+                                                   mock_write):
+        # Test WSGI worker config context with rate limiting enabled
+        self.config.side_effect = fake_config({
+            'worker-multiplier': 2,
+            'non-defined-wsgi-socket-rotation': True,
+            'haproxy-enable-proxy-protocol': True,
+            'apache-rate-limit-enabled': True,
+            'apache-rate-limit-requests': 150,
+            'apache-rate-limit-window': 45,
+        })
+        _calculate_workers.return_value = 8
+        self.relation_ids.return_value = ['cluster:0']
+        self.related_units.return_value = ['unit/1']
+        self.relation_get.return_value = '10.0.0.2'
+        self.get_relation_ip.return_value = '10.0.0.1'
+        service_name = 'service-name'
+        script = '/usr/bin/script'
+        ctxt = context.WSGIWorkerConfigContext(name=service_name,
+                                               script=script)
+        result = ctxt()
+        self.assertTrue(result['apache_rate_limit_enabled'])
+        self.assertEqual(result['apache_rate_limit_requests'], 150)
+        self.assertEqual(result['apache_rate_limit_window'], 45)
+        self.assertTrue(result['haproxy_enable_proxy_protocol'])
+        self.assertEqual(result['lua_real_ip_script'],
+                         '/etc/apache2/qos_real_ip.lua')
+        mock_write.assert_called_with(
+            path='/etc/apache2/qos_real_ip.lua',
+            content=context.LUA_QOS_REAL_IP_CONTENT,
+            owner='root',
+            group='root',
+            perms=0o644,
+        )
+        self.assertIn('10.0.0.1', result['rate_limit_exempt_ips'])
+        self.assertIn('10.0.0.2', result['rate_limit_exempt_ips'])
+
+    @patch.object(context, '_calculate_workers')
+    def test_wsgi_worker_config_context_rate_limit_invalid_config(
+            self, _calculate_workers):
+        _calculate_workers.return_value = 4
+        self.relation_ids.return_value = []
+        for bad_requests, bad_window, exp_requests, exp_window in [
+                (None, 60, 200, 60),
+                (200, None, 200, 60),
+                (0, 60, 200, 60),
+                (200, -1, 200, 60)]:
+            self.config.side_effect = fake_config({
+                'apache-rate-limit-enabled': True,
+                'apache-rate-limit-requests': bad_requests,
+                'apache-rate-limit-window': bad_window,
+            })
+            ctxt = context.WSGIWorkerConfigContext(
+                name='svc', script='/usr/bin/svc')
+            result = ctxt()
+            self.assertTrue(
+                result.get('apache_rate_limit_enabled'),
+                "Rate limiting should stay enabled for requests={!r} "
+                "window={!r}".format(bad_requests, bad_window))
+            self.assertEqual(result['apache_rate_limit_requests'], exp_requests)
+            self.assertEqual(result['apache_rate_limit_window'], exp_window)
 
     def test_zeromq_context_unrelated(self):
         self.is_relation_made.return_value = False


### PR DESCRIPTION
When apache-rate-limit-enabled=true, Apache limits how many HTTP requests a client IP can make within a time window and returns HTTP 429 when limit is hit.

Builds on proxy protocol support (f516806411319fd967dee205701c2fabceb3144f). HAProxy forwards the real client IP, which mod_remoteip extracts, but mod_qos cannot use directly. A small Lua script bridges this gap by running after mod_remoteip has extracted the real IP and copying it into `X-Real-Client-IP` header that mod_qos can read.

The mod_qos module is installed and enabled automatically.

**A few notes:**
- When services are running behind HAProxy, proxy protocol must be enabled for rate limiting to take effect
- Limits are enforced per unit (not cluster-wide), so the effective limit scales with the number of backend units
- Cluster peer IPs are exempted to avoid throttling health checks
- [`LuaScope thread`](https://httpd.apache.org/docs/2.4/mod/mod_lua.html#luascope) and [`LuaCodeCache forever`](https://httpd.apache.org/docs/2.4/mod/mod_lua.html#luacodecache) directives are set for performance because the lua script is stateless and does not need to be re-read and re-compiled on every request

**Testing**
- Integration tested on 3-unit neutron-api HA deployment with HTTPS and proxy protocol
-  Integration tested on single-unit neutron-api with HTTPS:
    - Rate limiting still requires proxy protocol for neutron-api (local HAProxy service masks client IP without it)

**Note on mod_qos and mod_lua**

Noble ships version 11.74 for mod_qos which cannot use the client IP from mod_remoteip directly, newer versions of mod_qos (11.75+) improve this, so the lua script workaround may not be needed in the future.

See: https://mod-qos.sourceforge.net/CHANGES.txt
  