### PR TITLE
Python 3.12 compatibility backports [caracal]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
             env: pep8,py38
           - python-version: "3.10"
             env: pep8,py310
+          - python-version: "3.12"
+            env: pep8,py312
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,5 +39,8 @@ jobs:
         fi
         sudo apt -qq update
         sudo apt install --yes $PKG
+
+    - name: Install tox
+      run: pip install tox
     - name: Test
       run: tox -c tox.ini -e ${{ matrix.env }}

--- a/charmhelpers/core/hookenv.py
+++ b/charmhelpers/core/hookenv.py
@@ -18,7 +18,10 @@
 #  Charm Helpers Developers <juju@lists.ubuntu.com>
 
 import copy
-from distutils.version import LooseVersion
+try:
+    from distutils.version import LooseVersion
+except ImportError:
+    from looseversion import LooseVersion
 from enum import Enum
 from functools import wraps
 from collections import namedtuple, UserDict

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+setuptools<82.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Jinja2
 netaddr
 
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
+
+looseversion;python_version >= '3.12'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,9 +3,8 @@
 pip
 coverage>=3.6
 mock>=1.0.1,<1.1.0
-nose>=1.3.1; python_version < '3.10'
-nose2; python_version >= '3.10'
-nose2[coverage_plugin]; python_version >= '3.10'
+nose2
+nose2[coverage_plugin]
 flake8
 # testtools==0.9.14  # Before dependent on modern 'six'
 testtools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -24,7 +24,7 @@ Jinja2
 
 ##############################################################
 
-netifaces==0.10    # trusty is 0.8, but using py3 compatible version for tests.
+netifaces
 psutil
 python-keystoneclient
 # Fixes:
@@ -33,3 +33,6 @@ python-keystoneclient
 # IndexError: list index out of range
 MarkupSafe<3.0.3
 dnspython
+breezy==3.0.2; python_version < '3.10' # Focal version
+breezy==3.2.1; python_version >= '3.10' and python_version < '3.12' # Jammy version
+breezy==3.3.4; python_version >= '3.12' # Close to Noble version

--- a/tests/contrib/hahelpers/test_apache_utils.py
+++ b/tests/contrib/hahelpers/test_apache_utils.py
@@ -73,11 +73,11 @@ class ApacheUtilsTests(TestCase):
             'some_ca_key',  # config_Get('ssl_key')
         ]
         result = apache_utils.get_cert('test-cn')
-        self.assertEquals(('some_ca_cert', 'some_ca_key'), result)
+        self.assertEqual(('some_ca_cert', 'some_ca_key'), result)
 
     def test_get_ca_cert_from_config(self):
         self.config_get.return_value = "some_ca_cert"
-        self.assertEquals('some_ca_cert', apache_utils.get_ca_cert())
+        self.assertEqual('some_ca_cert', apache_utils.get_ca_cert())
 
     def test_get_cert_from_relation(self):
         self.config_get.return_value = None
@@ -86,7 +86,7 @@ class ApacheUtilsTests(TestCase):
         self.relation_list.side_effect = rel.relation_units
         self.relation_get.side_effect = rel.get
         result = apache_utils.get_cert('test-cn')
-        self.assertEquals(('keystone_provided_cert', 'keystone_provided_key'),
+        self.assertEqual(('keystone_provided_cert', 'keystone_provided_key'),
                           result)
 
     def test_get_cert_from_relation_deprecated(self):
@@ -96,7 +96,7 @@ class ApacheUtilsTests(TestCase):
         self.relation_list.side_effect = rel.relation_units
         self.relation_get.side_effect = rel.get
         result = apache_utils.get_cert()
-        self.assertEquals(('keystone_provided_cert', 'keystone_provided_key'),
+        self.assertEqual(('keystone_provided_cert', 'keystone_provided_key'),
                           result)
 
     def test_get_ca_cert_from_relation(self):
@@ -110,7 +110,7 @@ class ApacheUtilsTests(TestCase):
         result = apache_utils.get_ca_cert()
         self.relation_ids.assert_has_calls([call('identity-service'),
                                             call('identity-credentials')])
-        self.assertEquals('keystone_provided_ca',
+        self.assertEqual('keystone_provided_ca',
                           result)
 
     @patch.object(apache_utils.os.path, 'isfile')

--- a/tests/contrib/hahelpers/test_cluster_utils.py
+++ b/tests/contrib/hahelpers/test_cluster_utils.py
@@ -149,7 +149,7 @@ class ClusterUtilsTests(TestCase):
         peers = ['peer_node/1', 'peer_node/2']
         self.relation_ids.return_value = ['cluster:0']
         self.relation_list.return_value = peers
-        self.assertEquals(peers, cluster_utils.peer_units())
+        self.assertEqual(peers, cluster_utils.peer_units())
 
     def test_peer_ips(self):
         '''Get a dict of peers and their ips'''
@@ -163,7 +163,7 @@ class ClusterUtilsTests(TestCase):
         self.relation_ids.return_value = ['cluster:0']
         self.relation_list.return_value = peers.keys()
         self.relation_get.side_effect = _relation_get
-        self.assertEquals(peers, cluster_utils.peer_ips())
+        self.assertEqual(peers, cluster_utils.peer_ips())
 
     @patch('os.getenv')
     def test_is_oldest_peer(self, getenv):
@@ -280,7 +280,7 @@ class ClusterUtilsTests(TestCase):
         '''It determines API port in presence of peers'''
         peer_units.return_value = ['peer1']
         https.return_value = False
-        self.assertEquals(9686, cluster_utils.determine_api_port(9696))
+        self.assertEqual(9686, cluster_utils.determine_api_port(9696))
 
     @patch.object(cluster_utils, 'https')
     @patch.object(cluster_utils, 'peer_units')
@@ -289,7 +289,7 @@ class ClusterUtilsTests(TestCase):
         peer_units.return_value = []
         https.return_value = False
         port = cluster_utils.determine_api_port(9696, singlenode_mode=True)
-        self.assertEquals(9686, port)
+        self.assertEqual(9686, port)
 
     @patch.object(cluster_utils, 'is_clustered')
     @patch.object(cluster_utils, 'https')
@@ -300,7 +300,7 @@ class ClusterUtilsTests(TestCase):
         peer_units.return_value = []
         is_clustered.return_value = True
         https.return_value = False
-        self.assertEquals(9686, cluster_utils.determine_api_port(9696))
+        self.assertEqual(9686, cluster_utils.determine_api_port(9696))
 
     @patch.object(cluster_utils, 'is_clustered')
     @patch.object(cluster_utils, 'https')
@@ -311,13 +311,13 @@ class ClusterUtilsTests(TestCase):
         peer_units.return_value = []
         is_clustered.return_value = True
         https.return_value = True
-        self.assertEquals(9676, cluster_utils.determine_api_port(9696))
+        self.assertEqual(9676, cluster_utils.determine_api_port(9696))
 
     @patch.object(cluster_utils, 'https')
     def test_determine_apache_port_https(self, https):
         '''It determines haproxy port with https enabled'''
         https.return_value = True
-        self.assertEquals(9696, cluster_utils.determine_apache_port(9696))
+        self.assertEqual(9696, cluster_utils.determine_apache_port(9696))
 
     @patch.object(cluster_utils, 'https')
     @patch.object(cluster_utils, 'is_clustered')
@@ -325,7 +325,7 @@ class ClusterUtilsTests(TestCase):
         '''It determines haproxy port with https disabled'''
         https.return_value = True
         is_clustered.return_value = True
-        self.assertEquals(9686, cluster_utils.determine_apache_port(9696))
+        self.assertEqual(9686, cluster_utils.determine_apache_port(9696))
 
     @patch.object(cluster_utils, 'peer_units')
     @patch.object(cluster_utils, 'https')
@@ -338,7 +338,7 @@ class ClusterUtilsTests(TestCase):
         https.return_value = False
         is_clustered.return_value = False
         port = cluster_utils.determine_apache_port(9696, singlenode_mode=True)
-        self.assertEquals(9686, port)
+        self.assertEqual(9686, port)
 
     @patch.object(cluster_utils, 'valid_hacluster_config')
     def test_get_hacluster_config_complete(self, valid_hacluster_config):
@@ -359,7 +359,7 @@ class ClusterUtilsTests(TestCase):
             return conf[setting]
 
         self.config_get.side_effect = _fake_config_get
-        self.assertEquals(conf, cluster_utils.get_hacluster_config())
+        self.assertEqual(conf, cluster_utils.get_hacluster_config())
 
     @patch.object(cluster_utils, 'valid_hacluster_config')
     def test_get_hacluster_config_incomplete(self, valid_hacluster_config):
@@ -399,7 +399,7 @@ class ClusterUtilsTests(TestCase):
         exclude_keys = ['vip', 'os-admin-hostname', 'os-internal-hostname',
                         'os-public-hostname', 'os-access-hostname']
         result = cluster_utils.get_hacluster_config(exclude_keys)
-        self.assertEquals(conf, result)
+        self.assertEqual(conf, result)
 
     @patch.object(cluster_utils, 'is_clustered')
     def test_canonical_url_bare(self, is_clustered):
@@ -410,7 +410,7 @@ class ClusterUtilsTests(TestCase):
         configs.complete_contexts = MagicMock()
         configs.complete_contexts.return_value = []
         url = cluster_utils.canonical_url(configs)
-        self.assertEquals('http://foohost1', url)
+        self.assertEqual('http://foohost1', url)
 
     @patch.object(cluster_utils, 'is_clustered')
     def test_canonical_url_https_no_cluster(self, is_clustered):
@@ -421,7 +421,7 @@ class ClusterUtilsTests(TestCase):
         configs.complete_contexts = MagicMock()
         configs.complete_contexts.return_value = ['https']
         url = cluster_utils.canonical_url(configs)
-        self.assertEquals('https://foohost1', url)
+        self.assertEqual('https://foohost1', url)
 
     @patch.object(cluster_utils, 'is_clustered')
     def test_canonical_url_https_cluster(self, is_clustered):
@@ -432,7 +432,7 @@ class ClusterUtilsTests(TestCase):
         configs.complete_contexts = MagicMock()
         configs.complete_contexts.return_value = ['https']
         url = cluster_utils.canonical_url(configs)
-        self.assertEquals('https://10.0.0.1', url)
+        self.assertEqual('https://10.0.0.1', url)
 
     @patch.object(cluster_utils, 'is_clustered')
     def test_canonical_url_cluster_no_https(self, is_clustered):
@@ -444,7 +444,7 @@ class ClusterUtilsTests(TestCase):
         configs.complete_contexts = MagicMock()
         configs.complete_contexts.return_value = []
         url = cluster_utils.canonical_url(configs)
-        self.assertEquals('http://10.0.0.1', url)
+        self.assertEqual('http://10.0.0.1', url)
 
     @patch.object(cluster_utils, 'status_set')
     def test_valid_hacluster_config_incomplete(self, status_set):

--- a/tests/contrib/mellanox/test_infiniband.py
+++ b/tests/contrib/mellanox/test_infiniband.py
@@ -92,12 +92,12 @@ class InfinibandTest(unittest.TestCase):
 
         info = infiniband.device_info("mlx4_0")
 
-        self.assertEquals(info.num_ports, "2")
-        self.assertEquals(info.device_type, "MT4103")
-        self.assertEquals(info.fw_ver, "2.33.5000")
-        self.assertEquals(info.hw_ver, "0")
-        self.assertEquals(info.node_guid, "0xe41d2d03000a1120")
-        self.assertEquals(info.sys_guid, "0xe41d2d03000a1123")
+        self.assertEqual(info.num_ports, "2")
+        self.assertEqual(info.device_type, "MT4103")
+        self.assertEqual(info.fw_ver, "2.33.5000")
+        self.assertEqual(info.hw_ver, "0")
+        self.assertEqual(info.node_guid, "0xe41d2d03000a1120")
+        self.assertEqual(info.sys_guid, "0xe41d2d03000a1123")
 
     @patch("subprocess.check_output")
     def test_ipoib_interfaces(self, check_output):
@@ -112,4 +112,4 @@ class InfinibandTest(unittest.TestCase):
                 return "driver: mock"
 
         check_output.side_effect = c
-        self.assertEquals(infiniband.ipoib_interfaces(), [ipoib_nic])
+        self.assertEqual(infiniband.ipoib_interfaces(), [ipoib_nic])

--- a/tests/contrib/network/ovs/test_ovn.py
+++ b/tests/contrib/network/ovs/test_ovn.py
@@ -88,7 +88,7 @@ class TestOVN(test_utils.BaseTestCase):
     def test_cluster_status(self):
         self.patch_object(ovn, 'ovn_appctl')
         self.ovn_appctl.return_value = CLUSTER_STATUS
-        self.assertEquals(ovn.cluster_status('ovnnb_db'),
+        self.assertEqual(ovn.cluster_status('ovnnb_db'),
                           CLUSTER_STATUS_OBJECT)
         self.ovn_appctl.assert_called_once_with('ovnnb_db', ('cluster/status',
                                                 'OVN_Northbound'),

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -200,7 +200,7 @@ class TestOVS(test_utils.BaseTestCase):
             {'_uuid': fake_uuid},
         ]
         self.SimpleOVSDB.return_value = ovsdb
-        self.assertEquals(ovs.uuid_for_port('fake-port'), fake_uuid)
+        self.assertEqual(ovs.uuid_for_port('fake-port'), fake_uuid)
         ovsdb.port.find.assert_called_once_with('name=fake-port')
 
     def test_bridge_for_port(self):
@@ -214,7 +214,7 @@ class TestOVS(test_utils.BaseTestCase):
             },
         ]
         self.SimpleOVSDB.return_value = ovsdb
-        self.assertEquals(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
+        self.assertEqual(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
         # If there is a single port on a bridge the ports property will not be
         # a list. ref: juju/charm-helpers#510
         ovsdb.bridge.__iter__.return_value = [
@@ -223,7 +223,7 @@ class TestOVS(test_utils.BaseTestCase):
                 'ports': fake_uuid,
             },
         ]
-        self.assertEquals(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
+        self.assertEqual(ovs.bridge_for_port(fake_uuid), 'fake-bridge')
 
     def test_patch_ports_on_bridge(self):
         self.patch_object(ovs.ch_ovsdb, 'SimpleOVSDB')
@@ -258,7 +258,7 @@ class TestOVS(test_utils.BaseTestCase):
         self.SimpleOVSDB.return_value = ovsdb
         self.bridge_for_port.side_effect = ['some-other-bridge', 'fake-bridge', 'fake-peer-bridge']
         for patch in ovs.patch_ports_on_bridge('fake-bridge'):
-            self.assertEquals(
+            self.assertEqual(
                 patch,
                 ovs.Patch(
                     this_end=ovs.PatchPort(

--- a/tests/contrib/network/ovs/test_utils.py
+++ b/tests/contrib/network/ovs/test_utils.py
@@ -8,6 +8,6 @@ class TestUtils(test_utils.BaseTestCase):
     def test__run(self):
         self.patch_object(utils.subprocess, 'check_output')
         self.check_output.return_value = 'aReturn'
-        self.assertEquals(utils._run('aArg'), 'aReturn')
+        self.assertEqual(utils._run('aArg'), 'aReturn')
         self.check_output.assert_called_once_with(
             ('aArg',), universal_newlines=True)

--- a/tests/contrib/network/test_ip.py
+++ b/tests/contrib/network/test_ip.py
@@ -259,15 +259,15 @@ class IPTest(unittest.TestCase):
             return DUMMY_ADDRESSES[iface]
         _interfaces.return_value = ['eth0', 'eth1']
         _ifaddresses.side_effect = mock_ifaddresses
-        self.assertEquals(
+        self.assertEqual(
             net_ip.get_iface_for_address('192.168.1.220'),
             'eth0')
-        self.assertEquals(net_ip.get_iface_for_address('10.5.20.4'), 'eth1')
-        self.assertEquals(
+        self.assertEqual(net_ip.get_iface_for_address('10.5.20.4'), 'eth1')
+        self.assertEqual(
             net_ip.get_iface_for_address('2a01:348:2f4:0:685e:5748:ae62:210f'),
             'eth0'
         )
-        self.assertEquals(net_ip.get_iface_for_address('172.4.5.5'), None)
+        self.assertEqual(net_ip.get_iface_for_address('172.4.5.5'), None)
 
     @patch.object(netifaces, 'ifaddresses')
     @patch.object(netifaces, 'interfaces')
@@ -276,19 +276,19 @@ class IPTest(unittest.TestCase):
             return DUMMY_ADDRESSES[iface]
         _interfaces.return_value = ['eth0', 'eth1']
         _ifaddresses.side_effect = mock_ifaddresses
-        self.assertEquals(
+        self.assertEqual(
             net_ip.get_netmask_for_address('192.168.1.220'),
             '255.255.255.0')
-        self.assertEquals(
+        self.assertEqual(
             net_ip.get_netmask_for_address('10.5.20.4'),
             '255.255.0.0')
-        self.assertEquals(net_ip.get_netmask_for_address('172.4.5.5'), None)
-        self.assertEquals(
+        self.assertEqual(net_ip.get_netmask_for_address('172.4.5.5'), None)
+        self.assertEqual(
             net_ip.get_netmask_for_address(
                 '2a01:348:2f4:0:685e:5748:ae62:210f'),
             '64'
         )
-        self.assertEquals(
+        self.assertEqual(
             net_ip.get_netmask_for_address('2001:db8:1::'),
             '128'
         )
@@ -518,12 +518,12 @@ class IPTest(unittest.TestCase):
 
     def test_format_ipv6_addr(self):
         DUMMY_ADDRESS = '2001:db8:1:0:f131:fc84:ea37:7d4'
-        self.assertEquals(net_ip.format_ipv6_addr(DUMMY_ADDRESS),
+        self.assertEqual(net_ip.format_ipv6_addr(DUMMY_ADDRESS),
                           '[2001:db8:1:0:f131:fc84:ea37:7d4]')
 
     def test_format_invalid_ipv6_addr(self):
         INVALID_IPV6_ADDR = 'myhost'
-        self.assertEquals(net_ip.format_ipv6_addr(INVALID_IPV6_ADDR),
+        self.assertEqual(net_ip.format_ipv6_addr(INVALID_IPV6_ADDR),
                           None)
 
     @patch('charmhelpers.contrib.network.ip.get_iface_from_addr')
@@ -634,7 +634,7 @@ class IPTest(unittest.TestCase):
         fake_dns = FakeDNS('10.0.0.1')
         with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com')
-        self.assertEquals(ip, '10.0.0.1')
+        self.assertEqual(ip, '10.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.ns_query')
     @patch('charmhelpers.contrib.network.ip.socket.gethostbyname')
@@ -646,7 +646,7 @@ class IPTest(unittest.TestCase):
         socket.return_value = '10.0.0.1'
         with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com')
-        self.assertEquals(ip, '10.0.0.1')
+        self.assertEqual(ip, '10.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.log')
     @patch('charmhelpers.contrib.network.ip.ns_query')
@@ -663,14 +663,14 @@ class IPTest(unittest.TestCase):
         socket.side_effect = r
         with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('www.ubuntu.com', fallback='127.0.0.1')
-        self.assertEquals(ip, '127.0.0.1')
+        self.assertEqual(ip, '127.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_host_ip_with_ip(self, apt_install):
         fake_dns = FakeDNS('5.5.5.5')
         with patch('builtins.__import__', side_effect=[fake_dns]):
             ip = net_ip.get_host_ip('4.2.2.1')
-        self.assertEquals(ip, '4.2.2.1')
+        self.assertEqual(ip, '4.2.2.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_trigger_apt_install(self, apt_install):
@@ -678,14 +678,14 @@ class IPTest(unittest.TestCase):
         with patch('builtins.__import__', side_effect=[ImportError, fake_dns]):
             nsq = net_ip.ns_query('5.5.5.5')
             apt_install.assert_called_with('python3-dnspython', fatal=True)
-        self.assertEquals(nsq, '5.5.5.5')
+        self.assertEqual(nsq, '5.5.5.5')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_ptr_record(self, apt_install):
         fake_dns = FakeDNS('127.0.0.1')
         with patch('builtins.__import__', side_effect=[fake_dns]):
             nsq = net_ip.ns_query('127.0.0.1')
-        self.assertEquals(nsq, '127.0.0.1')
+        self.assertEqual(nsq, '127.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_a_record(self, apt_install):
@@ -693,21 +693,21 @@ class IPTest(unittest.TestCase):
         fake_dns_name = FakeDNSName('www.somedomain.tld')
         with patch('builtins.__import__', side_effect=[fake_dns]):
             nsq = net_ip.ns_query(fake_dns_name)
-        self.assertEquals(nsq, '127.0.0.1')
+        self.assertEqual(nsq, '127.0.0.1')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_blank_record(self, apt_install):
         fake_dns = FakeDNS(None)
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             nsq = net_ip.ns_query(None)
-        self.assertEquals(nsq, None)
+        self.assertEqual(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_lookup_fail(self, apt_install):
         fake_dns = FakeDNS('')
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             nsq = net_ip.ns_query('nonexistant')
-        self.assertEquals(nsq, None)
+        self.assertEqual(nsq, None)
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_ns_query_loopup_fail_real_implementation(self, apt_install):
@@ -719,29 +719,29 @@ class IPTest(unittest.TestCase):
         fake_dns = FakeDNS('www.ubuntu.com')
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
-        self.assertEquals(hn, 'www.ubuntu.com')
+        self.assertEqual(hn, 'www.ubuntu.com')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_ip_not_fqdn(self, apt_install):
         fake_dns = FakeDNS('packages.ubuntu.com')
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1', fqdn=False)
-        self.assertEquals(hn, 'packages')
+        self.assertEqual(hn, 'packages')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_hostname(self, apt_install):
         hn = net_ip.get_hostname('www.ubuntu.com')
-        self.assertEquals(hn, 'www.ubuntu.com')
+        self.assertEqual(hn, 'www.ubuntu.com')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_hostname_trailingdot(self, apt_install):
         hn = net_ip.get_hostname('www.ubuntu.com.')
-        self.assertEquals(hn, 'www.ubuntu.com')
+        self.assertEqual(hn, 'www.ubuntu.com')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_with_hostname_not_fqdn(self, apt_install):
         hn = net_ip.get_hostname('packages.ubuntu.com', fqdn=False)
-        self.assertEquals(hn, 'packages')
+        self.assertEqual(hn, 'packages')
 
     @patch('charmhelpers.contrib.network.ip.apt_install')
     def test_get_hostname_trigger_apt_install(self, apt_install):
@@ -751,7 +751,7 @@ class IPTest(unittest.TestCase):
             hn = net_ip.get_hostname('4.2.2.1')
             apt_install.assert_called_with('python3-dnspython', fatal=True)
 
-        self.assertEquals(hn, 'www.ubuntu.com')
+        self.assertEqual(hn, 'www.ubuntu.com')
 
     @patch('charmhelpers.contrib.network.ip.socket.gethostbyaddr')
     @patch('charmhelpers.contrib.network.ip.ns_query')
@@ -762,7 +762,7 @@ class IPTest(unittest.TestCase):
         socket.return_value = ()
         with patch('builtins.__import__', side_effect=[fake_dns, fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
-        self.assertEquals(hn, None)
+        self.assertEqual(hn, None)
 
     @patch('charmhelpers.contrib.network.ip.socket.gethostbyaddr')
     @patch('charmhelpers.contrib.network.ip.ns_query')
@@ -774,7 +774,7 @@ class IPTest(unittest.TestCase):
         socket.return_value = ("www.ubuntu.com", "", "")
         with patch('builtins.__import__', side_effect=[fake_dns]):
             hn = net_ip.get_hostname('4.2.2.1')
-        self.assertEquals(hn, "www.ubuntu.com")
+        self.assertEqual(hn, "www.ubuntu.com")
 
     @patch('charmhelpers.contrib.network.ip.subprocess.call')
     def test_port_has_listener(self, subprocess_call):

--- a/tests/contrib/network/test_ufw.py
+++ b/tests/contrib/network/test_ufw.py
@@ -545,4 +545,4 @@ class TestUFW(unittest.TestCase):
             for n, r in ufw.status():
                 self.assertDictEqual(r, expect[n])
                 n_rules += 1
-            self.assertEquals(n_rules, 3)
+            self.assertEqual(n_rules, 3)

--- a/tests/contrib/openstack/test_ip.py
+++ b/tests/contrib/openstack/test_ip.py
@@ -51,30 +51,30 @@ class IPTestCase(TestCase):
         self.is_clustered.return_value = True
         self.test_config.set('vip', '10.5.3.200')
         self.get_iface_for_address.return_value = 'ens3'
-        self.assertEquals(ip.get_invalid_vips(), [])
+        self.assertEqual(ip.get_invalid_vips(), [])
 
     def test_get_invalid_vips_invalid_ip(self):
         self.is_clustered.return_value = True
         self.test_config.set('vip', '10.3.2.50')
         self.get_iface_for_address.return_value = None
-        self.assertEquals(ip.get_invalid_vips(), ['10.3.2.50'])
+        self.assertEqual(ip.get_invalid_vips(), ['10.3.2.50'])
 
     def test_get_invalid_vips_no_vip(self):
         self.is_clustered.return_value = True
         self.test_config.set('vip', '')
-        self.assertEquals(ip.get_invalid_vips(), [])
+        self.assertEqual(ip.get_invalid_vips(), [])
 
     def test_get_invalid_vips_mixed(self):
         self.is_clustered.return_value = True
         self.test_config.set('vip', '10.3.1.100 10.5.3.200 2.3.5.6')
         self.get_iface_for_address.side_effect = [None, 'ens3', None]
-        self.assertEquals(ip.get_invalid_vips(), ['10.3.1.100', '2.3.5.6'])
+        self.assertEqual(ip.get_invalid_vips(), ['10.3.1.100', '2.3.5.6'])
 
     def test_resolve_address_default(self):
         self.is_clustered.return_value = False
         self.unit_get.return_value = 'unit1'
         self.get_address_in_network.return_value = 'unit1'
-        self.assertEquals(ip.resolve_address(), 'unit1')
+        self.assertEqual(ip.resolve_address(), 'unit1')
         self.unit_get.assert_called_with('public-address')
         calls = [call('os-public-network'),
                  call('prefer-ipv6')]
@@ -84,7 +84,7 @@ class IPTestCase(TestCase):
         self.is_clustered.return_value = False
         self.unit_get.return_value = 'unit1'
         self.get_address_in_network.return_value = 'unit1'
-        self.assertEquals(ip.resolve_address(ip.INTERNAL), 'unit1')
+        self.assertEqual(ip.resolve_address(ip.INTERNAL), 'unit1')
         self.unit_get.assert_called_with('private-address')
         calls = [call('os-internal-network'),
                  call('prefer-ipv6')]
@@ -95,7 +95,7 @@ class IPTestCase(TestCase):
         self.test_config.set('os-public-network', '192.168.20.0/24')
         self.unit_get.return_value = 'unit1'
         self.get_address_in_network.return_value = '192.168.20.1'
-        self.assertEquals(ip.resolve_address(), '192.168.20.1')
+        self.assertEqual(ip.resolve_address(), '192.168.20.1')
         self.unit_get.assert_called_with('public-address')
         calls = [call('os-public-network'),
                  call('prefer-ipv6')]
@@ -108,12 +108,12 @@ class IPTestCase(TestCase):
         self.is_clustered.return_value = True
         self.test_config.set('os-public-network', '192.168.20.0/24')
         self.test_config.set('vip', '192.168.20.100 10.5.3.1')
-        self.assertEquals(ip.resolve_address(), '192.168.20.100')
+        self.assertEqual(ip.resolve_address(), '192.168.20.100')
 
     def test_resolve_address_default_clustered(self):
         self.is_clustered.return_value = True
         self.test_config.set('vip', '10.5.3.1')
-        self.assertEquals(ip.resolve_address(), '10.5.3.1')
+        self.assertEqual(ip.resolve_address(), '10.5.3.1')
         self.config.assert_has_calls(
             [call('vip'),
              call('os-public-network')])

--- a/tests/contrib/openstack/test_keystone_utils.py
+++ b/tests/contrib/openstack/test_keystone_utils.py
@@ -79,11 +79,11 @@ class KeystoneTests(unittest.TestCase):
                                                 service_type="openstack"))
 
     def test_get_api_suffix(self):
-        self.assertEquals(keystone.get_api_suffix(2), "v2.0")
-        self.assertEquals(keystone.get_api_suffix(3), "v3")
+        self.assertEqual(keystone.get_api_suffix(2), "v2.0")
+        self.assertEqual(keystone.get_api_suffix(3), "v3")
 
     def test_format_endpoint(self):
-        self.assertEquals(keystone.format_endpoint(
+        self.assertEqual(keystone.format_endpoint(
             "http", "10.0.0.5", "5000", 2), "http://10.0.0.5:5000/v2.0/")
 
     def test_get_keystone_manager_from_identity_service_context(self):

--- a/tests/contrib/openstack/test_neutron_utils.py
+++ b/tests/contrib/openstack/test_neutron_utils.py
@@ -24,75 +24,75 @@ class NeutronTests(unittest.TestCase):
     def test_headers_package(self):
         self.check_output.return_value = b'3.13.0-19-generic'
         kname = neutron.headers_package()
-        self.assertEquals(kname, 'linux-headers-3.13.0-19-generic')
+        self.assertEqual(kname, 'linux-headers-3.13.0-19-generic')
 
     def test_kernel_version(self):
         self.check_output.return_value = b'3.13.0-19-generic'
         kver_maj, kver_min = neutron.kernel_version()
-        self.assertEquals((kver_maj, kver_min), (3, 13))
+        self.assertEqual((kver_maj, kver_min), (3, 13))
 
     @patch.object(neutron, 'kernel_version')
     def test_determine_dkms_package_old_kernel(self, _kernel_version):
         self.check_output.return_value = b'3.4.0-19-generic'
         _kernel_version.return_value = (3, 10)
         dkms_package = neutron.determine_dkms_package()
-        self.assertEquals(dkms_package, ['linux-headers-3.4.0-19-generic',
+        self.assertEqual(dkms_package, ['linux-headers-3.4.0-19-generic',
                                          'openvswitch-datapath-dkms'])
 
     @patch.object(neutron, 'kernel_version')
     def test_determine_dkms_package_new_kernel(self, _kernel_version):
         _kernel_version.return_value = (3, 13)
         dkms_package = neutron.determine_dkms_package()
-        self.assertEquals(dkms_package, [])
+        self.assertEqual(dkms_package, [])
 
     def test_quantum_plugins(self):
         self.config.return_value = 'foo'
         plugins = neutron.quantum_plugins()
-        self.assertEquals(plugins['ovs']['services'],
+        self.assertEqual(plugins['ovs']['services'],
                           ['quantum-plugin-openvswitch-agent'])
-        self.assertEquals(plugins['nvp']['services'], [])
+        self.assertEqual(plugins['nvp']['services'], [])
 
     def test_neutron_plugins_preicehouse(self):
         self.config.return_value = 'foo'
         self.os_release.return_value = 'havana'
         plugins = neutron.neutron_plugins()
-        self.assertEquals(plugins['ovs']['config'],
+        self.assertEqual(plugins['ovs']['config'],
                           '/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini')
-        self.assertEquals(plugins['nvp']['services'], [])
+        self.assertEqual(plugins['nvp']['services'], [])
 
     def test_neutron_plugins(self):
         self.config.return_value = 'foo'
         self.os_release.return_value = 'icehouse'
         plugins = neutron.neutron_plugins()
-        self.assertEquals(plugins['ovs']['config'],
+        self.assertEqual(plugins['ovs']['config'],
                           '/etc/neutron/plugins/ml2/ml2_conf.ini')
-        self.assertEquals(plugins['nvp']['config'],
+        self.assertEqual(plugins['nvp']['config'],
                           '/etc/neutron/plugins/vmware/nsx.ini')
         self.assertTrue('neutron-plugin-vmware' in
                         plugins['nvp']['server_packages'])
-        self.assertEquals(plugins['n1kv']['config'],
+        self.assertEqual(plugins['n1kv']['config'],
                           '/etc/neutron/plugins/cisco/cisco_plugins.ini')
-        self.assertEquals(plugins['Calico']['config'],
+        self.assertEqual(plugins['Calico']['config'],
                           '/etc/neutron/plugins/ml2/ml2_conf.ini')
-        self.assertEquals(plugins['plumgrid']['config'],
+        self.assertEqual(plugins['plumgrid']['config'],
                           '/etc/neutron/plugins/plumgrid/plumgrid.ini')
-        self.assertEquals(plugins['midonet']['config'],
+        self.assertEqual(plugins['midonet']['config'],
                           '/etc/neutron/plugins/midonet/midonet.ini')
 
-        self.assertEquals(plugins['nvp']['services'], [])
-        self.assertEquals(plugins['nsx'], plugins['nvp'])
+        self.assertEqual(plugins['nvp']['services'], [])
+        self.assertEqual(plugins['nsx'], plugins['nvp'])
 
         self.os_release.return_value = 'kilo'
         plugins = neutron.neutron_plugins()
-        self.assertEquals(plugins['midonet']['driver'],
+        self.assertEqual(plugins['midonet']['driver'],
                           'neutron.plugins.midonet.plugin.MidonetPluginV2')
-        self.assertEquals(plugins['nsx']['config'],
+        self.assertEqual(plugins['nsx']['config'],
                           '/etc/neutron/plugins/vmware/nsx.ini')
 
         self.os_release.return_value = 'liberty'
         self.config.return_value = 'mem-1.9'
         plugins = neutron.neutron_plugins()
-        self.assertEquals(plugins['midonet']['driver'],
+        self.assertEqual(plugins['midonet']['driver'],
                           'midonet.neutron.plugin_v1.MidonetPluginV2')
         self.assertTrue('python-networking-midonet' in
                         plugins['midonet']['server_packages'])
@@ -100,7 +100,7 @@ class NeutronTests(unittest.TestCase):
         self.os_release.return_value = 'mitaka'
         self.config.return_value = 'mem-1.9'
         plugins = neutron.neutron_plugins()
-        self.assertEquals(plugins['nsx']['config'],
+        self.assertEqual(plugins['nsx']['config'],
                           '/etc/neutron/nsx.ini')
         self.assertTrue('python-vmware-nsx' in
                         plugins['nsx']['server_packages'])
@@ -110,7 +110,7 @@ class NeutronTests(unittest.TestCase):
         self.config.return_value = 'foo'
         _network_manager.return_value = 'quantum'
         plugins = neutron.neutron_plugin_attribute('ovs', 'services')
-        self.assertEquals(plugins, ['quantum-plugin-openvswitch-agent'])
+        self.assertEqual(plugins, ['quantum-plugin-openvswitch-agent'])
 
     @patch.object(neutron, 'network_manager')
     def test_neutron_plugin_attribute_neutron(self, _network_manager):
@@ -118,7 +118,7 @@ class NeutronTests(unittest.TestCase):
         self.os_release.return_value = 'icehouse'
         _network_manager.return_value = 'neutron'
         plugins = neutron.neutron_plugin_attribute('ovs', 'services')
-        self.assertEquals(plugins, ['neutron-plugin-openvswitch-agent'])
+        self.assertEqual(plugins, ['neutron-plugin-openvswitch-agent'])
 
     @patch.object(neutron, 'network_manager')
     def test_neutron_plugin_attribute_foo(self, _network_manager):
@@ -136,7 +136,7 @@ class NeutronTests(unittest.TestCase):
         self.config.return_value = 'foo'
         _network_manager.return_value = 'quantum'
         plugins = neutron.neutron_plugin_attribute('ovs', 'foo')
-        self.assertEquals(plugins, None)
+        self.assertEqual(plugins, None)
 
     def test_network_manager_essex(self):
         essex_cases = {
@@ -161,7 +161,7 @@ class NeutronTests(unittest.TestCase):
         for nwmanager in folsom_cases:
             self.config.return_value = nwmanager
             renamed_manager = neutron.network_manager()
-            self.assertEquals(renamed_manager, folsom_cases[nwmanager])
+            self.assertEqual(renamed_manager, folsom_cases[nwmanager])
 
     def test_network_manager_grizzly(self):
         grizzly_cases = {
@@ -173,7 +173,7 @@ class NeutronTests(unittest.TestCase):
         for nwmanager in grizzly_cases:
             self.config.return_value = nwmanager
             renamed_manager = neutron.network_manager()
-            self.assertEquals(renamed_manager, grizzly_cases[nwmanager])
+            self.assertEqual(renamed_manager, grizzly_cases[nwmanager])
 
     def test_network_manager_havana(self):
         havana_cases = {
@@ -185,7 +185,7 @@ class NeutronTests(unittest.TestCase):
         for nwmanager in havana_cases:
             self.config.return_value = nwmanager
             renamed_manager = neutron.network_manager()
-            self.assertEquals(renamed_manager, havana_cases[nwmanager])
+            self.assertEqual(renamed_manager, havana_cases[nwmanager])
 
     def test_network_manager_icehouse(self):
         icehouse_cases = {
@@ -197,7 +197,7 @@ class NeutronTests(unittest.TestCase):
         for nwmanager in icehouse_cases:
             self.config.return_value = nwmanager
             renamed_manager = neutron.network_manager()
-            self.assertEquals(renamed_manager, icehouse_cases[nwmanager])
+            self.assertEqual(renamed_manager, icehouse_cases[nwmanager])
 
     def test_parse_bridge_mappings(self):
         ret = neutron.parse_bridge_mappings(None)

--- a/tests/contrib/openstack/test_openstack_utils.py
+++ b/tests/contrib/openstack/test_openstack_utils.py
@@ -187,7 +187,7 @@ class OpenStackHelpersTestCase(TestCase):
         def _filter_missing_packages(pkgs):
             return [x for x in pkgs if x in ['cinder-common']]
         mock_filter.side_effect = _filter_missing_packages
-        self.assertEquals(
+        self.assertEqual(
             openstack.get_installed_semantic_versioned_packages(),
             ['cinder-common'])
 
@@ -197,41 +197,41 @@ class OpenStackHelpersTestCase(TestCase):
         mocked_lsb.return_value = FAKE_RELEASE
 
         # the openstack release shipped with respective ubuntu/lsb release.
-        self.assertEquals(openstack.get_os_codename_install_source('distro'),
+        self.assertEqual(openstack.get_os_codename_install_source('distro'),
                           'essex')
         # proposed pocket
-        self.assertEquals(openstack.get_os_codename_install_source(
+        self.assertEqual(openstack.get_os_codename_install_source(
             'distro-proposed'),
             'essex')
-        self.assertEquals(openstack.get_os_codename_install_source(
+        self.assertEqual(openstack.get_os_codename_install_source(
             'proposed'),
             'essex')
 
         # various cloud archive pockets
         src = 'cloud:precise-grizzly'
-        self.assertEquals(openstack.get_os_codename_install_source(src),
+        self.assertEqual(openstack.get_os_codename_install_source(src),
                           'grizzly')
         src = 'cloud:precise-grizzly/proposed'
-        self.assertEquals(openstack.get_os_codename_install_source(src),
+        self.assertEqual(openstack.get_os_codename_install_source(src),
                           'grizzly')
 
         # ppas and full repo urls.
         src = 'ppa:openstack-ubuntu-testing/havana-trunk-testing'
-        self.assertEquals(openstack.get_os_codename_install_source(src),
+        self.assertEqual(openstack.get_os_codename_install_source(src),
                           'havana')
         src = ('deb http://ubuntu-cloud.archive.canonical.com/ubuntu '
                'precise-havana main')
-        self.assertEquals(openstack.get_os_codename_install_source(src),
+        self.assertEqual(openstack.get_os_codename_install_source(src),
                           'havana')
-        self.assertEquals(openstack.get_os_codename_install_source(None),
+        self.assertEqual(openstack.get_os_codename_install_source(None),
                           '')
 
         # check that bare ubuntu releases end up as the release.
-        self.assertEquals(openstack.get_os_codename_install_source('essex'),
+        self.assertEqual(openstack.get_os_codename_install_source('essex'),
                           'essex')
-        self.assertEquals(openstack.get_os_codename_install_source('ussuri'),
+        self.assertEqual(openstack.get_os_codename_install_source('ussuri'),
                           'ussuri')
-        self.assertEquals(openstack.get_os_codename_install_source('queens'),
+        self.assertEqual(openstack.get_os_codename_install_source('queens'),
                           'queens')
 
     @patch.object(openstack, 'get_os_version_codename')
@@ -257,7 +257,7 @@ class OpenStackHelpersTestCase(TestCase):
 
     def test_os_codename_from_version(self):
         """Test mapping OpenStack numerical versions to code name"""
-        self.assertEquals(openstack.get_os_codename_version('2013.1'),
+        self.assertEqual(openstack.get_os_codename_version('2013.1'),
                           'grizzly')
 
     @patch('charmhelpers.contrib.openstack.utils.error_out')
@@ -270,7 +270,7 @@ class OpenStackHelpersTestCase(TestCase):
 
     def test_os_version_from_codename(self):
         """Test mapping a OpenStack codename to numerical version"""
-        self.assertEquals(openstack.get_os_version_codename('folsom'),
+        self.assertEqual(openstack.get_os_version_codename('folsom'),
                           '2012.2')
 
     @patch('charmhelpers.contrib.openstack.utils.error_out')
@@ -284,24 +284,24 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.get_os_version_codename('foo', raise_exception=True)
             raise Exception("Failed call should have raised ValueError")
         except ValueError as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Could not derive OpenStack version for codename: foo")
 
     def test_get_swift_codename_single_version_kilo(self):
-        self.assertEquals(openstack.get_swift_codename('2.2.2'), 'kilo')
+        self.assertEqual(openstack.get_swift_codename('2.2.2'), 'kilo')
 
     def test_get_swift_codename_multiple_versions_liberty(self):
         with patch('subprocess.check_output') as _subp:
             _subp.return_value = b"... trusty-updates/liberty/main ..."
-            self.assertEquals(openstack.get_swift_codename('2.5.0'), 'liberty')
+            self.assertEqual(openstack.get_swift_codename('2.5.0'), 'liberty')
 
     def test_get_swift_codename_multiple_versions_mitaka(self):
         with patch('subprocess.check_output') as _subp:
             _subp.return_value = b"... trusty-updates/mitaka/main ..."
-            self.assertEquals(openstack.get_swift_codename('2.5.0'), 'mitaka')
+            self.assertEqual(openstack.get_swift_codename('2.5.0'), 'mitaka')
 
     def test_get_swift_codename_none(self):
-        self.assertEquals(openstack.get_swift_codename('1.2.3'), None)
+        self.assertEqual(openstack.get_swift_codename('1.2.3'), None)
 
     @patch("charmhelpers.core.hookenv.cache", new={})
     @patch.object(openstack, 'openstack_release')
@@ -311,7 +311,7 @@ class OpenStackHelpersTestCase(TestCase):
                                                  mock_filter_installed_packages,
                                                  mock_openstack_release):
         mock_openstack_release.return_value = {}
-        self.assertEquals(
+        self.assertEqual(
             openstack.get_installed_os_version(), None)
 
     @patch("charmhelpers.core.hookenv.cache", new={})
@@ -322,7 +322,7 @@ class OpenStackHelpersTestCase(TestCase):
                                                    mock_filter_installed_packages,
                                                    mock_openstack_release):
         mock_openstack_release.return_value = {'OPENSTACK_CODENAME': 'wallaby'}
-        self.assertEquals(
+        self.assertEqual(
             openstack.get_installed_os_version(), 'wallaby')
 
     @patch.object(openstack, 'get_installed_os_version')
@@ -340,7 +340,7 @@ class OpenStackHelpersTestCase(TestCase):
                     continue
                 if 'pkg_vers' not in vers:
                     continue
-                self.assertEquals(openstack.get_os_codename_package(pkg),
+                self.assertEqual(openstack.get_os_codename_package(pkg),
                                   vers['os_release'])
 
     @patch.object(openstack, 'get_installed_os_version')
@@ -389,7 +389,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_get_installed_os_version.return_value = None
         with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
-            self.assertEquals(
+            self.assertEqual(
                 None,
                 openstack.get_os_codename_package('foo', fatal=False)
             )
@@ -423,7 +423,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_get_installed_os_version.return_value = None
         with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
-            self.assertEquals(
+            self.assertEqual(
                 None,
                 openstack.get_os_codename_package('cinder-common', fatal=False)
             )
@@ -444,7 +444,7 @@ class OpenStackHelpersTestCase(TestCase):
                     continue
                 if 'pkg_vers' not in vers:
                     continue
-                self.assertEquals(openstack.get_os_version_package(pkg),
+                self.assertEqual(openstack.get_os_version_package(pkg),
                                   vers['os_version'])
 
     @patch.object(openstack, 'get_installed_os_version')
@@ -478,7 +478,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_get_installed_os_version.return_value = None
         with patch.object(openstack, 'apt_cache') as cache:
             cache.return_value = self._apt_cache()
-            self.assertEquals(
+            self.assertEqual(
                 None,
                 openstack.get_os_version_package('foo', fatal=False)
             )
@@ -492,7 +492,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_lsb_release.return_value = {
             'DISTRIB_CODENAME': 'bionic',
         }
-        self.assertEquals('folsom', openstack.os_release('nova-common'))
+        self.assertEqual('folsom', openstack.os_release('nova-common'))
 
     @patch.object(openstack, 'lsb_release')
     def test_os_release_cached(self, mock_lsb_release):
@@ -500,7 +500,7 @@ class OpenStackHelpersTestCase(TestCase):
         mock_lsb_release.return_value = {
             'DISTRIB_CODENAME': 'bionic',
         }
-        self.assertEquals('foo', openstack.os_release('nova-common'))
+        self.assertEqual('foo', openstack.os_release('nova-common'))
 
     @patch.object(openstack, 'juju_log')
     @patch('sys.exit')
@@ -774,12 +774,12 @@ class OpenStackHelpersTestCase(TestCase):
         ensure_loopback.return_value = '/tmp/cinder.img'
         result = openstack.ensure_block_device('/tmp/cinder.img')
         ensure_loopback.assert_called_with('/tmp/cinder.img', defsize)
-        self.assertEquals(result, '/tmp/cinder.img')
+        self.assertEqual(result, '/tmp/cinder.img')
 
         ensure_loopback.return_value = '/tmp/cinder-2.img'
         result = openstack.ensure_block_device('/tmp/cinder-2.img|15G')
         ensure_loopback.assert_called_with('/tmp/cinder-2.img', '15G')
-        self.assertEquals(result, '/tmp/cinder-2.img')
+        self.assertEqual(result, '/tmp/cinder-2.img')
 
     @patch.object(openstack, 'is_block_device')
     def test_ensure_standard_block_device(self, is_bd):
@@ -1285,8 +1285,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             services)
-        self.assertEquals(state, None)
-        self.assertEquals(message, None)
+        self.assertEqual(state, None)
+        self.assertEqual(message, None)
 
     @patch('charmhelpers.contrib.openstack.utils.service_running')
     @patch('charmhelpers.contrib.openstack.utils.port_has_listener')
@@ -1298,8 +1298,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             services)
-        self.assertEquals(state, 'blocked')
-        self.assertEquals(
+        self.assertEqual(state, 'blocked')
+        self.assertEqual(
             message,
             "Services should be paused but these services running: identity")
 
@@ -1317,8 +1317,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             services)
-        self.assertEquals(state, None)
-        self.assertEquals(message, None)
+        self.assertEqual(state, None)
+        self.assertEqual(message, None)
 
     @patch('charmhelpers.contrib.openstack.utils.service_running')
     @patch('charmhelpers.contrib.openstack.utils.port_has_listener')
@@ -1334,8 +1334,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             services)
-        self.assertEquals(state, 'blocked')
-        self.assertEquals(
+        self.assertEqual(state, 'blocked')
+        self.assertEqual(
             message,
             "Services should be paused but these services running: identity")
 
@@ -1353,8 +1353,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             services)
-        self.assertEquals(state, 'blocked')
-        self.assertEquals(message,
+        self.assertEqual(state, 'blocked')
+        self.assertEqual(message,
                           'Services should be paused but these service:ports'
                           ' are open: database: [20]')
 
@@ -1368,8 +1368,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             ports=ports)
-        self.assertEquals(state, None)
-        self.assertEquals(state, None)
+        self.assertEqual(state, None)
+        self.assertEqual(state, None)
 
     @patch('charmhelpers.contrib.openstack.utils.service_running')
     @patch('charmhelpers.contrib.openstack.utils.port_has_listener')
@@ -1381,8 +1381,8 @@ class OpenStackHelpersTestCase(TestCase):
 
         state, message = openstack.check_actually_paused(
             ports=ports)
-        self.assertEquals(state, 'blocked')
-        self.assertEquals(message,
+        self.assertEqual(state, 'blocked')
+        self.assertEqual(message,
                           'Services should be paused but these ports '
                           'which should be closed, but are open: 60')
 
@@ -1430,10 +1430,10 @@ class OpenStackHelpersTestCase(TestCase):
         kv.get.return_value = True
         r = openstack.is_unit_paused_set()
         kv.get.assert_called_once_with('unit-paused')
-        self.assertEquals(r, True)
+        self.assertEqual(r, True)
         kv.get.return_value = False
         r = openstack.is_unit_paused_set()
-        self.assertEquals(r, False)
+        self.assertEqual(r, False)
 
     @patch('charmhelpers.contrib.openstack.utils.unitdata.HookData')
     def test_is_unit_upgrading_set(self, hook_data):
@@ -1441,10 +1441,10 @@ class OpenStackHelpersTestCase(TestCase):
         kv.get.return_value = True
         r = openstack.is_unit_upgrading_set()
         kv.get.assert_called_once_with('unit-upgrading')
-        self.assertEquals(r, True)
+        self.assertEqual(r, True)
         kv.get.return_value = False
         r = openstack.is_unit_upgrading_set()
-        self.assertEquals(r, False)
+        self.assertEqual(r, False)
 
     @patch.object(openstack, 'config')
     @patch.object(openstack, 'is_unit_paused_set')
@@ -1591,7 +1591,7 @@ class OpenStackHelpersTestCase(TestCase):
         service_pause.side_effect = [True, True]
         openstack.pause_unit(None, services=services)
         set_unit_paused.assert_called_once_with()
-        self.assertEquals(service_pause.call_count, 2)
+        self.assertEqual(service_pause.call_count, 2)
 
     @patch('charmhelpers.contrib.openstack.utils.service_pause')
     @patch('charmhelpers.contrib.openstack.utils.set_unit_paused')
@@ -1600,14 +1600,14 @@ class OpenStackHelpersTestCase(TestCase):
         service_pause.side_effect = [True, True]
         openstack.pause_unit(None, services=services)
         set_unit_paused.assert_called_once_with()
-        self.assertEquals(service_pause.call_count, 2)
+        self.assertEqual(service_pause.call_count, 2)
         # Fail the 2nd service
         service_pause.side_effect = [True, False]
         try:
             openstack.pause_unit(None, services=services)
             raise Exception("pause_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Couldn't pause: service2 didn't pause cleanly.")
 
     @patch('charmhelpers.contrib.openstack.utils.service_pause')
@@ -1627,7 +1627,7 @@ class OpenStackHelpersTestCase(TestCase):
                 None, services=services, charm_func=charm_func)
             raise Exception("pause_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Couldn't pause: Custom charm failed")
 
     @patch('charmhelpers.contrib.openstack.utils.service_pause')
@@ -1646,7 +1646,7 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.pause_unit(assess_status_func, services=services)
             raise Exception("pause_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Couldn't pause: assess_status_func failed")
 
     @patch('charmhelpers.contrib.openstack.utils.service_pause')
@@ -1667,7 +1667,7 @@ class OpenStackHelpersTestCase(TestCase):
         service_resume.side_effect = [True, True]
         openstack.resume_unit(None, services=services)
         clear_unit_paused.assert_called_once_with()
-        self.assertEquals(service_resume.call_count, 2)
+        self.assertEqual(service_resume.call_count, 2)
 
     @patch('charmhelpers.contrib.openstack.utils.service_resume')
     @patch('charmhelpers.contrib.openstack.utils.clear_unit_paused')
@@ -1677,14 +1677,14 @@ class OpenStackHelpersTestCase(TestCase):
         service_resume.side_effect = [True, True]
         openstack.resume_unit(None, services=services)
         clear_unit_paused.assert_called_once_with()
-        self.assertEquals(service_resume.call_count, 2)
+        self.assertEqual(service_resume.call_count, 2)
         # Fail the 2nd service
         service_resume.side_effect = [True, False]
         try:
             openstack.resume_unit(None, services=services)
             raise Exception("resume_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(
+            self.assertEqual(
                 e.args[0], "Couldn't resume: service2 didn't resume cleanly.")
 
     @patch('charmhelpers.contrib.openstack.utils.service_resume')
@@ -1704,7 +1704,7 @@ class OpenStackHelpersTestCase(TestCase):
                 None, services=services, charm_func=charm_func)
             raise Exception("resume_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Couldn't resume: Custom charm failed")
 
     @patch('charmhelpers.contrib.openstack.utils.service_resume')
@@ -1723,7 +1723,7 @@ class OpenStackHelpersTestCase(TestCase):
             openstack.resume_unit(assess_status_func, services=services)
             raise Exception("resume_unit should have raised Exception")
         except Exception as e:
-            self.assertEquals(e.args[0],
+            self.assertEqual(e.args[0],
                               "Couldn't resume: assess_status_func failed")
 
     @patch('charmhelpers.contrib.openstack.utils.status_set')
@@ -1734,14 +1734,14 @@ class OpenStackHelpersTestCase(TestCase):
         _determine_os_workload_status.return_value = ('active', 'fine')
         f = openstack.make_assess_status_func('one', 'two', three='three')
         r = f()
-        self.assertEquals(r, None)
+        self.assertEqual(r, None)
         _determine_os_workload_status.assert_called_once_with(
             'one', 'two', three='three')
         status_set.assert_called_once_with('active', 'fine')
         # return something other than 'active' or 'maintenance'
         _determine_os_workload_status.return_value = ('broken', 'damaged')
         r = f()
-        self.assertEquals(r, 'damaged')
+        self.assertEqual(r, 'damaged')
 
     # TODO(ajkavanagh) -- there should be a test for
     # _determine_os_workload_status() as the policyd override code has changed
@@ -1758,12 +1758,12 @@ class OpenStackHelpersTestCase(TestCase):
         # test with pause: restart_on_change_helper should not be called.
         is_unit_paused_set.return_value = True
         test_func()
-        self.assertEquals(restart_on_change_helper.call_count, 0)
+        self.assertEqual(restart_on_change_helper.call_count, 0)
 
         # test without pause: restart_on_change_helper should be called.
         is_unit_paused_set.return_value = False
         test_func()
-        self.assertEquals(restart_on_change_helper.call_count, 1)
+        self.assertEqual(restart_on_change_helper.call_count, 1)
 
     @patch.object(openstack, 'restart_on_change_helper')
     @patch.object(openstack, 'is_unit_paused_set')
@@ -1783,7 +1783,7 @@ class OpenStackHelpersTestCase(TestCase):
         self.assertFalse(mock_test.called_set)
         is_unit_paused_set.return_value = False
         test_func()
-        self.assertEquals(restart_on_change_helper.call_count, 1)
+        self.assertEqual(restart_on_change_helper.call_count, 1)
         self.assertTrue(mock_test.called_set)
 
     @patch.object(openstack, 'juju_log')

--- a/tests/contrib/openstack/test_os_contexts.py
+++ b/tests/contrib/openstack/test_os_contexts.py
@@ -822,7 +822,7 @@ class ContextTests(unittest.TestCase):
             'database_password': 'foo',
             'database_type': 'mysql+pymysql',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'config')
     def test_keystone_audit_middleware_ctxt_enabled(self, mock_config):
@@ -858,7 +858,7 @@ class ContextTests(unittest.TestCase):
         self.config.side_effect = fake_config(SHARED_DB_CONFIG)
         shared_db = context.SharedDBContext()
         result = shared_db()
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
         self.relation_set.assert_called_with(
             relation_settings={
                 'hostname': '10.5.5.1'})
@@ -882,7 +882,7 @@ class ContextTests(unittest.TestCase):
             'database_password': 'foo',
             'database_type': 'mysql+pymysql',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'get_os_codename_install_source')
     def test_shared_db_context_explicit_relation_id(self, os_codename):
@@ -902,7 +902,7 @@ class ContextTests(unittest.TestCase):
             'database_password': 'flump',
             'database_type': 'mysql+pymysql',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'get_os_codename_install_source')
     def test_shared_db_context_with_port(self, os_codename):
@@ -922,7 +922,7 @@ class ContextTests(unittest.TestCase):
             'database_type': 'mysql+pymysql',
             'database_port': 3306,
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch('os.path.exists')
     @patch('builtins.open')
@@ -942,17 +942,17 @@ class ContextTests(unittest.TestCase):
         ]
         for f in files:
             self.assertIn(f, _open.call_args_list)
-        self.assertEquals(db_ssl_ctxt, expected)
+        self.assertEqual(db_ssl_ctxt, expected)
         decode = [
             call(SHARED_DB_RELATION_SSL['ssl_ca']),
             call(SHARED_DB_RELATION_SSL['ssl_cert']),
             call(SHARED_DB_RELATION_SSL['ssl_key'])
         ]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        self.assertEqual(decode, self.b64decode.call_args_list)
 
     def test_db_ssl_nossldir(self):
         db_ssl_ctxt = context.db_ssl(SHARED_DB_RELATION_SSL, {}, None)
-        self.assertEquals(db_ssl_ctxt, {})
+        self.assertEqual(db_ssl_ctxt, {})
 
     @patch.object(context, 'get_os_codename_install_source')
     def test_shared_db_context_with_missing_relation(self, os_codename):
@@ -965,7 +965,7 @@ class ContextTests(unittest.TestCase):
         self.config.return_value = SHARED_DB_CONFIG
         shared_db = context.SharedDBContext()
         result = shared_db()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     def test_shared_db_context_with_missing_config(self):
         '''Test shared-db context missing relation data'''
@@ -990,7 +990,7 @@ class ContextTests(unittest.TestCase):
         self.assertIn(
             call(rid='foo:0', unit='foo/0'),
             self.relation_get.call_args_list)
-        self.assertEquals(
+        self.assertEqual(
             result, {'database': 'quantum',
                      'database_user': 'quantum',
                      'database_password': 'bar2',
@@ -1009,7 +1009,7 @@ class ContextTests(unittest.TestCase):
         self.assertIn(
             call(rid='foo:0', unit='foo/0'),
             self.relation_get.call_args_list)
-        self.assertEquals(
+        self.assertEqual(
             result, {'database': 'quantum',
                      'database_user': 'quantum',
                      'database_password': 'bar2',
@@ -1030,7 +1030,7 @@ class ContextTests(unittest.TestCase):
         self.assertIn(
             call(rid='foo:0', unit='foo/0'),
             self.relation_get.call_args_list)
-        self.assertEquals(
+        self.assertEqual(
             result, {'database': 'quantum',
                      'database_user': 'quantum',
                      'database_password': 'bar2',
@@ -1051,7 +1051,7 @@ class ContextTests(unittest.TestCase):
             'database_password': 'foo',
             'database_type': 'postgresql',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_postgresql_db_context_with_missing_relation(self):
         '''Test postgresql-db context missing relation data'''
@@ -1062,7 +1062,7 @@ class ContextTests(unittest.TestCase):
         self.config.return_value = POSTGRESQL_DB_CONFIG
         postgresql_db = context.PostgresqlDBContext()
         result = postgresql_db()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     def test_postgresql_db_context_with_missing_config(self):
         '''Test postgresql-db context missing relation data'''
@@ -1079,7 +1079,7 @@ class ContextTests(unittest.TestCase):
         '''Test postgresql-db context with object parameters'''
         postgresql_db = context.PostgresqlDBContext(database='quantum')
         result = postgresql_db()
-        self.assertEquals(result['database'], 'quantum')
+        self.assertEqual(result['database'], 'quantum')
 
     def test_oslo_db_context_unset_values(self):
         '''Test oslo-db context with unset config values'''
@@ -1152,7 +1152,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_identity_credentials_context_with_data(self):
         '''Test identity-credentials context with all required data'''
@@ -1174,7 +1174,7 @@ class ContextTests(unittest.TestCase):
             'service_protocol': 'https',
             'api_version': '2.0',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1211,7 +1211,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1245,7 +1245,7 @@ class ContextTests(unittest.TestCase):
         }
         self.assertTrue(self.mkdir.called)
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1276,7 +1276,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1307,7 +1307,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1344,7 +1344,7 @@ class ContextTests(unittest.TestCase):
             'internal_auth_url': 'http://keystoneinternal.local:80/keystone',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1387,7 +1387,7 @@ class ContextTests(unittest.TestCase):
             'internal_auth_url': 'http://keystoneinternal.local:80/keystone',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1422,7 +1422,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '3',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1454,7 +1454,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_identity_credentials_context_with_data_versioned(self):
         '''Test identity-credentials context with api version supplied from keystone'''
@@ -1478,7 +1478,7 @@ class ContextTests(unittest.TestCase):
             'service_type': 'volume',
             'api_version': '3',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1511,7 +1511,7 @@ class ContextTests(unittest.TestCase):
             'api_version': '2.0',
         }
         result.pop('keystone_authtoken')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'filter_installed_packages', return_value=[])
     @patch.object(context, 'os_release', return_value='rocky')
@@ -1523,7 +1523,7 @@ class ContextTests(unittest.TestCase):
         self.relation_get.side_effect = relation.get
         identity_service = context.IdentityServiceContext()
         result = identity_service()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     @patch.object(context, 'filter_installed_packages')
     @patch.object(context, 'os_release')
@@ -1554,7 +1554,7 @@ class ContextTests(unittest.TestCase):
             ('service_type', 'volume'),
         ))
 
-        self.assertEquals(keystone_authtoken, expected)
+        self.assertEqual(keystone_authtoken, expected)
 
     @patch.object(context, 'filter_installed_packages')
     @patch.object(context, 'os_release')
@@ -1587,7 +1587,7 @@ class ContextTests(unittest.TestCase):
             ('service_type', 'volume'),
         ))
 
-        self.assertEquals(keystone_authtoken, expected)
+        self.assertEqual(keystone_authtoken, expected)
 
     def test_amqp_context_with_data(self):
         '''Test amqp context with all required data'''
@@ -1604,7 +1604,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_virtual_host': 'foo',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_explicit_relation_id(self):
         '''Test amqp context setting the relation_id'''
@@ -1622,7 +1622,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_virtual_host': 'foo',
             'transport_url': 'rabbit://adam:flump@rabbitalthost1:5672/foo'
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_data_altname(self):
         '''Test amqp context with alternative relation name'''
@@ -1641,7 +1641,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_virtual_host': 'foo',
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch('builtins.open')
     def test_amqp_context_with_data_ssl(self, _open):
@@ -1664,8 +1664,8 @@ class ContextTests(unittest.TestCase):
             'transport_url': 'rabbit://adam:foobar@rabbithost:5671/foo'
         }
         _open.assert_called_once_with(ssl_dir + '/rabbit-client-ca.pem', 'wb')
-        self.assertEquals(result, expected)
-        self.assertEquals([call(AMQP_RELATION_WITH_SSL['ssl_ca'])],
+        self.assertEqual(result, expected)
+        self.assertEqual([call(AMQP_RELATION_WITH_SSL['ssl_ca'])],
                           self.b64decode.call_args_list)
 
     def test_amqp_context_with_data_ssl_noca(self):
@@ -1686,7 +1686,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_ha_queues': True,
             'transport_url': 'rabbit://adam:foobar@rabbithost:5671/foo'
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_data_clustered(self):
         '''Test amqp context with all required data with clustered rabbit'''
@@ -1706,7 +1706,7 @@ class ContextTests(unittest.TestCase):
             'rabbitmq_virtual_host': 'foo',
             'transport_url': 'rabbit://adam:foobar@10.0.0.1:5672/foo'
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_data_active_active(self):
         '''Test amqp context with required data with active/active rabbit'''
@@ -1728,7 +1728,7 @@ class ContextTests(unittest.TestCase):
             'transport_url': ('rabbit://adam:foobar@rabbithost1:5672'
                               ',adam:foobar@rabbithost2:5672/foo')
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_missing_relation(self):
         '''Test amqp context missing relation data'''
@@ -1739,7 +1739,7 @@ class ContextTests(unittest.TestCase):
         self.config.return_value = AMQP_CONFIG
         amqp = context.AMQPContext()
         result = amqp()
-        self.assertEquals({}, result)
+        self.assertEqual({}, result)
 
     def test_amqp_context_with_missing_config(self):
         '''Test amqp context missing relation data'''
@@ -1773,7 +1773,7 @@ class ContextTests(unittest.TestCase):
             'transport_url': ('rabbit://adam:foobar@[2001:db8:1::1]:5672'
                               ',adam:foobar@[2001:db8:1::1]:5672/foo')
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_oslo_messaging(self):
         """Test amqp context with oslo-messaging-flags option"""
@@ -1797,7 +1797,7 @@ class ContextTests(unittest.TestCase):
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_notification_format(self):
         """Test amqp context with notification_format option"""
@@ -1817,7 +1817,7 @@ class ContextTests(unittest.TestCase):
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_notification_topics(self):
         """Test amqp context with notification_topics option"""
@@ -1837,7 +1837,7 @@ class ContextTests(unittest.TestCase):
             'transport_url': 'rabbit://adam:foobar@rabbithost:5672/foo'
         }
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_amqp_context_with_notifications_to_logs(self):
         """Test amqp context with send_notifications_to_logs"""
@@ -1857,7 +1857,7 @@ class ContextTests(unittest.TestCase):
             'send_notifications_to_logs': True,
         }
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_libvirt_config_flags(self):
         self.config.side_effect = fake_config({
@@ -1865,7 +1865,7 @@ class ContextTests(unittest.TestCase):
         })
 
         results = context.LibvirtConfigFlagsContext()()
-        self.assertEquals(results, {
+        self.assertEqual(results, {
             'libvirt_flags': {
                 'chap_auth': 'False',
                 'iscsi_use_multipath': 'True'
@@ -1878,7 +1878,7 @@ class ContextTests(unittest.TestCase):
         self.relation_ids.side_effect = relation.get
         ceph = context.CephContext()
         result = ceph()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     def test_ceph_rel_with_no_units(self):
         '''Test ceph context with missing related units'''
@@ -1887,7 +1887,7 @@ class ContextTests(unittest.TestCase):
         self.related_units.side_effect = []
         ceph = context.CephContext()
         result = ceph()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     @patch.object(context, 'config')
     @patch('os.path.isdir')
@@ -1915,7 +1915,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
 
     @patch('os.mkdir')
@@ -1932,7 +1932,7 @@ class ContextTests(unittest.TestCase):
         self.related_units.side_effect = relation.relation_units
         ceph = context.CephContext()
         result = ceph()
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
         self.assertFalse(ensure_packages.called)
 
     @patch.object(context, 'config')
@@ -1965,7 +1965,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch.object(context, 'config')
     @patch('os.path.isdir')
@@ -1994,7 +1994,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2025,7 +2025,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2056,7 +2056,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2088,7 +2088,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2119,7 +2119,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2151,7 +2151,7 @@ class ContextTests(unittest.TestCase):
             'use_syslog': 'true',
             'rbd_features': '1',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2188,7 +2188,7 @@ class ContextTests(unittest.TestCase):
             'rbd_features': '1',
             'rbd_default_data_pool': 'testing-foo',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2224,7 +2224,7 @@ class ContextTests(unittest.TestCase):
             'rbd_features': '1',
             'rbd_default_data_pool': 'glance',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2260,7 +2260,7 @@ class ContextTests(unittest.TestCase):
             'rbd_features': '1',
             'rbd_default_data_pool': 'nova',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2367,7 +2367,7 @@ class ContextTests(unittest.TestCase):
             'key': 'bar',
             'use_syslog': 'true',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         ensure_packages.assert_called_with(['ceph-common'])
         mkdir.assert_called_with('/etc/ceph')
 
@@ -2420,9 +2420,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
@@ -2483,9 +2483,9 @@ class ContextTests(unittest.TestCase):
             'haproxy_server_timeout': 50000,
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', None),
                                                call('internal', None),
@@ -2574,9 +2574,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
@@ -2649,9 +2649,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('public', None),
                                                call('cluster')])
@@ -2714,9 +2714,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', None),
                                                call('internal', None),
@@ -2727,7 +2727,7 @@ class ContextTests(unittest.TestCase):
         '''Test haproxy context with missing relation data'''
         self.relation_ids.return_value = []
         haproxy = context.HAProxyContext()
-        self.assertEquals({}, haproxy())
+        self.assertEqual({}, haproxy())
 
     @patch('charmhelpers.contrib.openstack.context.local_address')
     @patch('charmhelpers.contrib.openstack.context.local_unit')
@@ -2752,7 +2752,7 @@ class ContextTests(unittest.TestCase):
         self.related_units.side_effect = relation.relation_units
         self.config.return_value = False
         haproxy = context.HAProxyContext()
-        self.assertEquals({}, haproxy())
+        self.assertEqual({}, haproxy())
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
                                                call('public', False),
@@ -2786,7 +2786,7 @@ class ContextTests(unittest.TestCase):
         c.data['os-public-network'] = '192.168.30.0/24'
         self.config.side_effect = c
         haproxy = context.HAProxyContext()
-        self.assertEquals({}, haproxy())
+        self.assertEqual({}, haproxy())
         self.get_relation_ip.assert_has_calls([call('admin', '192.168.10.0/24'),
                                                call('internal', '192.168.20.0/24'),
                                                call('public', '192.168.30.0/24'),
@@ -2835,9 +2835,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
             'stat_password': 'testpassword',
         }
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
@@ -2898,9 +2898,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
@@ -2962,9 +2962,9 @@ class ContextTests(unittest.TestCase):
             'stat_port': '8888',
         }
         # the context gets generated.
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
         # and /etc/default/haproxy is updated.
-        self.assertEquals(_file.write.call_args_list,
+        self.assertEqual(_file.write.call_args_list,
                           [call('ENABLED=1\n')])
         self.get_relation_ip.assert_has_calls([call('admin', False),
                                                call('internal', False),
@@ -2976,7 +2976,7 @@ class ContextTests(unittest.TestCase):
         '''Test apache2 https when no https data available'''
         apache = context.ApacheSSLContext()
         self.https.return_value = False
-        self.assertEquals({}, apache())
+        self.assertEqual({}, apache())
 
     def _https_context_setup(self):
         '''
@@ -3021,7 +3021,7 @@ class ContextTests(unittest.TestCase):
 
         apache, ex = self._https_context_setup()
 
-        self.assertEquals(ex, apache())
+        self.assertEqual(ex, apache())
 
         apache.configure_cert.assert_has_calls([
             call('10.5.1.1'),
@@ -3039,7 +3039,7 @@ class ContextTests(unittest.TestCase):
 
         apache, ex = self._https_context_setup()
 
-        self.assertEquals(ex, apache())
+        self.assertEqual(ex, apache())
 
         self.assertFalse(apache.configure_cert.called)
         self.assertFalse(apache.configure_ca.called)
@@ -3053,7 +3053,7 @@ class ContextTests(unittest.TestCase):
         self.resolve_address.side_effect = (
             '10.5.1.4', '10.5.2.5', '10.5.3.6')
 
-        self.assertEquals(ex, apache())
+        self.assertEqual(ex, apache())
 
         apache.configure_cert.assert_has_calls([
             call('10.5.1.4'),
@@ -3097,7 +3097,7 @@ class ContextTests(unittest.TestCase):
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        self.assertEqual(decode, self.b64decode.call_args_list)
 
     def test_https_configure_cert_deprecated(self):
         # Test apache2 properly installs certs and keys to disk
@@ -3118,7 +3118,7 @@ class ContextTests(unittest.TestCase):
         self.write_file.assert_has_calls(files)
         # appropriate bits are b64decoded.
         decode = [call('SSL_CERT'), call('SSL_KEY')]
-        self.assertEquals(decode, self.b64decode.call_args_list)
+        self.assertEqual(decode, self.b64decode.call_args_list)
 
     def test_https_canonical_names(self):
         rel = FakeRelation(IDENTITY_RELATION_SINGLE_CERT)
@@ -3126,24 +3126,24 @@ class ContextTests(unittest.TestCase):
         self.related_units.side_effect = rel.relation_units
         self.relation_get.side_effect = rel.get
         apache = context.ApacheSSLContext()
-        self.assertEquals(apache.canonical_names(), ['cinderhost1'])
+        self.assertEqual(apache.canonical_names(), ['cinderhost1'])
         rel.relation_data = IDENTITY_RELATION_MULTIPLE_CERT
-        self.assertEquals(apache.canonical_names(),
+        self.assertEqual(apache.canonical_names(),
                           sorted(['cinderhost1-adm-network',
                                   'cinderhost1-int-network',
                                   'cinderhost1-pub-network']))
         rel.relation_data = IDENTITY_RELATION_NO_CERT
-        self.assertEquals(apache.canonical_names(), [])
+        self.assertEqual(apache.canonical_names(), [])
 
     def test_image_service_context_missing_data(self):
         '''Test image-service with missing relation and missing data'''
         image_service = context.ImageServiceContext()
         self.relation_ids.return_value = []
-        self.assertEquals({}, image_service())
+        self.assertEqual({}, image_service())
         self.relation_ids.return_value = ['image-service:0']
         self.related_units.return_value = ['glance/0']
         self.relation_get.return_value = None
-        self.assertEquals({}, image_service())
+        self.assertEqual({}, image_service())
 
     def test_image_service_context_with_data(self):
         '''Test image-service with required data'''
@@ -3151,7 +3151,7 @@ class ContextTests(unittest.TestCase):
         self.relation_ids.return_value = ['image-service:0']
         self.related_units.return_value = ['glance/0']
         self.relation_get.return_value = 'http://glancehost:9292'
-        self.assertEquals({'glance_api_servers': 'http://glancehost:9292'},
+        self.assertEqual({'glance_api_servers': 'http://glancehost:9292'},
                           image_service())
 
     @patch.object(context, 'neutron_plugin_attribute')
@@ -3159,10 +3159,10 @@ class ContextTests(unittest.TestCase):
         '''Test neutron context base properties'''
         neutron = context.NeutronContext()
         attr.return_value = 'quantum-plugin-package'
-        self.assertEquals(None, neutron.plugin)
-        self.assertEquals(None, neutron.network_manager)
-        self.assertEquals(None, neutron.neutron_security_groups)
-        self.assertEquals('quantum-plugin-package', neutron.packages)
+        self.assertEqual(None, neutron.plugin)
+        self.assertEqual(None, neutron.network_manager)
+        self.assertEqual(None, neutron.neutron_security_groups)
+        self.assertEqual('quantum-plugin-package', neutron.packages)
 
     @patch.object(context, 'neutron_plugin_attribute')
     @patch.object(context, 'apt_install')
@@ -3183,7 +3183,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'ovs',
@@ -3198,7 +3198,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'nvp',
@@ -3215,7 +3215,7 @@ class ContextTests(unittest.TestCase):
         attr.return_value = 'some.quantum.driver.class'
         config.return_value = 'n1kv'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'n1kv',
             'neutron_security_groups': True,
@@ -3236,7 +3236,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'Calico',
@@ -3251,7 +3251,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'plumgrid',
@@ -3266,7 +3266,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'vsp',
@@ -3281,7 +3281,7 @@ class ContextTests(unittest.TestCase):
         sec_groups.__get__ = MagicMock(return_value=True)
         attr.return_value = 'some.quantum.driver.class'
         neutron = context.NeutronContext()
-        self.assertEquals({
+        self.assertEqual({
             'config': 'some.quantum.driver.class',
             'core_plugin': 'some.quantum.driver.class',
             'neutron_plugin': 'midonet',
@@ -3302,14 +3302,14 @@ class ContextTests(unittest.TestCase):
         mock_network_manager.__get__ = Mock(return_value='neutron')
 
         self.is_clustered.return_value = False
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'neutron_url': 'https://%s:9696' % (priv_addr)},
             neutron.neutron_ctxt()
         )
 
         self.is_clustered.return_value = True
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'neutron_url': 'https://%s:9696' % (vip)},
             neutron.neutron_ctxt()
@@ -3330,14 +3330,14 @@ class ContextTests(unittest.TestCase):
         mock_network_manager.__get__ = Mock(return_value='neutron')
 
         self.is_clustered.return_value = False
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'neutron_url': 'http://%s:9696' % (priv_addr)},
             neutron.neutron_ctxt()
         )
 
         self.is_clustered.return_value = True
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'neutron_url': 'http://%s:9696' % (vip)},
             neutron.neutron_ctxt()
@@ -3362,18 +3362,18 @@ class ContextTests(unittest.TestCase):
         mock_network_manager.__get__ = Mock(return_value='flatdhcpmanager')
         mock_plugin.__get__ = Mock()
 
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_network_manager.__get__.called)
         self.assertFalse(mock_plugin.__get__.called)
 
         mock_network_manager.__get__.return_value = 'neutron'
         mock_plugin.__get__ = Mock(return_value=None)
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_plugin.__get__.called)
 
         mock_ovs_ctxt.return_value = {'ovs': 'ovs_context'}
         mock_plugin.__get__.return_value = 'ovs'
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'ovs': 'ovs_context',
              'neutron_url': 'https://foo:9696'},
@@ -3401,18 +3401,18 @@ class ContextTests(unittest.TestCase):
         mock_network_manager.__get__ = Mock(return_value='flatdhcpmanager')
         mock_plugin.__get__ = Mock()
 
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_network_manager.__get__.called)
         self.assertFalse(mock_plugin.__get__.called)
 
         mock_network_manager.__get__.return_value = 'neutron'
         mock_plugin.__get__ = Mock(return_value=None)
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_plugin.__get__.called)
 
         mock_nvp_ctxt.return_value = {'nvp': 'nvp_context'}
         mock_plugin.__get__.return_value = 'nvp'
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'nvp': 'nvp_context',
              'neutron_alchemy_flags': {'pool_size': '20'},
@@ -3439,18 +3439,18 @@ class ContextTests(unittest.TestCase):
         mock_network_manager.__get__ = Mock(return_value='flatdhcpmanager')
         mock_plugin.__get__ = Mock()
 
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_network_manager.__get__.called)
         self.assertFalse(mock_plugin.__get__.called)
 
         mock_network_manager.__get__.return_value = 'neutron'
         mock_plugin.__get__ = Mock(return_value=None)
-        self.assertEquals({}, neutron())
+        self.assertEqual({}, neutron())
         self.assertTrue(mock_plugin.__get__.called)
 
         mock_ovs_ctxt.return_value = {'Calico': 'calico_context'}
         mock_plugin.__get__.return_value = 'Calico'
-        self.assertEquals(
+        self.assertEqual(
             {'network_manager': 'neutron',
              'Calico': 'calico_context',
              'neutron_url': 'https://foo:9696'},
@@ -3465,7 +3465,7 @@ class ContextTests(unittest.TestCase):
 
         # single
         config.return_value = 'deadbeef=True'
-        self.assertEquals({
+        self.assertEqual({
             'user_config_flags': {
                 'deadbeef': 'True',
             }
@@ -3473,7 +3473,7 @@ class ContextTests(unittest.TestCase):
 
         # multi
         config.return_value = 'floating_ip=True,use_virtio=False,max=5'
-        self.assertEquals({
+        self.assertEqual({
             'user_config_flags': {
                 'floating_ip': 'True',
                 'use_virtio': 'False',
@@ -3483,11 +3483,11 @@ class ContextTests(unittest.TestCase):
 
         for empty in [None, '']:
             config.return_value = empty
-            self.assertEquals({}, flags())
+            self.assertEqual({}, flags())
 
         # multi with commas
         config.return_value = 'good_flag=woot,badflag,great_flag=w00t'
-        self.assertEquals({
+        self.assertEqual({
             'user_config_flags': {
                 'good_flag': 'woot,badflag',
                 'great_flag': 'w00t',
@@ -3510,7 +3510,7 @@ class ContextTests(unittest.TestCase):
 
         # single
         config.return_value = 'deadbeef=True'
-        self.assertEquals({
+        self.assertEqual({
             'api_config_flags': {
                 'deadbeef': 'True',
             }
@@ -3546,7 +3546,7 @@ class ContextTests(unittest.TestCase):
             config_file='/etc/foo/foo.conf',
             interface='empty-subordinate',
         )
-        self.assertEquals(
+        self.assertEqual(
             nova_sub_ctxt(),
             {'sections': {
                 'DEFAULT': [
@@ -3554,7 +3554,7 @@ class ContextTests(unittest.TestCase):
                     ['nova-key2', 'value2']]
             }}
         )
-        self.assertEquals(
+        self.assertEqual(
             glance_sub_ctxt(),
             {'sections': {
                 'DEFAULT': [
@@ -3562,7 +3562,7 @@ class ContextTests(unittest.TestCase):
                     ['glance-key2', 'value2']]
             }}
         )
-        self.assertEquals(
+        self.assertEqual(
             cinder_sub_ctxt(),
             {'sections': {
                 'cinder-1-section': [
@@ -3577,11 +3577,11 @@ class ContextTests(unittest.TestCase):
 
         # subrodinate supplies nothing for given config
         glance_sub_ctxt.config_file = '/etc/glance/glance-api-paste.ini'
-        self.assertEquals(glance_sub_ctxt(), {})
+        self.assertEqual(glance_sub_ctxt(), {})
 
         # subordinate supplies bad input
-        self.assertEquals(foo_sub_ctxt(), {})
-        self.assertEquals(empty_sub_ctxt(), {})
+        self.assertEqual(foo_sub_ctxt(), {})
+        self.assertEqual(empty_sub_ctxt(), {})
         self.assertFalse(
             empty_sub_ctxt.context_complete(empty_sub_ctxt()))
 
@@ -3595,7 +3595,7 @@ class ContextTests(unittest.TestCase):
             config_file='/etc/nova/nova.conf',
             interface=['nova-ceilometer', 'neutron-plugin'],
         )
-        self.assertEquals(
+        self.assertEqual(
             nova_sub_ctxt(),
             {'sections': {
                 'DEFAULT': [
@@ -3615,7 +3615,7 @@ class ContextTests(unittest.TestCase):
         expected = {
             'use_syslog': 'foo',
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_loglevel_context_set(self):
         self.config.side_effect = fake_config({
@@ -3628,7 +3628,7 @@ class ContextTests(unittest.TestCase):
             'debug': True,
             'verbose': True,
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_loglevel_context_unset(self):
         self.config.side_effect = fake_config({
@@ -3641,7 +3641,7 @@ class ContextTests(unittest.TestCase):
             'debug': False,
             'verbose': False,
         }
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_calculate_workers_with_multiplier(self):
         self.config.side_effect = fake_config({
@@ -3788,14 +3788,14 @@ class ContextTests(unittest.TestCase):
 
     def test_zeromq_context_unrelated(self):
         self.is_relation_made.return_value = False
-        self.assertEquals(context.ZeroMQContext()(), {})
+        self.assertEqual(context.ZeroMQContext()(), {})
 
     def test_zeromq_context_related(self):
         self.is_relation_made.return_value = True
         self.relation_ids.return_value = ['zeromq-configuration:1']
         self.related_units.return_value = ['openstack-zeromq/0']
         self.relation_get.side_effect = ['nonce-data', 'hostname', 'redis']
-        self.assertEquals(context.ZeroMQContext()(),
+        self.assertEqual(context.ZeroMQContext()(),
                           {'zmq_host': 'hostname',
                            'zmq_nonce': 'nonce-data',
                            'zmq_redis_address': 'redis'})
@@ -3807,7 +3807,7 @@ class ContextTests(unittest.TestCase):
         }
         rels = fake_is_relation_made(relations=relations)
         self.is_relation_made.side_effect = rels.rel_made
-        self.assertEquals(context.NotificationDriverContext()(),
+        self.assertEqual(context.NotificationDriverContext()(),
                           {'notifications': 'False'})
 
     def test_notificationdriver_context_zmq_nometer(self):
@@ -3817,7 +3817,7 @@ class ContextTests(unittest.TestCase):
         }
         rels = fake_is_relation_made(relations=relations)
         self.is_relation_made.side_effect = rels.rel_made
-        self.assertEquals(context.NotificationDriverContext()(),
+        self.assertEqual(context.NotificationDriverContext()(),
                           {'notifications': 'False'})
 
     def test_notificationdriver_context_zmq_meter(self):
@@ -3827,7 +3827,7 @@ class ContextTests(unittest.TestCase):
         }
         rels = fake_is_relation_made(relations=relations)
         self.is_relation_made.side_effect = rels.rel_made
-        self.assertEquals(context.NotificationDriverContext()(),
+        self.assertEqual(context.NotificationDriverContext()(),
                           {'notifications': 'False'})
 
     def test_notificationdriver_context_amq(self):
@@ -3837,7 +3837,7 @@ class ContextTests(unittest.TestCase):
         }
         rels = fake_is_relation_made(relations=relations)
         self.is_relation_made.side_effect = rels.rel_made
-        self.assertEquals(context.NotificationDriverContext()(),
+        self.assertEqual(context.NotificationDriverContext()(),
                           {'notifications': 'True'})
 
     @patch.object(context, 'psutil')
@@ -4019,7 +4019,7 @@ class ContextTests(unittest.TestCase):
     def test_no_ext_port(self, mock_config):
         self.config.side_effect = config = fake_config({})
         mock_config.side_effect = config
-        self.assertEquals(context.ExternalPortContext()(), {})
+        self.assertEqual(context.ExternalPortContext()(), {})
 
     @patch('charmhelpers.contrib.openstack.context.list_nics')
     @patch('charmhelpers.contrib.openstack.context.config')
@@ -4028,7 +4028,7 @@ class ContextTests(unittest.TestCase):
         self.config.side_effect = config
         mock_config.side_effect = config
         mock_list_nics.return_value = ['eth1010']
-        self.assertEquals(context.ExternalPortContext()(),
+        self.assertEqual(context.ExternalPortContext()(),
                           {'ext_port': 'eth1010'})
 
     @patch('charmhelpers.contrib.openstack.context.list_nics')
@@ -4038,7 +4038,7 @@ class ContextTests(unittest.TestCase):
         self.config.side_effect = config
         mock_config.side_effect = config
         mock_list_nics.return_value = []
-        self.assertEquals(context.ExternalPortContext()(), {})
+        self.assertEqual(context.ExternalPortContext()(), {})
 
     @patch('charmhelpers.contrib.openstack.context.is_phy_iface',
            lambda arg: True)
@@ -4060,14 +4060,14 @@ class ContextTests(unittest.TestCase):
         mock_list_nics.return_value = MACHINE_MACS.keys()
         mock_get_nic_hwaddr.side_effect = self._fake_get_hwaddr
 
-        self.assertEquals(context.ExternalPortContext()(),
+        self.assertEqual(context.ExternalPortContext()(),
                           {'ext_port': 'eth2'})
 
         config = fake_config({'ext-port': ABSENT_MACS})
         self.config.side_effect = config
         mock_config.side_effect = config
 
-        self.assertEquals(context.ExternalPortContext()(), {})
+        self.assertEqual(context.ExternalPortContext()(), {})
 
     @patch('charmhelpers.contrib.openstack.context.is_phy_iface',
            lambda arg: True)
@@ -4096,7 +4096,7 @@ class ContextTests(unittest.TestCase):
         config = fake_config({'ext-port': config_macs})
         self.config.side_effect = config
         mock_config.side_effect = config
-        self.assertEquals(context.ExternalPortContext()(),
+        self.assertEqual(context.ExternalPortContext()(),
                           {'ext_port': 'eth2', 'ext_port_mtu': 1234})
 
     @patch('charmhelpers.contrib.openstack.context.NeutronPortContext.'
@@ -4106,7 +4106,7 @@ class ContextTests(unittest.TestCase):
                                                'phybr1:eth1010 '
                                                'phybr1:eth1011'})
         mock_resolve.side_effect = lambda ports: ['eth1010']
-        self.assertEquals(context.DataPortContext()(),
+        self.assertEqual(context.DataPortContext()(),
                           {'eth1010': 'phybr1'})
 
     @patch.object(context, 'get_nic_hwaddr')
@@ -4129,7 +4129,7 @@ class ContextTests(unittest.TestCase):
         mock_get_nic_hwaddr.side_effect = lambda nic: extant_mac
         mock_resolve.side_effect = fake_resolve
 
-        self.assertEquals(context.DataPortContext()(),
+        self.assertEqual(context.DataPortContext()(),
                           {'eth1010': 'phybr1'})
 
     @patch.object(context.glob, 'glob')
@@ -4193,11 +4193,11 @@ class ContextTests(unittest.TestCase):
         api_ctxt = context.NeutronAPIContext()()
         for key in expected_keys:
             self.assertTrue(key in api_ctxt)
-        self.assertEquals(api_ctxt['polling_interval'], 2)
-        self.assertEquals(api_ctxt['rpc_response_timeout'], 60)
-        self.assertEquals(api_ctxt['report_interval'], 30)
-        self.assertEquals(api_ctxt['enable_nsg_logging'], False)
-        self.assertEquals(api_ctxt['global_physnet_mtu'], 1500)
+        self.assertEqual(api_ctxt['polling_interval'], 2)
+        self.assertEqual(api_ctxt['rpc_response_timeout'], 60)
+        self.assertEqual(api_ctxt['report_interval'], 30)
+        self.assertEqual(api_ctxt['enable_nsg_logging'], False)
+        self.assertEqual(api_ctxt['global_physnet_mtu'], 1500)
         self.assertIsNone(api_ctxt['physical_network_mtus'])
 
     def setup_neutron_api_context_relation(self, cfg):
@@ -4213,7 +4213,7 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
         self.assertTrue(api_ctxt['enable_qos'])
-        self.assertEquals(api_ctxt['extension_drivers'], 'qos')
+        self.assertEqual(api_ctxt['extension_drivers'], 'qos')
 
     def test_neutronapicontext_extension_drivers_qos_off(self):
         self.setup_neutron_api_context_relation({
@@ -4221,28 +4221,28 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
         self.assertFalse(api_ctxt['enable_qos'])
-        self.assertEquals(api_ctxt['extension_drivers'], '')
+        self.assertEqual(api_ctxt['extension_drivers'], '')
 
     def test_neutronapicontext_extension_drivers_qos_absent(self):
         self.setup_neutron_api_context_relation({
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
         self.assertFalse(api_ctxt['enable_qos'])
-        self.assertEquals(api_ctxt['extension_drivers'], '')
+        self.assertEqual(api_ctxt['extension_drivers'], '')
 
     def test_neutronapicontext_extension_drivers_log_off(self):
         self.setup_neutron_api_context_relation({
             'enable-nsg-logging': 'False',
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['extension_drivers'], '')
+        self.assertEqual(api_ctxt['extension_drivers'], '')
 
     def test_neutronapicontext_extension_drivers_log_on(self):
         self.setup_neutron_api_context_relation({
             'enable-nsg-logging': 'True',
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['extension_drivers'], 'log')
+        self.assertEqual(api_ctxt['extension_drivers'], 'log')
 
     def test_neutronapicontext_extension_drivers_log_qos_on(self):
         self.setup_neutron_api_context_relation({
@@ -4250,7 +4250,7 @@ class ContextTests(unittest.TestCase):
             'enable-nsg-logging': 'True',
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['extension_drivers'], 'qos,log')
+        self.assertEqual(api_ctxt['extension_drivers'], 'qos,log')
 
     def test_neutronapicontext_firewall_group_logging_on(self):
         self.setup_neutron_api_context_relation({
@@ -4258,7 +4258,7 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'
         })
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['enable_nfg_logging'], True)
+        self.assertEqual(api_ctxt['enable_nfg_logging'], True)
 
     def test_neutronapicontext_firewall_group_logging_off(self):
         self.setup_neutron_api_context_relation({
@@ -4266,7 +4266,7 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'
         })
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['enable_nfg_logging'], False)
+        self.assertEqual(api_ctxt['enable_nfg_logging'], False)
 
     def test_neutronapicontext_port_forwarding_on(self):
         self.setup_neutron_api_context_relation({
@@ -4274,7 +4274,7 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'
         })
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['enable_port_forwarding'], True)
+        self.assertEqual(api_ctxt['enable_port_forwarding'], True)
 
     def test_neutronapicontext_port_forwarding_off(self):
         self.setup_neutron_api_context_relation({
@@ -4282,26 +4282,26 @@ class ContextTests(unittest.TestCase):
             'l2-population': 'True'
         })
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['enable_port_forwarding'], False)
+        self.assertEqual(api_ctxt['enable_port_forwarding'], False)
 
     def test_neutronapicontext_string_converted(self):
         self.setup_neutron_api_context_relation({
             'l2-population': 'True'})
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['l2_population'], True)
+        self.assertEqual(api_ctxt['l2_population'], True)
 
     def test_neutronapicontext_none(self):
         self.relation_ids.return_value = ['neutron-plugin-api:1']
         self.related_units.return_value = ['neutron-api/0']
         self.relation_get.return_value = {'l2-population': 'True'}
         api_ctxt = context.NeutronAPIContext()()
-        self.assertEquals(api_ctxt['network_device_mtu'], None)
+        self.assertEqual(api_ctxt['network_device_mtu'], None)
 
     def test_network_service_ctxt_no_units(self):
         self.relation_ids.return_value = []
         self.relation_ids.return_value = ['foo']
         self.related_units.return_value = []
-        self.assertEquals(context.NetworkServiceContext()(), {})
+        self.assertEqual(context.NetworkServiceContext()(), {})
 
     @patch.object(context.OSContextGenerator, 'context_complete')
     def test_network_service_ctxt_no_data(self, mock_context_complete):
@@ -4311,7 +4311,7 @@ class ContextTests(unittest.TestCase):
         relation = FakeRelation(relation_data=QUANTUM_NETWORK_SERVICE_RELATION)
         self.relation_get.side_effect = relation.get
         mock_context_complete.return_value = False
-        self.assertEquals(context.NetworkServiceContext()(), {})
+        self.assertEqual(context.NetworkServiceContext()(), {})
 
     def test_network_service_ctxt_data(self):
         data_result = {
@@ -4334,7 +4334,7 @@ class ContextTests(unittest.TestCase):
         self.related_units.side_effect = rel.relation_units
         relation = FakeRelation(relation_data=QUANTUM_NETWORK_SERVICE_RELATION)
         self.relation_get.side_effect = relation.get
-        self.assertEquals(context.NetworkServiceContext()(), data_result)
+        self.assertEqual(context.NetworkServiceContext()(), data_result)
 
     def test_network_service_ctxt_data_api_version(self):
         data_result = {
@@ -4358,7 +4358,7 @@ class ContextTests(unittest.TestCase):
         relation = FakeRelation(
             relation_data=QUANTUM_NETWORK_SERVICE_RELATION_VERSIONED)
         self.relation_get.side_effect = relation.get
-        self.assertEquals(context.NetworkServiceContext()(), data_result)
+        self.assertEqual(context.NetworkServiceContext()(), data_result)
 
     def test_internal_endpoint_context(self):
         config = {'use-internal-endpoints': False}
@@ -4398,14 +4398,14 @@ class ContextTests(unittest.TestCase):
         mock_aa_object = context.AppArmorContext()
         # Test with invalid config
         self.config.return_value = 'NOTVALID'
-        self.assertEquals(mock_aa_object.__call__(), None)
+        self.assertEqual(mock_aa_object.__call__(), None)
 
     def test_apparmor_context_call_complain(self):
         ''' Tests for the apparmor context'''
         mock_aa_object = context.AppArmorContext()
         # Test complain mode
         self.config.return_value = 'complain'
-        self.assertEquals(mock_aa_object.__call__(),
+        self.assertEqual(mock_aa_object.__call__(),
                           {'aa_profile_mode': 'complain',
                            'ubuntu_release': '16.04'})
 
@@ -4414,7 +4414,7 @@ class ContextTests(unittest.TestCase):
         mock_aa_object = context.AppArmorContext()
         # Test enforce mode
         self.config.return_value = 'enforce'
-        self.assertEquals(mock_aa_object.__call__(),
+        self.assertEqual(mock_aa_object.__call__(),
                           {'aa_profile_mode': 'enforce',
                            'ubuntu_release': '16.04'})
 
@@ -4423,7 +4423,7 @@ class ContextTests(unittest.TestCase):
         mock_aa_object = context.AppArmorContext()
         # Test complain mode
         self.config.return_value = 'disable'
-        self.assertEquals(mock_aa_object.__call__(),
+        self.assertEqual(mock_aa_object.__call__(),
                           {'aa_profile_mode': 'disable',
                            'ubuntu_release': '16.04'})
 
@@ -4560,7 +4560,7 @@ class ContextTests(unittest.TestCase):
             'logrotate_interval': 'weekly',
             'logrotate_count': 'rotate 4',
         }
-        self.assertEquals(ctxt, expected_ctxt)
+        self.assertEqual(ctxt, expected_ctxt)
 
     @patch.object(context, 'os_release')
     def test_vendordata_static(self, os_release):

--- a/tests/contrib/openstack/test_os_templating.py
+++ b/tests/contrib/openstack/test_os_templating.py
@@ -136,8 +136,8 @@ class TemplatingTests(unittest.TestCase):
         renderer._get_template = MagicMock()
         renderer.register('/etc/nova/nova.conf', contexts=[])
         renderer.render('/etc/nova/nova.conf')
-        self.assertEquals(1, len(renderer._get_template.call_args_list))
-        self.assertEquals(
+        self.assertEqual(1, len(renderer._get_template.call_args_list))
+        self.assertEqual(
             [call('nova.conf')], renderer._get_template.call_args_list)
 
     def test_render_template_by_munged_full_path_last(self):
@@ -152,8 +152,8 @@ class TemplatingTests(unittest.TestCase):
         renderer._get_template.side_effect = [e, tmp]
         renderer.register('/etc/nova/nova.conf', contexts=[])
         renderer.render('/etc/nova/nova.conf')
-        self.assertEquals(2, len(renderer._get_template.call_args_list))
-        self.assertEquals(
+        self.assertEqual(2, len(renderer._get_template.call_args_list))
+        self.assertEqual(
             [call('nova.conf'), call('etc_nova_nova.conf')],
             renderer._get_template.call_args_list)
 
@@ -183,7 +183,7 @@ class TemplatingTests(unittest.TestCase):
         ]
         with patch.object(self.renderer, 'write') as _write:
             self.renderer.write_all()
-            self.assertEquals(sorted(ex_calls), sorted(_write.call_args_list))
+            self.assertEqual(sorted(ex_calls), sorted(_write.call_args_list))
             pass
 
     @patch.object(templating, 'get_loader')
@@ -238,7 +238,7 @@ class TemplatingTests(unittest.TestCase):
                     ['/tmp/foo/diablo'],
                     ['/tmp/foo'],
                     [common_tmplts]]
-        self.assertEquals(dirs, expected)
+        self.assertEqual(dirs, expected)
 
     @patch('os.path.isdir')
     def test_get_loader_some_search_paths(self, isdir):
@@ -256,7 +256,7 @@ class TemplatingTests(unittest.TestCase):
                     ['/tmp/foo/diablo'],
                     ['/tmp/foo'],
                     [common_tmplts]]
-        self.assertEquals(dirs, expected)
+        self.assertEqual(dirs, expected)
 
     def test_register_template_with_list_of_contexts(self):
         '''Ensure registering a template with a list of context generators'''
@@ -267,7 +267,7 @@ class TemplatingTests(unittest.TestCase):
             pass
         tmpl = templating.OSConfigTemplate(config_file='/tmp/foo',
                                            contexts=[_c1, _c2])
-        self.assertEquals(tmpl.contexts, [_c1, _c2])
+        self.assertEqual(tmpl.contexts, [_c1, _c2])
 
     def test_register_template_with_single_context(self):
         '''Ensure registering a template with a single non-list context'''
@@ -275,7 +275,7 @@ class TemplatingTests(unittest.TestCase):
             pass
         tmpl = templating.OSConfigTemplate(config_file='/tmp/foo',
                                            contexts=_c1)
-        self.assertEquals(tmpl.contexts, [_c1])
+        self.assertEqual(tmpl.contexts, [_c1])
 
 
 class TemplatingStringTests(unittest.TestCase):
@@ -320,7 +320,7 @@ class TemplatingStringTests(unittest.TestCase):
         # template source
         output = self.renderer.render(self.config_file)
 
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_render_template_from_string_incomplete_context(self):
         '''
@@ -345,7 +345,7 @@ class TemplatingStringTests(unittest.TestCase):
         # template source
         output = self.renderer.render(self.config_file)
 
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)
 
     def test_register_string_template_with_single_context(self):
         '''Template rendering from a provided string with a context'''
@@ -360,6 +360,6 @@ class TemplatingStringTests(unittest.TestCase):
             config_template=config_template
         )
 
-        self.assertEquals(tmpl.contexts, [_c1])
-        self.assertEquals(tmpl.config_file, config_file)
-        self.assertEquals(tmpl.config_template, config_template)
+        self.assertEqual(tmpl.contexts, [_c1])
+        self.assertEqual(tmpl.config_file, config_file)
+        self.assertEqual(tmpl.config_template, config_template)

--- a/tests/contrib/openstack/test_os_utils.py
+++ b/tests/contrib/openstack/test_os_utils.py
@@ -279,19 +279,19 @@ class UtilsTests(unittest.TestCase):
         f = utils.sequence_status_check_functions(f1, f2, f3)
         expected = ('blocked', 'status 1, status 2, status 3')
         result = f(mock.Mock())
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         # empty status must be replaced by "unknown"
         f4 = mock.Mock(return_value=('', 'status 4'))
         f5 = mock.Mock(return_value=('', 'status 5'))
         f = utils.sequence_status_check_functions(f4, f5)
         expected = ('unknown', 'status 4, status 5')
         result = f(mock.Mock())
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         # sequencing 0 status checks must return state 'unknown', ''
         f = utils.sequence_status_check_functions()
         expected = ('unknown', '')
         result = f(mock.Mock())
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @mock.patch.object(utils, 'relation_get')
     @mock.patch.object(utils, 'related_units')
@@ -337,18 +337,18 @@ class UtilsTests(unittest.TestCase):
         ]
         # None of the subordinate relations have information about rocky or
         # earlier for deb installations
-        self.assertEquals(
+        self.assertEqual(
             utils.get_subordinate_release_packages('rocky'),
             utils.SubordinatePackages(set(), set()))
         # Information on most recent earlier release with matching package
         # type will be provided when requesting a release not specifically
         # provided by subordinates
-        self.assertEquals(
+        self.assertEqual(
             utils.get_subordinate_release_packages(
                 'rocky', package_type='snap'),
             utils.SubordinatePackages(
                 {'q_inst'}, {'q_purg'}))
-        self.assertEquals(
+        self.assertEqual(
             utils.get_subordinate_release_packages('train'),
             utils.SubordinatePackages(
                 {'s_inst'}, {'s_purg'}))
@@ -361,7 +361,7 @@ class UtilsTests(unittest.TestCase):
             json.dumps(rdata),
             json.dumps(rdata2),
         ]
-        self.assertEquals(
+        self.assertEqual(
             utils.get_subordinate_release_packages('train'),
             utils.SubordinatePackages(
                 {'s_inst', 't_inst'}, {'s_purg', 't_purg'}))
@@ -371,7 +371,7 @@ class UtilsTests(unittest.TestCase):
             json.dumps(rdata),
             None,
         ]
-        self.assertEquals(
+        self.assertEqual(
             utils.get_subordinate_release_packages('train'),
             utils.SubordinatePackages(
                 {'s_inst'}, {'s_purg'}))

--- a/tests/contrib/openstack/test_vaultlocker.py
+++ b/tests/contrib/openstack/test_vaultlocker.py
@@ -216,7 +216,7 @@ class VaultLockerTestCase(unittest.TestCase):
                           'vault_url': 'http://vault:8200'})
         self.hookenv.relation_ids.assert_called_with('secrets-storage')
         self.assertTrue(vaultlocker.vault_relation_complete())
-        self.assertEquals(self.db.get('secret-id'),
+        self.assertEqual(self.db.get('secret-id'),
                           '31be8e65-20a3-45e0-a4a8-4d5a0554fb60')
         calls = [mock.call(url='http://vault:8200',
                            token='67b36149-dc86-4b80-96c4-35b91847d16e')]
@@ -236,7 +236,7 @@ class VaultLockerTestCase(unittest.TestCase):
                           'vault_url': 'http://vault:8200'})
         self.hookenv.relation_ids.assert_called_with('secrets-storage')
         self.assertTrue(vaultlocker.vault_relation_complete())
-        self.assertEquals(self.db.get('secret-id'),
+        self.assertEqual(self.db.get('secret-id'),
                           '31be8e65-20a3-45e0-a4a8-4d5a0554fb60')
         calls = [mock.call(url='http://vault:8200',
                            token='67b36149-dc86-4b80-96c4-35b91847d16e')]

--- a/tests/contrib/peerstorage/test_peerstorage.py
+++ b/tests/contrib/peerstorage/test_peerstorage.py
@@ -158,7 +158,7 @@ class TestPeerStorage(TestCase):
         }
         peer_settings = {rel_id + '_' + k: v for k, v in settings.items()}
         peer_retrieve.return_value = peer_settings
-        self.assertEquals(peerstorage.peer_retrieve_by_prefix(rel_id), settings)
+        self.assertEqual(peerstorage.peer_retrieve_by_prefix(rel_id), settings)
 
     @patch.object(peerstorage, 'peer_retrieve')
     def test_peer_retrieve_by_prefix_empty_relation(self, peer_retrieve):
@@ -166,7 +166,7 @@ class TestPeerStorage(TestCase):
         # an empty dictionary.
         peer_retrieve.return_value = None
         rel_id = 'db:2'
-        self.assertEquals(peerstorage.peer_retrieve_by_prefix(rel_id), {})
+        self.assertEqual(peerstorage.peer_retrieve_by_prefix(rel_id), {})
 
     @patch.object(peerstorage, 'peer_retrieve')
     def test_peer_retrieve_by_prefix_exc_list(self, peer_retrieve):
@@ -179,7 +179,7 @@ class TestPeerStorage(TestCase):
         peer_settings = {rel_id + '_' + k: v for k, v in settings.items()}
         del settings['host']
         peer_retrieve.return_value = peer_settings
-        self.assertEquals(peerstorage.peer_retrieve_by_prefix(rel_id,
+        self.assertEqual(peerstorage.peer_retrieve_by_prefix(rel_id,
                                                               exc_list=['host']),
                           settings)
 
@@ -193,7 +193,7 @@ class TestPeerStorage(TestCase):
         }
         peer_settings = {rel_id + '_' + k: v for k, v in settings.items()}
         peer_retrieve.return_value = peer_settings
-        self.assertEquals(peerstorage.peer_retrieve_by_prefix(rel_id,
+        self.assertEqual(peerstorage.peer_retrieve_by_prefix(rel_id,
                                                               inc_list=['host']),
                           {'host': 'myhost'})
 

--- a/tests/contrib/storage/test_linux_ceph.py
+++ b/tests/contrib/storage/test_linux_ceph.py
@@ -487,21 +487,21 @@ class CephUtilsTests(TestCase):
 
         self.test_config.set('pgs-per-osd', 300)
         pg_num = p.get_pgs(pool_size=3, percent_data=100)
-        self.assertEquals(1024, pg_num)
+        self.assertEqual(1024, pg_num)
 
         # Tests the case in which the expected OSD count is provided (and is
         # greater than the found OSD count).
         self.test_config.set('pgs-per-osd', 100)
         self.test_config.set('expected-osd-count', 20)
         pg_num = p.get_pgs(pool_size=3, percent_data=100)
-        self.assertEquals(512, pg_num)
+        self.assertEqual(512, pg_num)
 
         # Test small % weight with minimal OSD count (3)
         get_osds.return_value = range(1, 3)
         self.test_config.set('expected-osd-count', None)
         self.test_config.set('pgs-per-osd', None)
         pg_num = p.get_pgs(pool_size=3, percent_data=0.1)
-        self.assertEquals(2, pg_num)
+        self.assertEqual(2, pg_num)
 
         # Check device_class is passed to get_osds
         p.get_pgs(pool_size=3, percent_data=90, device_class='nvme')
@@ -1129,15 +1129,15 @@ class CephUtilsTests(TestCase):
 
     def test_get_osds(self):
         self.check_output.return_value = json.dumps([1, 2, 3]).encode('UTF-8')
-        self.assertEquals(ceph_utils.get_osds('test'), [1, 2, 3])
+        self.assertEqual(ceph_utils.get_osds('test'), [1, 2, 3])
 
     def test_get_osds_none(self):
         self.check_output.return_value = json.dumps(None).encode('UTF-8')
-        self.assertEquals(ceph_utils.get_osds('test'), None)
+        self.assertEqual(ceph_utils.get_osds('test'), None)
 
     def test_get_osds_device_class(self):
         self.check_output.return_value = json.dumps([1, 2, 3]).encode('UTF-8')
-        self.assertEquals(ceph_utils.get_osds('test', 'nvme'), [1, 2, 3])
+        self.assertEqual(ceph_utils.get_osds('test', 'nvme'), [1, 2, 3])
         self.check_output.assert_called_once_with(
             ['ceph', '--id', 'test',
              'osd', 'crush', 'class',
@@ -1147,7 +1147,7 @@ class CephUtilsTests(TestCase):
     def test_get_osds_device_class_older(self):
         self.check_output.return_value = json.dumps([1, 2, 3]).encode('UTF-8')
         self.cmp_pkgrevno.return_value = -1
-        self.assertEquals(ceph_utils.get_osds('test', 'nvme'), [1, 2, 3])
+        self.assertEqual(ceph_utils.get_osds('test', 'nvme'), [1, 2, 3])
         self.check_output.assert_called_once_with(
             ['ceph', '--id', 'test', 'osd', 'ls', '--format=json']
         )
@@ -1204,12 +1204,12 @@ class CephUtilsTests(TestCase):
     def test_keyring_path(self):
         """It correctly derives keyring path from service name"""
         result = ceph_utils._keyring_path('cinder')
-        self.assertEquals('/etc/ceph/ceph.client.cinder.keyring', result)
+        self.assertEqual('/etc/ceph/ceph.client.cinder.keyring', result)
 
     def test_keyfile_path(self):
         """It correctly derives keyring path from service name"""
         result = ceph_utils._keyfile_path('cinder')
-        self.assertEquals('/etc/ceph/ceph.client.cinder.key', result)
+        self.assertEqual('/etc/ceph/ceph.client.cinder.key', result)
 
     def test_pool_exists(self):
         """It detects an rbd pool exists"""
@@ -1272,12 +1272,12 @@ class CephUtilsTests(TestCase):
         self.relation_ids.return_value = ['ceph:0']
         self.related_units.return_value = units
         self.relation_get.return_value = '192.168.1.1'
-        self.assertEquals(len(ceph_utils.get_ceph_nodes()), 3)
+        self.assertEqual(len(ceph_utils.get_ceph_nodes()), 3)
 
     def test_get_ceph_nodes_not_related(self):
         self._patch('relation_ids')
         self.relation_ids.return_value = []
-        self.assertEquals(ceph_utils.get_ceph_nodes(), [])
+        self.assertEqual(ceph_utils.get_ceph_nodes(), [])
 
     def test_configure(self):
         self._patch('add_key')
@@ -1467,9 +1467,9 @@ class CephUtilsTests(TestCase):
         device = '/no/such/device'
         e = self.assertRaises(IOError, ceph_utils.make_filesystem, device,
                               timeout=0)
-        self.assertEquals(device, e.filename)
-        self.assertEquals(errno.ENOENT, e.errno)
-        self.assertEquals(os.strerror(errno.ENOENT), e.strerror)
+        self.assertEqual(device, e.filename)
+        self.assertEqual(errno.ENOENT, e.errno)
+        self.assertEqual(os.strerror(errno.ENOENT), e.strerror)
         self.log.assert_called_with(
             'Gave up waiting on block device %s' % device, level='ERROR')
 
@@ -1528,11 +1528,11 @@ class CephUtilsTests(TestCase):
     @patch.object(ceph_utils, 'relation_get')
     def test_ensure_ceph_keyring_no_relation_no_data(self, rget, runits, rids):
         rids.return_value = []
-        self.assertEquals(False, ceph_utils.ensure_ceph_keyring(service='foo'))
+        self.assertEqual(False, ceph_utils.ensure_ceph_keyring(service='foo'))
         rids.return_value = ['ceph:0']
         runits.return_value = ['ceph/0']
         rget.return_value = ''
-        self.assertEquals(False, ceph_utils.ensure_ceph_keyring(service='foo'))
+        self.assertEqual(False, ceph_utils.ensure_ceph_keyring(service='foo'))
 
     @patch.object(ceph_utils, '_keyring_path')
     @patch.object(ceph_utils, 'add_key')
@@ -1555,14 +1555,14 @@ class CephUtilsTests(TestCase):
         rids.return_value = ['ceph:0']
         runits.return_value = ['ceph/0']
         rget.return_value = 'fookey'
-        self.assertEquals(True,
+        self.assertEqual(True,
                           ceph_utils.ensure_ceph_keyring(service='foo'))
         create.assert_called_with(service='foo', key='fookey')
         _path.assert_called_with('foo')
         self.assertFalse(self.check_call.called)
 
         _path.return_value = '/etc/ceph/client.foo.keyring'
-        self.assertEquals(
+        self.assertEqual(
             True,
             ceph_utils.ensure_ceph_keyring(
                 service='foo', user='adam', group='users'))

--- a/tests/contrib/storage/test_linux_storage_loopback.py
+++ b/tests/contrib/storage/test_linux_storage_loopback.py
@@ -24,7 +24,7 @@ class LoopbackStorageUtilsTests(unittest.TestCase):
             '/dev/loop0': '/tmp/foo.img',
             '/dev/loop2': '/tmp/baz.img (deleted)'
         }
-        self.assertEquals(loopback.loopback_devices(), ex)
+        self.assertEqual(loopback.loopback_devices(), ex)
 
     @patch(STORAGE_LINUX_LOOPBACK + '.create_loopback')
     @patch('subprocess.check_call')
@@ -34,7 +34,7 @@ class LoopbackStorageUtilsTests(unittest.TestCase):
         """It finds existing loopback device for requested file"""
         loopbacks.return_value = {'/dev/loop1': '/tmp/bar.img'}
         res = loopback.ensure_loopback_device('/tmp/bar.img', '5G')
-        self.assertEquals(res, '/dev/loop1')
+        self.assertEqual(res, '/dev/loop1')
         self.assertFalse(create.called)
         self.assertFalse(check_call.called)
 
@@ -72,11 +72,11 @@ class LoopbackStorageUtilsTests(unittest.TestCase):
             check_call.return_value = ''
             result = loopback.create_loopback('/tmp/foo')
             check_call.assert_called_with(['losetup', '--find', '/tmp/foo'])
-            self.assertEquals(result, '/dev/loop0')
+            self.assertEqual(result, '/dev/loop0')
 
     @patch.object(loopback, 'loopback_devices')
     def test_create_is_mapped_loopback_device(self, devs):
         devs.return_value = {'/dev/loop0': "/tmp/manco"}
-        self.assertEquals(loopback.is_mapped_loopback_device("/dev/loop0"),
+        self.assertEqual(loopback.is_mapped_loopback_device("/dev/loop0"),
                           "/tmp/manco")
         self.assertFalse(loopback.is_mapped_loopback_device("/dev/loop1"))

--- a/tests/contrib/storage/test_linux_storage_lvm.py
+++ b/tests/contrib/storage/test_linux_storage_lvm.py
@@ -61,14 +61,14 @@ class LVMStorageUtilsTests(unittest.TestCase):
         with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
             check_output.return_value = PVDISPLAY
             vg = lvm.list_lvm_volume_group('/dev/loop0')
-            self.assertEquals(vg, 'foo')
+            self.assertEqual(vg, 'foo')
 
     def test_find_empty_volume_group_on_pv(self):
         """Return empty string when no volume group is assigned to the PV"""
         with patch(STORAGE_LINUX_LVM + '.check_output') as check_output:
             check_output.return_value = EMPTY_VG_IN_PVDISPLAY
             vg = lvm.list_lvm_volume_group('/dev/loop0')
-            self.assertEquals(vg, '')
+            self.assertEqual(vg, '')
 
     @patch(STORAGE_LINUX_LVM + '.list_lvm_volume_group')
     def test_deactivate_lvm_volume_groups(self, ls_vg):

--- a/tests/contrib/unison/test_unison.py
+++ b/tests/contrib/unison/test_unison.py
@@ -60,7 +60,7 @@ class UnisonHelperTests(TestCase):
         fake_user = MagicMock()
         fake_user.pw_dir = '/home/foo'
         pwnam.return_value = fake_user
-        self.assertEquals(unison.get_homedir('foo'),
+        self.assertEqual(unison.get_homedir('foo'),
                           '/home/foo')
 
     @patch('pwd.getpwnam')
@@ -185,8 +185,8 @@ class UnisonHelperTests(TestCase):
             for f in ['/home/foo/.ssh/id_rsa',
                       '/home/foo/.ssh/id_rsa.pub']:
                 self.assertIn(call(f, 'r'), _open.call_args_list)
-        self.assertEquals(priv, 'foopriv')
-        self.assertEquals(pub, 'foopub')
+        self.assertEqual(priv, 'foopriv')
+        self.assertEqual(pub, 'foopub')
 
     @patch.object(unison, 'get_homedir')
     @patch('os.chown')
@@ -279,7 +279,7 @@ class UnisonHelperTests(TestCase):
         fake_user.pw_dir = '/home/foo'
         pwnam.return_value = fake_user
         inner = unison._run_as_user('foo')
-        self.assertEquals(fake_env['HOME'], '/home/foo')
+        self.assertEqual(fake_env['HOME'], '/home/foo')
         inner()
         setgid.assert_called_with(1011)
         setuid.assert_called_with(1010)
@@ -302,7 +302,7 @@ class UnisonHelperTests(TestCase):
         fake_group_id = 2000
         pwnam.return_value = fake_user
         inner = unison._run_as_user('foo', gid=fake_group_id)
-        self.assertEquals(fake_env['HOME'], '/home/foo')
+        self.assertEqual(fake_env['HOME'], '/home/foo')
         inner()
         setgid.assert_called_with(2000)
         setuid.assert_called_with(1010)
@@ -378,13 +378,13 @@ class UnisonHelperTests(TestCase):
         # only one of the hosts in fake environment has auth'd
         # the local peer
         hosts = unison.collect_authed_hosts('cluster')
-        self.assertEquals(hosts, ['cluster0.local'])
+        self.assertEqual(hosts, ['cluster0.local'])
 
     def test_collect_authed_hosts_none_authed(self):
         with patch.object(unison, 'relation_get') as relation_get:
             relation_get.return_value = ''
             hosts = unison.collect_authed_hosts('cluster')
-            self.assertEquals(hosts, [])
+            self.assertEqual(hosts, [])
 
     @patch.object(unison, 'run_as_user')
     def test_sync_path_to_host(self, run_as_user, verbose=True, gid=None):

--- a/tests/core/test_files.py
+++ b/tests/core/test_files.py
@@ -27,6 +27,6 @@ class FileTests(unittest.TestCase):
         files.sed(tmp.name, "IPV6=.*", "IPV6=no")
 
         with open(tmp.name) as tmp:
-            self.assertEquals(tmp.read(), "IPV6=no")
+            self.assertEqual(tmp.read(), "IPV6=no")
 
         os.unlink(tmp.name)

--- a/tests/core/test_hookenv.py
+++ b/tests/core/test_hookenv.py
@@ -289,7 +289,7 @@ class SerializableTest(TestCase):
         pickled = pickle.dumps(wrapped)
         unpickled = pickle.loads(pickled)
 
-        self.assert_(isinstance(unpickled, hookenv.Serializable))
+        self.assertTrue(isinstance(unpickled, hookenv.Serializable))
         self.assertEqual(unpickled, foo)
 
     def test_boolean(self):
@@ -366,7 +366,7 @@ class HelpersTest(TestCase):
         self.assertEqual(result[1], 'a')
 
         # ... because the result is actually a string
-        self.assert_(isinstance(result, str))
+        self.assertTrue(isinstance(result, str))
 
     @patch('charmhelpers.core.hookenv.log', lambda *args, **kwargs: None)
     @patch('charmhelpers.core.hookenv._cache_config', None)
@@ -472,7 +472,7 @@ class HelpersTest(TestCase):
         self.assertEqual(result[1], 'a')
 
         # ... because the result is actually a string
-        self.assert_(isinstance(result, str))
+        self.assertTrue(isinstance(result, str))
 
         self.assertFalse(check_output.called)
 
@@ -1492,13 +1492,13 @@ class HelpersTest(TestCase):
             calls.append(attribute)
             return values[attribute]
 
-        self.assertEquals(cache_function('hello'), 'world')
-        self.assertEquals(cache_function('hello'), 'world')
-        self.assertEquals(cache_function('foo'), 'bar')
-        self.assertEquals(cache_function('baz'), None)
-        self.assertEquals(cache_function('baz'), None)
-        self.assertEquals(cache_function(unserializable), 'qux')
-        self.assertEquals(calls, ['hello', 'foo', 'baz', unserializable])
+        self.assertEqual(cache_function('hello'), 'world')
+        self.assertEqual(cache_function('hello'), 'world')
+        self.assertEqual(cache_function('foo'), 'bar')
+        self.assertEqual(cache_function('baz'), None)
+        self.assertEqual(cache_function('baz'), None)
+        self.assertEqual(cache_function(unserializable), 'qux')
+        self.assertEqual(calls, ['hello', 'foo', 'baz', unserializable])
 
     def test_gets_charm_dir(self):
         with patch.dict('os.environ', {}):
@@ -2253,7 +2253,7 @@ class HooksTest(TestCase):
         juju_version.return_value = '2.1.4'
         self.assertRaises(NotImplementedError, hookenv.network_get, 'binding')
         juju_version.return_value = '2.2.0'
-        self.assertEquals(hookenv.network_get('endpoint'), 'result')
+        self.assertEqual(hookenv.network_get('endpoint'), 'result')
 
     @patch('charmhelpers.core.hookenv.juju_version')
     @patch('subprocess.check_output')

--- a/tests/core/test_host.py
+++ b/tests/core/test_host.py
@@ -5,7 +5,10 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from textwrap import dedent
 
-import imp
+try:
+    import imp
+except ImportError:
+    import importlib as imp
 
 from charmhelpers import osplatform
 from mock import patch, call, mock_open
@@ -1522,7 +1525,7 @@ class HelpersTest(TestCase):
         # Restart should only happen once per service
         for svc in ['test-service2', 'test-service']:
             c = call('restart', svc)
-            self.assertEquals(1, service.call_args_list.count(c))
+            self.assertEqual(1, service.call_args_list.count(c))
 
         exists.assert_has_calls([
             call(file_name_one),
@@ -1558,7 +1561,7 @@ class HelpersTest(TestCase):
             call('restart', 'some-api'),
             call('restart', 'haproxy')
         ]
-        self.assertEquals(expected, service.call_args_list)
+        self.assertEqual(expected, service.call_args_list)
 
     @patch.object(host, 'service')
     @patch('os.path.exists')
@@ -1583,7 +1586,7 @@ class HelpersTest(TestCase):
                                           b'content', b'content2']
             make_some_changes()
 
-        self.assertEquals([], service.call_args_list)
+        self.assertEqual([], service.call_args_list)
 
     @patch.object(host, 'service')
     @patch('os.path.exists')
@@ -1608,7 +1611,7 @@ class HelpersTest(TestCase):
                                           b'changed', b'content2']
             make_some_changes()
 
-        self.assertEquals([call('restart', 'service')], service.call_args_list)
+        self.assertEqual([call('restart', 'service')], service.call_args_list)
 
     @patch.object(host, 'service')
     @patch('os.path.exists')
@@ -1633,7 +1636,7 @@ class HelpersTest(TestCase):
                                           b'exists', b'created']
             make_some_changes()
 
-        self.assertEquals([call('restart', 'service')], service.call_args_list)
+        self.assertEqual([call('restart', 'service')], service.call_args_list)
 
     @patch.object(host, 'service')
     @patch('os.path.exists')
@@ -1658,7 +1661,7 @@ class HelpersTest(TestCase):
                                           b'exists2']
             make_some_changes()
 
-        self.assertEquals([call('restart', 'service')], service.call_args_list)
+        self.assertEqual([call('restart', 'service')], service.call_args_list)
 
     @patch.object(host, 'service_reload')
     @patch.object(host, 'service')
@@ -1688,8 +1691,8 @@ class HelpersTest(TestCase):
             mock_file.read.side_effect = [b'exists', b'missing', b'exists2']
             make_some_changes()
 
-        self.assertEquals([call('restart', 'haproxy')], service.call_args_list)
-        self.assertEquals([call('some-api')], service_reload.call_args_list)
+        self.assertEqual([call('restart', 'haproxy')], service.call_args_list)
+        self.assertEqual([call('some-api')], service_reload.call_args_list)
 
     @patch.object(osplatform, 'get_platform')
     def test_lsb_release_ubuntu(self, platform):
@@ -1736,7 +1739,7 @@ class HelpersTest(TestCase):
 
     def test_pwgen(self):
         pw = host.pwgen()
-        self.assert_(len(pw) >= 35, 'Password is too short')
+        self.assertTrue(len(pw) >= 35, 'Password is too short')
 
         pw = host.pwgen(10)
         self.assertEqual(len(pw), 10, 'Password incorrect length')
@@ -2091,14 +2094,14 @@ class HelpersTest(TestCase):
     @patch('subprocess.check_output')
     def test_get_system_env(self, check_output):
         check_output.return_value = ''
-        self.assertEquals(
+        self.assertEqual(
             host.get_system_env('aKey', 'aDefault'), 'aDefault')
-        self.assertEquals(host.get_system_env('aKey'), None)
+        self.assertEqual(host.get_system_env('aKey'), None)
         check_output.return_value = 'aKey=aValue\n'
-        self.assertEquals(
+        self.assertEqual(
             host.get_system_env('aKey', 'aDefault'), 'aValue')
         check_output.return_value = 'otherKey=shell=wicked\n'
-        self.assertEquals(
+        self.assertEqual(
             host.get_system_env('otherKey', 'aDefault'), 'shell=wicked')
 
 

--- a/tests/core/test_kernel.py
+++ b/tests/core/test_kernel.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import imp
+try:
+    import imp
+except ImportError:
+    import importlib as imp
 
 from charmhelpers import osplatform
 from mock import patch

--- a/tests/core/test_strutils.py
+++ b/tests/core/test_strutils.py
@@ -63,9 +63,9 @@ class TestStrUtils(unittest.TestCase):
             _list = ('zomg', 'bartlet', 'over', 'and')
 
         x = MyComparator('zomg')
-        self.assertEquals(x.index, 0)
+        self.assertEqual(x.index, 0)
         y = MyComparator('over')
-        self.assertEquals(y.index, 2)
+        self.assertEqual(y.index, 2)
         self.assertTrue(x == 'zomg')
         self.assertTrue(x != 'bartlet')
         self.assertTrue(x == x)

--- a/tests/core/test_templating.py
+++ b/tests/core/test_templating.py
@@ -44,14 +44,14 @@ class TestTemplating(unittest.TestCase):
             templating.render('fake_cc.yml', fn1.name,
                               context, templates_dir=TEMPLATES_DIR)
             contents = open(fn1.name).read()
-            self.assertRegexpMatches(contents, 'port: 1234')
-            self.assertRegexpMatches(contents, 'host: example.com')
-            self.assertRegexpMatches(contents, 'domain: api.foo.com')
+            self.assertRegex(contents, 'port: 1234')
+            self.assertRegex(contents, 'host: example.com')
+            self.assertRegex(contents, 'domain: api.foo.com')
 
             templating.render('test.conf', fn2.name, context,
                               templates_dir=TEMPLATES_DIR)
             contents = open(fn2.name).read()
-            self.assertRegexpMatches(contents, 'listen 80')
+            self.assertRegex(contents, 'listen 80')
             self.assertEqual(fchown.call_count, 2)
             # Not called, because the target directory exists. Calling
             # it would make the target directory world readable and
@@ -72,7 +72,7 @@ class TestTemplating(unittest.TestCase):
                               context, templates_dir=TEMPLATES_DIR,
                               config_template=config_template)
             contents = open(fn.name).read()
-            self.assertRegexpMatches(contents, 'bar')
+            self.assertRegex(contents, 'bar')
 
             self.assertEqual(fchown.call_count, 1)
             # Not called, because the target directory exists. Calling
@@ -99,9 +99,9 @@ class TestTemplating(unittest.TestCase):
             templating.render('fake_cc.yml', fn1.name,
                               context, template_loader=template_loader)
             contents = open(fn1.name).read()
-            self.assertRegexpMatches(contents, 'port: 1234')
-            self.assertRegexpMatches(contents, 'host: example.com')
-            self.assertRegexpMatches(contents, 'domain: api.foo.com')
+            self.assertRegex(contents, 'port: 1234')
+            self.assertRegex(contents, 'host: example.com')
+            self.assertRegex(contents, 'domain: api.foo.com')
 
     @mock.patch.object(templating.os.path, 'exists')
     @mock.patch.object(templating.host.os, 'fchown')
@@ -124,14 +124,14 @@ class TestTemplating(unittest.TestCase):
             templating.render('fake_cc.yml', fn1.name,
                               context, templates_dir=TEMPLATES_DIR)
             contents = open(fn1.name).read()
-            self.assertRegexpMatches(contents, 'port: 1234')
-            self.assertRegexpMatches(contents, 'host: example.com')
-            self.assertRegexpMatches(contents, 'domain: api.foo.com')
+            self.assertRegex(contents, 'port: 1234')
+            self.assertRegex(contents, 'host: example.com')
+            self.assertRegex(contents, 'domain: api.foo.com')
 
             templating.render('test.conf', fn2.name, context,
                               templates_dir=TEMPLATES_DIR)
             contents = open(fn2.name).read()
-            self.assertRegexpMatches(contents, 'listen 80')
+            self.assertRegex(contents, 'listen 80')
             self.assertEqual(fchown.call_count, 2)
             # Target directory was created, world readable (!).
             self.assertEqual(mkdir.call_count, 2)
@@ -150,7 +150,7 @@ class TestTemplating(unittest.TestCase):
             with open(fn1) as f:
                 contents = f.read()
 
-            self.assertRegexpMatches(contents, 'something')
+            self.assertRegex(contents, 'something')
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/tests/fetch/python/test_version.py
+++ b/tests/fetch/python/test_version.py
@@ -19,9 +19,9 @@ class VersionTestCase(TestCase):
         Check if version.current_version and version.current_version_string
         works correctly
         """
-        self.assertEquals(version.current_version(),
+        self.assertEqual(version.current_version(),
                           sys.version_info)
-        self.assertEquals(version.current_version_string(),
+        self.assertEqual(version.current_version_string(),
                           "{0}.{1}.{2}".format(sys.version_info.major,
                                                sys.version_info.minor,
                                                sys.version_info.micro))

--- a/tests/fetch/test_archiveurl.py
+++ b/tests/fetch/test_archiveurl.py
@@ -112,7 +112,7 @@ class ArchiveUrlFetchHandlerTest(TestCase):
         self.fh.download = MagicMock()
         url = "file://example.com/foo.tar.bz2#sha512=a&sha512=b"
         with patch.dict('os.environ', {'CHARM_DIR': 'foo'}):
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                     TypeError, "Expected 1 hash value, not 2"):
                 self.fh.install(url)
 

--- a/tests/fetch/test_bzrurl.py
+++ b/tests/fetch/test_bzrurl.py
@@ -94,7 +94,7 @@ class BzrUrlFetchHandlerTest(TestCase):
         dst = None
         try:
             src = tempfile.mkdtemp()
-            subprocess.check_output(['bzr', 'init', src], stderr=subprocess.STDOUT)
+            subprocess.check_output(['bzr', 'init', src])
             dst = tempfile.mkdtemp()
             os.rmdir(dst)
             self.fh.branch(src, dst)

--- a/tests/fetch/test_fetch_centos.py
+++ b/tests/fetch/test_fetch_centos.py
@@ -41,7 +41,7 @@ class FetchTest(TestCase):
         import yum
         yum.YumBase.return_value.doPackageLists.return_value = yum_dict
         result = fetch.filter_installed_packages(['vim', 'emacs'])
-        self.assertEquals(result, ['emacs'])
+        self.assertEqual(result, ['emacs'])
 
     @patch("charmhelpers.fetch.log")
     def test_filter_packages_none_missing_centos(self, log):
@@ -61,7 +61,7 @@ class FetchTest(TestCase):
         import yum
         yum.yumBase.return_value.doPackageLists.return_value = yum_dict
         result = fetch.filter_installed_packages(['vim'])
-        self.assertEquals(result, [])
+        self.assertEqual(result, [])
 
     @patch('charmhelpers.fetch.centos.log')
     @patch('yum.YumBase.doPackageLists')
@@ -80,7 +80,7 @@ class FetchTest(TestCase):
         yum.YumBase.return_value.doPackageLists.return_value = yum_dict
 
         result = fetch.filter_installed_packages(['vim', 'joe'])
-        self.assertEquals(result, ['joe'])
+        self.assertEqual(result, ['joe'])
 
     @patch('charmhelpers.fetch.centos.log')
     def test_add_source_none_centos(self, log):

--- a/tests/fetch/test_fetch_ubuntu.py
+++ b/tests/fetch/test_fetch_ubuntu.py
@@ -92,21 +92,21 @@ class FetchTest(TestCase):
     def test_filter_packages_missing_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim', 'emacs'])
-        self.assertEquals(result, ['emacs'])
+        self.assertEqual(result, ['emacs'])
 
     @patch("charmhelpers.fetch.ubuntu.log")
     @patch.object(fetch, 'apt_cache')
     def test_filter_packages_none_missing_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim'])
-        self.assertEquals(result, [])
+        self.assertEqual(result, [])
 
     @patch('charmhelpers.fetch.ubuntu.log')
     @patch.object(fetch, 'apt_cache')
     def test_filter_packages_not_available_ubuntu(self, cache, log):
         cache.side_effect = fake_apt_cache
         result = fetch.filter_installed_packages(['vim', 'joe'])
-        self.assertEquals(result, ['joe'])
+        self.assertEqual(result, ['joe'])
         log.assert_called_with('Package joe has no installation candidate.',
                                level='WARNING')
 
@@ -1138,6 +1138,6 @@ class TestAptDpkgEnv(TestCase):
     @patch.object(fetch, 'get_system_env')
     def test_get_apt_dpkg_env(self, mock_get_system_env):
         mock_get_system_env.return_value = '/a/path'
-        self.assertEquals(
+        self.assertEqual(
             fetch.get_apt_dpkg_env(),
             {'DEBIAN_FRONTEND': 'noninteractive', 'PATH': '/a/path'})

--- a/tests/fetch/test_fetch_ubuntu_apt_pkg.py
+++ b/tests/fetch/test_fetch_ubuntu_apt_pkg.py
@@ -73,7 +73,7 @@ class Test_apt_pkg_Cache(unittest.TestCase):
             'Version: 4.91+dfsg-1ubuntu1\n'
             '\n'
             'N: There is 1 additional record.\n')
-        self.assertEquals(
+        self.assertEqual(
             apt_cache._apt_cache_show(['package']),
             {'dpkg': {
                 'package': 'dpkg', 'version': '1.19.0.5ubuntu2.1',
@@ -110,18 +110,18 @@ class Test_apt_pkg_Cache(unittest.TestCase):
                 'description': 'utility to list open files'
             },
         }
-        self.assertEquals(
+        self.assertEqual(
             apt_cache.dpkg_list(['package']), expect)
         self.check_output.side_effect = subprocess.CalledProcessError(
             1, '', output=self.check_output.return_value)
-        self.assertEquals(apt_cache.dpkg_list(['package']), expect)
+        self.assertEqual(apt_cache.dpkg_list(['package']), expect)
         self.check_output.side_effect = subprocess.CalledProcessError(2, '')
         with self.assertRaises(subprocess.CalledProcessError):
             _ = apt_cache.dpkg_list(['package'])
 
     def test_version_compare(self):
         self.patch_object(apt_pkg.subprocess, 'check_call')
-        self.assertEquals(apt_pkg.version_compare('2', '1'), 1)
+        self.assertEqual(apt_pkg.version_compare('2', '1'), 1)
         self.check_call.assert_called_once_with(
             ['dpkg', '--compare-versions', '2', 'gt', '1'],
             stderr=subprocess.STDOUT,
@@ -131,13 +131,13 @@ class Test_apt_pkg_Cache(unittest.TestCase):
             None,
             None,
         ]
-        self.assertEquals(apt_pkg.version_compare('2', '2'), 0)
+        self.assertEqual(apt_pkg.version_compare('2', '2'), 0)
         self.check_call.side_effect = [
             subprocess.CalledProcessError(1, '', ''),
             subprocess.CalledProcessError(1, '', ''),
             None,
         ]
-        self.assertEquals(apt_pkg.version_compare('1', '2'), -1)
+        self.assertEqual(apt_pkg.version_compare('1', '2'), -1)
         self.check_call.side_effect = subprocess.CalledProcessError(2, '', '')
         self.assertRaises(subprocess.CalledProcessError,
                           apt_pkg.version_compare, '2', '2')
@@ -161,9 +161,9 @@ class Test_apt_pkg_Cache(unittest.TestCase):
              'dpkg-query: no packages found matching test\n'),
         ]
         pkg = apt_cache['dpkg']
-        self.assertEquals(pkg.name, 'dpkg')
-        self.assertEquals(pkg.current_ver.ver_str, '1.19.0.5ubuntu2.1')
-        self.assertEquals(pkg.architecture, 'amd64')
+        self.assertEqual(pkg.name, 'dpkg')
+        self.assertEqual(pkg.current_ver.ver_str, '1.19.0.5ubuntu2.1')
+        self.assertEqual(pkg.architecture, 'amd64')
         self.check_output.side_effect = [
             subprocess.CalledProcessError(100, ''),
             subprocess.CalledProcessError(1, ''),

--- a/tests/tools/test_charm_helper_sync.py
+++ b/tests/tools/test_charm_helper_sync.py
@@ -30,21 +30,21 @@ class HelperSyncTests(unittest.TestCase):
 
     def test_module_path(self):
         '''It converts a python module path to a filesystem path'''
-        self.assertEquals(sync._module_path('some.test.module'),
+        self.assertEqual(sync._module_path('some.test.module'),
                           'some/test/module')
 
     def test_src_path(self):
         '''It renders the correct path to module within charm-helpers tree'''
         path = sync._src_path(src='/tmp/charm-helpers',
                               module='contrib.openstack')
-        self.assertEquals('/tmp/charm-helpers/charmhelpers/contrib/openstack',
+        self.assertEqual('/tmp/charm-helpers/charmhelpers/contrib/openstack',
                           path)
 
     def test_dest_path(self):
         '''It correctly finds the correct install path within a charm'''
         path = sync._dest_path(dest='/tmp/mycharm/hooks/charmhelpers',
                                module='contrib.openstack')
-        self.assertEquals('/tmp/mycharm/hooks/charmhelpers/contrib/openstack',
+        self.assertEqual('/tmp/mycharm/hooks/charmhelpers/contrib/openstack',
                           path)
 
     @patch('builtins.open')
@@ -124,7 +124,7 @@ class HelperSyncTests(unittest.TestCase):
         '''It filters out all non-py files by default'''
         result = self._test_filter_dir(opts=None, isfile=isfile, isdir=isdir)
         ex = ['bad_file.bin', 'bad_file.img', 'some_dir']
-        self.assertEquals(sorted(ex), sorted(result))
+        self.assertEqual(sorted(ex), sorted(result))
 
     @patch('os.path.isdir')
     @patch('os.path.isfile')
@@ -133,13 +133,13 @@ class HelperSyncTests(unittest.TestCase):
         result = sorted(self._test_filter_dir(opts=['inc=*.img'],
                                               isfile=isfile, isdir=isdir))
         ex = sorted(['bad_file.bin', 'some_dir'])
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
 
     @patch('os.path.isdir')
     @patch('os.path.isfile')
     def test_filter_dir_include_all(self, isfile, isdir):
         '''It does not filter anything if option specified to include all'''
-        self.assertEquals(sync.get_filter(opts=['inc=*']), None)
+        self.assertEqual(sync.get_filter(opts=['inc=*']), None)
 
     @patch('tools.charm_helpers_sync.charm_helpers_sync.get_filter')
     @patch('tools.charm_helpers_sync.charm_helpers_sync.ensure_init')
@@ -233,7 +233,7 @@ class HelperSyncTests(unittest.TestCase):
         [ex_calls.append(
             call('/tmp/charm-helpers', 'hooks/charmhelpers', c, [])
         ) for c in mods]
-        self.assertEquals(ex_calls, _sync.call_args_list)
+        self.assertEqual(ex_calls, _sync.call_args_list)
 
     @patch('tools.charm_helpers_sync.charm_helpers_sync.sync')
     @patch('os.path.isdir')
@@ -265,14 +265,14 @@ class HelperSyncTests(unittest.TestCase):
         [ex_calls.append(
             call('/tmp/charm-helpers', 'hooks/charmhelpers', c, [])
         ) for c in mods]
-        self.assertEquals(ex_calls, _sync.call_args_list)
+        self.assertEqual(ex_calls, _sync.call_args_list)
 
     def test_extract_option_no_globals(self):
         '''It extracts option from an included item with no global options'''
         inc = 'contrib.openstack.templates|inc=*.template'
         result = sync.extract_options(inc)
         ex = ('contrib.openstack.templates', ['inc=*.template'])
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
 
     def test_extract_option_with_global_as_string(self):
         '''It extracts option for include with global options as str'''
@@ -280,14 +280,14 @@ class HelperSyncTests(unittest.TestCase):
         result = sync.extract_options(inc, global_options='inc=foo.*')
         ex = ('contrib.openstack.templates',
               ['inc=*.template', 'inc=foo.*'])
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
 
     def test_extract_option_with_globals(self):
         '''It extracts option from an included item with global options'''
         inc = 'contrib.openstack.templates|inc=*.template'
         result = sync.extract_options(inc, global_options=['inc=*.cfg'])
         ex = ('contrib.openstack.templates', ['inc=*.template', 'inc=*.cfg'])
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)
 
     def test_extract_multiple_options_with_globals(self):
         '''It extracts multiple options from an included item'''
@@ -295,4 +295,4 @@ class HelperSyncTests(unittest.TestCase):
         result = sync.extract_options(inc, global_options=['inc=*.cfg'])
         ex = ('contrib.openstack.templates',
               ['inc=*.template', 'inc=foo.*', 'inc=*.cfg'])
-        self.assertEquals(ex, result)
+        self.assertEqual(ex, result)

--- a/tox.ini
+++ b/tox.ini
@@ -7,26 +7,14 @@ sitepackages = false
 # NOTE(beisner): the 'py3' env is useful to "just give me whatever py3 is here."
 # NOTE(beisner): the 'py3x' envs are useful to use a distinct interpreter version (will fail if not found)
 ignore_basepython_conflict = true
-# NOTES:
-# * We avoid the new dependency resolver by pinning pip < 20.3, see
-#   https://github.com/pypa/pip/issues/9187
-# * Pinning dependencies requires tox >= 3.2.0, see
-#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
-# * It is also necessary to pin virtualenv as a newer virtualenv would still
-#   lead to fetching the latest pip in the func* tox targets, see
-#   https://stackoverflow.com/a/38133283
-requires = pip < 20.3
-           virtualenv < 20.0
-           tox < 4.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
-install_command = {toxinidir}/pip.sh install {opts} {packages}
-passenv = HOME TERM
-commands = nosetests -s --nologcapture {posargs} --with-coverage --cover-package=charmhelpers tests/
+passenv = HOME,TERM
+commands = nose2 {posargs} --with-coverage -s tests/
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:py3]
@@ -55,10 +43,14 @@ basepython = python3.11
 deps = -r{toxinidir}/test-requirements.txt
 commands = nose2 {posargs} --with-coverage -s tests/
 
+[testenv:py312]
+basepython = python3.12
+deps = -r{toxinidir}/test-requirements.txt
+
 [testenv:pep8]
 basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands = flake8 -v {posargs} charmhelpers tests tools
 
 [flake8]
-ignore = E402,E501,E741,E722,W504,F824
+ignore = E402,E501,E741,E722,W504,F824,E127

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     -c{toxinidir}/constraints.txt
     -r{toxinidir}/test-requirements.txt
 
-
 [testenv:py3]
 basepython = python3
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,11 +15,16 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME,TERM
 commands = nose2 {posargs} --with-coverage -s tests/
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
+
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:py36]
 basepython = python3.6
@@ -31,25 +36,33 @@ deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/test-requirements.txt
-commands = nose2 {posargs} --with-coverage -s tests/
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:py311]
 basepython = python3.11
-deps = -r{toxinidir}/test-requirements.txt
-commands = nose2 {posargs} --with-coverage -s tests/
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:py312]
 basepython = python3.12
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:pep8]
 basepython = python3
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+    -c{toxinidir}/constraints.txt
+    -r{toxinidir}/test-requirements.txt
 commands = flake8 -v {posargs} charmhelpers tests tools
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -25,14 +25,6 @@ deps =
     -c{toxinidir}/constraints.txt
     -r{toxinidir}/test-requirements.txt
 
-[testenv:py36]
-basepython = python3.6
-deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:py37]
-basepython = python3.7
-deps = -r{toxinidir}/test-requirements.txt
-
 [testenv:py38]
 basepython = python3.8
 deps =


### PR DESCRIPTION
Summary of changes:

- 7d773d99 Remove python 3.6,3.7 support
- 89435afb Switch default testing framework to nose2
- 6e3e6113 Add setuptools version constraint for test environments
- 0f731544 Update github workflow
- 868d70f2 Python3.12 compatibility
- 4fa9b9af Use looseversion in place of distutils
